### PR TITLE
Check all possible tool directories written by mms

### DIFF
--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -198,16 +198,14 @@ namespace GitHub.Runner.Common
                     break;
 
                 case WellKnownDirectory.Tools:
-                    path = Path.Combine(
-                                GetDirectory(WellKnownDirectory.Work),
-                                Constants.Path.ToolDirectory);
-                    // path = Environment.GetEnvironmentVariable("RUNNER_TOOLSDIRECTORY") ?? Environment.GetEnvironmentVariable(Constants.Variables.Agent.ToolsDirectory);
-                    // if (string.IsNullOrEmpty(path))
-                    // {
-                    //     path = Path.Combine(
-                    //         GetDirectory(WellKnownDirectory.Work),
-                    //         Constants.Path.ToolDirectory);
-                    // }
+                    // TODO: Coallesce to just check RUNNER_TOOL_CACHE when images stabilize
+                    path = Environment.GetEnvironmentVariable("RUNNER_TOOL_CACHE") ?? Environment.GetEnvironmentVariable("RUNNER_TOOLSDIRECTORY") ?? Environment.GetEnvironmentVariable("AGENT_TOOLSDIRECTORY") ?? Environment.GetEnvironmentVariable(Constants.Variables.Agent.ToolsDirectory);
+                    if (string.IsNullOrEmpty(path))
+                    {
+                        path = Path.Combine(
+                            GetDirectory(WellKnownDirectory.Work),
+                            Constants.Path.ToolDirectory);
+                    }
                     break;
 
                 case WellKnownDirectory.Update:


### PR DESCRIPTION
For private beta, can we just check all possible locations MMS might store the tool directory var? That would simplify the toolkit and keep references to the agent out of it (note that we'll open source that with public beta so the branding need is a little more pressing). It also means we don't need to keep reacting in the toolkit/all the first party actions