### PR TITLE
Use Utf8 by default

### DIFF
--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -144,7 +144,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         public int? Release_Parallel_Download_Limit => GetInt(Constants.Variables.Release.ReleaseParallelDownloadLimit);
 
 #if OS_WINDOWS
-        public bool Retain_Default_Encoding => GetBoolean(Constants.Variables.Agent.RetainDefaultEncoding) ?? true;
+        public bool Retain_Default_Encoding => GetBoolean(Constants.Variables.Agent.RetainDefaultEncoding) ?? false;
 #else
         public bool Retain_Default_Encoding => true;
 #endif


### PR DESCRIPTION
We might decide we want to get rid of this option entirely, but I think it should be on by default regardless (aka doesn't need message from server to be on)