### PR TITLE
Users/dakale/more job container

### DIFF
--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -194,10 +194,6 @@ namespace GitHub.Runner.Worker
             // Pull container from registry
             else
             {
-                if (container.ContainerImage.StartsWith("docker://"))
-                {
-                    container.ContainerImage = container.ContainerImage.Substring("docker://".Length);
-                }
                 // Pull down docker image with retry up to 3 times
                 int retryCount = 0;
                 int pullExitCode = 0;


### PR DESCRIPTION
Allows job container + service container from `docker://` or `./{dockerfile}` to match functionality of actions

eg:

```
a-job:
  container: ./build/env
  services:
        postgres: docker://postgres
        mysql:
          image: docker://mysql
        myservice: ./build/service/
```