### PR TITLE
Allow non-loop message before end

### DIFF
--- a/src/Runner.Worker/IssueMatcher.cs
+++ b/src/Runner.Worker/IssueMatcher.cs
@@ -317,7 +317,6 @@ namespace GitHub.Runner.Worker
             int? message = null;
             int? fromPath = null;
 
-            bool messageSet = false;
             // Validate each pattern config
             for (var i = 0; i < _patterns.Length; i++)
             {
@@ -333,18 +332,9 @@ namespace GitHub.Runner.Worker
                     ref code,
                     ref message,
                     ref fromPath);
-
-                if (message != null)
-                {
-                    if (messageSet)
-                    {
-                        throw new ArgumentException($"Only the last pattern may set 'message'");
-                    }
-                    messageSet = true;
-                }
             }
 
-            if (!messageSet)
+            if (message == null)
             {
                 throw new ArgumentException($"At least one pattern must set 'message'");
             }
@@ -409,11 +399,10 @@ namespace GitHub.Runner.Worker
                 throw new ArgumentException($"Only the last pattern in a multiline matcher may set '{_loopPropertyName}'");
             }
 
-            // Only the last pattern may set 'message' if we are looping
-            if (Loop && Message != null && !isLast)
+            if (Loop && Message == null)
             {
-                throw new ArgumentException($"Only the last pattern may set '{_messagePropertyName}' when looping");
-            }
+                throw new ArgumentException($"The {_loopPropertyName} pattern must set '{_messagePropertyName}'");
+            }   
 
             var regex = new Regex(Pattern ?? string.Empty, RegexOptions);
             var groupCount = regex.GetGroupNumbers().Length;

--- a/src/Test/L0/Worker/IssueMatcherL0.cs
+++ b/src/Test/L0/Worker/IssueMatcherL0.cs
@@ -86,7 +86,39 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public void Config_Validate_Message_OnlyAllowedOnLastPattern()
+        public void Config_Validate_Loop_MustSetMessage()
+        {
+            var config = JsonUtility.FromString<IssueMatchersConfig>(@"
+{
+  ""problemMatcher"": [
+    {
+      ""owner"": ""myMatcher"",
+      ""pattern"": [
+        {
+          ""regexp"": ""^file: (.+)$"",
+          ""message"": 1
+        },
+        {
+          ""regexp"": ""^file: (.+)$"",
+          ""file"": 1,
+          ""loop"": true
+        }
+      ]
+    }
+  ]
+}
+");
+
+            Assert.Throws<ArgumentException>(() => config.Validate());
+
+            config.Matchers[0].Patterns[1].Loop = false;
+            config.Validate();
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Config_Validate_Message_AllowedInFirstPattern()
         {
             var config = JsonUtility.FromString<IssueMatchersConfig>(@"
 {
@@ -107,13 +139,6 @@ namespace GitHub.Runner.Common.Tests.Worker
   ]
 }
 ");
-            Assert.Throws<ArgumentException>(() => config.Validate());
-
-            // Sanity test
-            config.Matchers[0].Patterns[0].File = 1;
-            config.Matchers[0].Patterns[0].Message = null;
-            config.Matchers[0].Patterns[1].File = null;
-            config.Matchers[0].Patterns[1].Message = 1;
             config.Validate();
         }
 


### PR DESCRIPTION
For non-loop patterns, message should be able to appear in any of the patterns. This allows us to match things with patterns like the following (which is basically how Java reports errors)

```
Error: {error message}
   occurred in {file}:{line number}
```