### PR TITLE
Convert multi-word context keys to env vars properly

### DIFF
--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -13,11 +13,11 @@ namespace GitHub.Runner.Worker
                 if (!data.Key.Equals("token") && data.Value is StringContextData value)
                 {
                     var camelKey = data.Key;
-		            var snakeKey = camelKey.Aggregate("", (result, ch) =>
+                    var snakeKey = camelKey.Aggregate("", (result, ch) =>
                         result + (result.Length > 0 && char.IsUpper(ch) ?
-						    "_" + ch.ToString().ToUpperInvariant()
-							: ch.ToString().ToUpperInvariant()));
-                    yield return new KeyValuePair<string, string>($"GITHUB_{snakeKey}", value);
+                            "_" + ch.ToString().ToUpperInvariant() :
+                            ch.ToString().ToUpperInvariant()));
+                    yield return new KeyValuePair < string, string > ($ "GITHUB_{snakeKey}", value);
                 }
             }
         }


### PR DESCRIPTION
Currently, a context key like `eventName` gets converted to `GITHUB_EVENTNAME`. This changes the code we use to convert keys to use a proper snake-case conversion from camel-case, so that `eventName` becomes `GITHUB_EVENT_NAME`.

This is literally the first C# code I think I've ever written, so go easy on me!