### PR TITLE
Remove fwlinks, aka.ms and TF/VS error codes

### DIFF
--- a/src/Runner.Listener/Configuration/CredentialProvider.cs
+++ b/src/Runner.Listener/Configuration/CredentialProvider.cs
@@ -57,7 +57,7 @@ namespace GitHub.Runner.Listener.Configuration
             var tenantAuthorityUrl = GetTenantAuthorityUrl(context, serverUrl);
             if (tenantAuthorityUrl == null)
             {
-                throw new NotSupportedException($"This Azure DevOps organization '{serverUrl}' is not backed by Azure Active Directory.");
+                throw new NotSupportedException($"'{serverUrl}' is not backed by Azure Active Directory.");
             }
 
             LoggerCallbackHandler.LogCallback = ((LogLevel level, string message, bool containsPii) =>

--- a/src/Sdk/ArtifactContent/Content.Common/ArtifactBillingException.cs
+++ b/src/Sdk/ArtifactContent/Content.Common/ArtifactBillingException.cs
@@ -12,8 +12,7 @@ namespace GitHub.Services.Content.Common
     public class ArtifactBillingException : VssServiceException
     {
         public const string DefaultExceptionMessage =
-            "Artifact cannot be uploaded because max quantity has been exceeded or the payment instrument is invalid. " +
-            "https://aka.ms/artbilling for details.";
+            "Artifact cannot be uploaded because max quantity has been exceeded or the payment instrument is invalid.";
 
         /// <inheritdoc />
         /// <summary>

--- a/src/Sdk/DTPipelines/Pipelines/Artifacts/PipelineArtifactConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/Artifacts/PipelineArtifactConstants.cs
@@ -80,7 +80,7 @@ namespace GitHub.DistributedTask.Pipelines.Artifacts
             RunsOn = { TaskRunsOnConstants.RunsOnAgent },
             Version = new TaskVersion("1.0.0"),
             Description = "Downloads pipeline type artifacts.",
-            HelpMarkDown = "[More Information](https://go.microsoft.com/fwlink/?LinkId=798199)",
+            HelpMarkDown = "[More Information]()",
             Inputs = {
                 new TaskInputDefinition()
                 {

--- a/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
@@ -138,7 +138,7 @@ namespace GitHub.DistributedTask.Pipelines
             RunsOn = { TaskRunsOnConstants.RunsOnAgent },
             Version = new TaskVersion("1.0.0"),
             Description = "Get sources from a repository. Supports Git, TfsVC, and SVN repositories.",
-            HelpMarkDown = "[More Information](https://go.microsoft.com/fwlink/?LinkId=798199)",
+            HelpMarkDown = "[More Information]()",
             Inputs = {
                 new TaskInputDefinition()
                 {

--- a/src/Sdk/Resources/CommonResources.g.cs
+++ b/src/Sdk/Resources/CommonResources.g.cs
@@ -31,13 +31,13 @@ namespace GitHub.Services.Common.Internal
 
         public static string InvalidPropertyName(object arg0)
         {
-            const string Format = @"TF400458: Invalid property name: '{0}'. Property names cannot contain leading or trailing whitespace.";
+            const string Format = @"Invalid property name: '{0}'. Property names cannot contain leading or trailing whitespace.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string InvalidPropertyValueSize(object arg0, object arg1, object arg2)
         {
-            const string Format = @"TF20509: The value of property '{0}' exceeds the maximum size allowed. '{1}' values must not exceed '{2}' bytes.";
+            const string Format = @"The value of property '{0}' exceeds the maximum size allowed. '{1}' values must not exceed '{2}' bytes.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1, arg2);
         }
 
@@ -49,7 +49,7 @@ namespace GitHub.Services.Common.Internal
 
         public static string PropertyArgumentExceededMaximumSizeAllowed(object arg0, object arg1)
         {
-            const string Format = @"TF20508: The argument '{0}' is too long. It must not contain more than '{1}' characters.";
+            const string Format = @"The argument '{0}' is too long. It must not contain more than '{1}' characters.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
@@ -79,7 +79,7 @@ namespace GitHub.Services.Common.Internal
 
         public static string VssInvalidUnicodeCharacter(object arg0)
         {
-            const string Format = @"TF20507: The string argument contains a character that is not valid:'u{0:X4}'. Correct the argument, and then try the operation again.";
+            const string Format = @"The string argument contains a character that is not valid:'u{0:X4}'. Correct the argument, and then try the operation again.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
@@ -121,13 +121,13 @@ namespace GitHub.Services.Common.Internal
 
         public static string VssUnauthorized(object arg0)
         {
-            const string Format = @"VS30063: You are not authorized to access {0}.";
+            const string Format = @"You are not authorized to access {0}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string VssUnauthorizedUnknownServer()
         {
-            const string Format = @"VS30064: You are not authorized to access the server.";
+            const string Format = @"You are not authorized to access the server.";
             return Format;
         }
 
@@ -457,31 +457,31 @@ namespace GitHub.Services.Common.Internal
 
         public static string UriUtility_AbsoluteUriRequired(object arg0)
         {
-            const string Format = @"TF205013: The following URL is not valid: {0}. You must specify an absolute path.";
+            const string Format = @"The following URL is not valid: {0}. You must specify an absolute path.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string UriUtility_RelativePathInvalid(object arg0)
         {
-            const string Format = @"TF205014: The following relative path is not valid: {0}. It must be both well formed and relative. It might be an absolute path.";
+            const string Format = @"The following relative path is not valid: {0}. It must be both well formed and relative. It might be an absolute path.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string UriUtility_UriNotAllowed(object arg0)
         {
-            const string Format = @"TF205012: The following URL is not valid: {0}. It must begin with http or https.";
+            const string Format = @"The following URL is not valid: {0}. It must begin with http or https.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string UriUtility_MustBeAuthorityOnlyUri(object arg0, object arg1)
         {
-            const string Format = @"TF253018: The following URL is not valid: {0}. Try removing any relative path information from the URL (for example, {1}).";
+            const string Format = @"The following URL is not valid: {0}. Try removing any relative path information from the URL (for example, {1}).";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string UrlNotValid()
         {
-            const string Format = @"TF249010: The URL that you specified is not valid. The URL must begin with either HTTP or HTTPS and be a valid address.";
+            const string Format = @"The URL that you specified is not valid. The URL must begin with either HTTP or HTTPS and be a valid address.";
             return Format;
         }
 

--- a/src/Sdk/Resources/ContentResources.g.cs
+++ b/src/Sdk/Resources/ContentResources.g.cs
@@ -13,7 +13,7 @@ namespace GitHub.Services.Content.Common
 
         public static string ArtifactBillingException()
         {
-            const string Format = @"Artifact cannot be uploaded because max quantity has been exceeded or the payment instrument is invalid. https://aka.ms/artbilling for details.";
+            const string Format = @"Artifact cannot be uploaded because max quantity has been exceeded or the payment instrument is invalid.";
             return Format;
         }
     }

--- a/src/Sdk/Resources/ExpressionResources.g.cs
+++ b/src/Sdk/Resources/ExpressionResources.g.cs
@@ -61,13 +61,13 @@ namespace GitHub.DistributedTask.Expressions
 
         public static string ParseErrorWithFwlink(object arg0)
         {
-            const string Format = @"{0}. For more help, refer to https://go.microsoft.com/fwlink/?linkid=842996";
+            const string Format = @"{0}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string ParseErrorWithTokenInfo(object arg0, object arg1, object arg2, object arg3)
         {
-            const string Format = @"{0}: '{1}'. Located at position {2} within expression: {3}. For more help, refer to https://go.microsoft.com/fwlink/?linkid=842996";
+            const string Format = @"{0}: '{1}'. Located at position {2} within expression: {3}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1, arg2, arg3);
         }
 

--- a/src/Sdk/Resources/IdentityResources.g.cs
+++ b/src/Sdk/Resources/IdentityResources.g.cs
@@ -13,121 +13,121 @@ namespace GitHub.Services.WebApi
 
         public static string GROUPCREATIONERROR(object arg0, object arg1)
         {
-            const string Format = @"TF50624: A group named {0} already exists in scope {1}.";
+            const string Format = @"A group named {0} already exists in scope {1}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string ADDMEMBERCYCLICMEMBERSHIPERROR(object arg0, object arg1)
         {
-            const string Format = @"TF50233: A cyclic group containment error occurred when adding a group member. The group {1} already has the group {0} as a contained member.";
+            const string Format = @"A cyclic group containment error occurred when adding a group member. The group {1} already has the group {0} as a contained member.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string GROUPSCOPECREATIONERROR(object arg0)
         {
-            const string Format = @"TF50620: The Azure DevOps group scope {0} already exists";
+            const string Format = @"The group scope {0} already exists";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string ADDMEMBERIDENTITYALREADYMEMBERERROR(object arg0, object arg1)
         {
-            const string Format = @"TF50235: The group {0} already has a member {1}.";
+            const string Format = @"The group {0} already has a member {1}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string REMOVEGROUPMEMBERNOTMEMBERERROR(object arg0)
         {
-            const string Format = @"TF50632: An error occurred removing the group member. There is no group member with the security identifier (SID) {0}.";
+            const string Format = @"An error occurred removing the group member. There is no group member with the security identifier (SID) {0}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string REMOVEADMINGROUPERROR()
         {
-            const string Format = @"TF50633: This group cannot be removed. Azure DevOps requires the existence of this Administrators group for its operation.";
+            const string Format = @"This group cannot be removed. The existence of this Administrators group is required.";
             return Format;
         }
 
         public static string REMOVEEVERYONEGROUPERROR()
         {
-            const string Format = @"TF50634: This group cannot be removed. Azure DevOps requires the existence of this Valid Users group for its operation.";
+            const string Format = @"This group cannot be removed. The existence of this Valid Users group is required.";
             return Format;
         }
 
         public static string REMOVESERVICEGROUPERROR()
         {
-            const string Format = @"TF50635: This group cannot be removed. Azure DevOps requires the existence of this Service Accounts group for its operation.";
+            const string Format = @"This group cannot be removed. The existence of this Service Accounts group is required.";
             return Format;
         }
 
         public static string REMOVESPECIALGROUPERROR()
         {
-            const string Format = @"TF50636: This group cannot be removed. Azure DevOps requires the existence of this group for its operation.";
+            const string Format = @"This group cannot be removed. The existence of this group is required.";
             return Format;
         }
 
         public static string FINDGROUPSIDDOESNOTEXISTERROR(object arg0)
         {
-            const string Format = @"TF50258: An error occurred finding the group. There is no group with the security identifier (SID) {0}.";
+            const string Format = @"An error occurred finding the group. There is no group with the security identifier (SID) {0}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string GROUPRENAMEERROR(object arg0)
         {
-            const string Format = @"TF50616: Error renaming group, a group named {0} already exists.";
+            const string Format = @"Error renaming group, a group named {0} already exists.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string GROUPSCOPEDOESNOTEXISTERROR(object arg0)
         {
-            const string Format = @"TF50620: The Azure DevOps identity scope {0} does not exist";
+            const string Format = @"The identity scope {0} does not exist";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string IdentityNotFoundMessage(object arg0)
         {
-            const string Format = @"TF14045: The identity with type '{0}' could not be found.";
+            const string Format = @"The identity with type '{0}' could not be found.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string IdentityNotFoundWithDescriptor(object arg0, object arg1)
         {
-            const string Format = @"TF14045: The identity with type '{0}' and identifier '{1}' could not be found.";
+            const string Format = @"The identity with type '{0}' and identifier '{1}' could not be found.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string IdentityNotFoundSimpleMessage()
         {
-            const string Format = @"TF14045: The identity could not be found.";
+            const string Format = @"The identity could not be found.";
             return Format;
         }
 
         public static string IdentityNotFoundWithTfid(object arg0)
         {
-            const string Format = @"TF14045: The identity with TeamFoundationId {0} could not be found.";
+            const string Format = @"The identity with TeamFoundationId {0} could not be found.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string IdentityNotFoundWithName(object arg0)
         {
-            const string Format = @"TF14045: The identity with name {0} could not be found.";
+            const string Format = @"The identity with name {0} could not be found.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string IdentityAccountNameAlreadyInUseError(object arg0)
         {
-            const string Format = @"TF400815: The identity account name '{0}' is already in use.";
+            const string Format = @"The identity account name '{0}' is already in use.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string IdentityAccountNameCollisionRepairFailedError(object arg0)
         {
-            const string Format = @"TF402001: Support will be required to repair this account. An attempt to repair an account name collision for identity '{0}' failed and cannot be completed automatically.";
+            const string Format = @"Support will be required to repair this account. An attempt to repair an account name collision for identity '{0}' failed and cannot be completed automatically.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string IdentityAccountNameCollisionRepairUnsafeError(object arg0)
         {
-            const string Format = @"TF402002: Support will be required to repair this account. An attempt to repair an account name collision for identity '{0}' is unsafe and cannot be completed automatically.";
+            const string Format = @"Support will be required to repair this account. An attempt to repair an account name collision for identity '{0}' is unsafe and cannot be completed automatically.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
@@ -139,73 +139,73 @@ namespace GitHub.Services.WebApi
 
         public static string InvalidNameNotRecognized(object arg0)
         {
-            const string Format = @"TF200041: You have specified a name, {0}, that contains character(s) that are not recognized. Specify a name that only contains characters that are supported by the database collation setting and try again.";
+            const string Format = @"You have specified a name, {0}, that contains character(s) that are not recognized. Specify a name that only contains characters that are supported by the database collation setting and try again.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string IdentityMapReadOnlyException()
         {
-            const string Format = @"TF401012: The identity map cannot be accessed while the collection is detached.";
+            const string Format = @"The identity map cannot be accessed while the collection is detached.";
             return Format;
         }
 
         public static string IdentityAccountNamesAlreadyInUseError(object arg0, object arg1)
         {
-            const string Format = @"TF400816: {0} identity account names including '{1}' are already in use.";
+            const string Format = @"{0} identity account names including '{1}' are already in use.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string InvalidServiceIdentityName(object arg0)
         {
-            const string Format = @"TF400325: Service identities are limited to a maximum of 200 characters, and may only contain alpha numeric, dash, and space characters. The name '{0}' is not a valid service identity name.";
+            const string Format = @"Service identities are limited to a maximum of 200 characters, and may only contain alpha numeric, dash, and space characters. The name '{0}' is not a valid service identity name.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string AccountPreferencesAlreadyExist()
         {
-            const string Format = @"TF400843: Organization preferences have already been set. You can only set the preferences for language, culture, and time zone when the organization is created, and these preferences cannot be changed.";
+            const string Format = @"Organization preferences have already been set. You can only set the preferences for language, culture, and time zone when the organization is created, and these preferences cannot be changed.";
             return Format;
         }
 
         public static string ADDGROUPMEMBERILLEGALINTERNETIDENTITY(object arg0)
         {
-            const string Format = @"TF400448: Internet identities cannot be added to this server. Unable to add {0}.";
+            const string Format = @"Internet identities cannot be added to this server. Unable to add {0}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string ADDGROUPMEMBERILLEGALWINDOWSIDENTITY(object arg0)
         {
-            const string Format = @"TF400447: Windows users cannot be added to this server. Unable to add {0}.";
+            const string Format = @"Windows users cannot be added to this server. Unable to add {0}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string ADDPROJECTGROUPTPROJECTMISMATCHERROR(object arg0, object arg1)
         {
-            const string Format = @"TF50375: Project group '{1}' cannot be added to group '{0}', it is from a different project.";
+            const string Format = @"Project group '{1}' cannot be added to group '{0}', it is from a different project.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string CANNOT_REMOVE_SERVICE_ACCOUNT()
         {
-            const string Format = @"TF50248: You cannot remove the service account from the Service Accounts group.";
+            const string Format = @"You cannot remove the service account from the Service Accounts group.";
             return Format;
         }
 
         public static string IDENTITYDOMAINDOESNOTEXISTERROR(object arg0)
         {
-            const string Format = @"TF246076: No Azure DevOps identity domain exists with the following security identifier (SID): {0}.";
+            const string Format = @"No identity domain exists with the following security identifier (SID): {0}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string IDENTITYDOMAINMISMATCHERROR(object arg0, object arg1)
         {
-            const string Format = @"TF50621: The Azure DevOps group that you wish to manage is not owned by service host {0}, it is owned by {1}. Please target your request at the correct host.";
+            const string Format = @"The group that you wish to manage is not owned by service host {0}, it is owned by {1}. Please target your request at the correct host.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string IdentityProviderUnavailable(object arg0, object arg1)
         {
-            const string Format = @"TF246104: The identity provider for type {0}, identifier {1} is unavailable.";
+            const string Format = @"The identity provider for type {0}, identifier {1} is unavailable.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
@@ -217,67 +217,67 @@ namespace GitHub.Services.WebApi
 
         public static string IllegalIdentityException(object arg0)
         {
-            const string Format = @"TF10158: The user or group name {0} contains unsupported characters, is empty, or too long.";
+            const string Format = @"The user or group name {0} contains unsupported characters, is empty, or too long.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string MODIFYEVERYONEGROUPEXCEPTION()
         {
-            const string Format = @"TF50618: The Azure DevOps Valid Users group cannot be modified directly.";
+            const string Format = @"The Valid Users group cannot be modified directly.";
             return Format;
         }
 
         public static string NOT_APPLICATION_GROUP()
         {
-            const string Format = @"TF56044: The identity you are attempting to edit is not an application group.";
+            const string Format = @"The identity you are attempting to edit is not an application group.";
             return Format;
         }
 
         public static string NOT_A_SECURITY_GROUP(object arg0)
         {
-            const string Format = @"TF50619: The group {0} is not a security group and cannot be added to Azure DevOps Server.";
+            const string Format = @"The group {0} is not a security group and cannot be added to Server.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string REMOVENONEXISTENTGROUPERROR(object arg0)
         {
-            const string Format = @"TF50265: An error occurred removing the group. There is no group with the security identifier (SID) {0}.";
+            const string Format = @"An error occurred removing the group. There is no group with the security identifier (SID) {0}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string RemoveSelfFromAdminGroupError(object arg0)
         {
-            const string Format = @"TF400571: You cannot remove yourself from the Administrators group. This is a safeguard to prevent an enterprise locking themselves out of a deployment or project collection. Please have another administrator remove your membership. Alternatively you can disable the safeguard by setting {0} to false in the TF registry.";
+            const string Format = @"You cannot remove yourself from the Administrators group. This is a safeguard to prevent an enterprise locking themselves out of a deployment or project collection. Please have another administrator remove your membership. Alternatively you can disable the safeguard by setting {0} to false in the TF registry.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string ADDPROJECTGROUPTOGLOBALGROUPERROR(object arg0, object arg1)
         {
-            const string Format = @"TF400031: You cannot add the project group {0} to the global group {1}. ";
+            const string Format = @"You cannot add the project group {0} to the global group {1}. ";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string DynamicIdentityTypeCreationNotSupported()
         {
-            const string Format = @"TF50645: Dynamic creation of identity types is no longer supported. Please check that the type of the identity you are trying to create is supported. ";
+            const string Format = @"Dynamic creation of identity types is no longer supported. Please check that the type of the identity you are trying to create is supported. ";
             return Format;
         }
 
         public static string TooManyResultsError()
         {
-            const string Format = @"TF400048: The query was aborted because it returned too many results. Please apply additional filters to reduce the size of the resultset returned.";
+            const string Format = @"The query was aborted because it returned too many results. Please apply additional filters to reduce the size of the resultset returned.";
             return Format;
         }
 
         public static string IncompatibleScopeError(object arg0, object arg1)
         {
-            const string Format = @"TF400049: Group cannot be created in the requested scope {1} since the requested scope is not within the root scope {0}.";
+            const string Format = @"Group cannot be created in the requested scope {1} since the requested scope is not within the root scope {0}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string InvalidIdentityIdTranslations()
         {
-            const string Format = @"VS401248: New translations have a record that may corrupt the existing translation data.";
+            const string Format = @"New translations have a record that may corrupt the existing translation data.";
             return Format;
         }
 
@@ -303,7 +303,7 @@ namespace GitHub.Services.WebApi
 
         public static string IdentityMaterializationFailedMessage(object arg0)
         {
-            const string Format = @"VS403283: Could not add user '{0}' at this time.";
+            const string Format = @"Could not add user '{0}' at this time.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
@@ -321,43 +321,43 @@ namespace GitHub.Services.WebApi
 
         public static string TooManyRequestedItemsError()
         {
-            const string Format = @"TF400049: The request was aborted because it contained too many requested items.";
+            const string Format = @"The request was aborted because it contained too many requested items.";
             return Format;
         }
 
         public static string TooManyRequestedItemsErrorWithCount(object arg0, object arg1)
         {
-            const string Format = @"TF400049: The request was aborted because it contained too many requested items {0}, maximum allowed is {1}.";
+            const string Format = @"The request was aborted because it contained too many requested items {0}, maximum allowed is {1}.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string InvalidIdentityKeyMaps()
         {
-            const string Format = @"VS401249: New identity key maps have a record that may corrupt the existing key map data.";
+            const string Format = @"New identity key maps have a record that may corrupt the existing key map data.";
             return Format;
         }
 
         public static string InvitationPendingMessage(object arg0, object arg1)
         {
-            const string Format = @"VS403318: {0} has not accepted the invitation to the {1} organization.";
+            const string Format = @"{0} has not accepted the invitation to the {1} organization.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
         public static string ShouldBePersonalAccountMessage()
         {
-            const string Format = @"VS403362: Your work or school account does not have access to this resource, but your personal account does.";
+            const string Format = @"Your work or school account does not have access to this resource, but your personal account does.";
             return Format;
         }
 
         public static string ShouldCreatePersonalAccountMessage()
         {
-            const string Format = @"VS403408: The VSTS account you are trying to access only allows Microsoft Accounts. Please create a Microsoft Account with a different email address and ask your administrator to invite the new Microsoft Account.";
+            const string Format = @"The account you are trying to access only allows Microsoft Accounts. Please create a Microsoft Account with a different email address and ask your administrator to invite the new Microsoft Account.";
             return Format;
         }
 
         public static string ShouldBeWorkAccountMessage()
         {
-            const string Format = @"VS403363: Your personal account does not have access to this resource, but your work or school account does.";
+            const string Format = @"Your personal account does not have access to this resource, but your work or school account does.";
             return Format;
         }
 

--- a/src/Sdk/Resources/LocationResources.g.cs
+++ b/src/Sdk/Resources/LocationResources.g.cs
@@ -7,13 +7,13 @@ namespace GitHub.Services.WebApi
 
         public static string CannotChangeParentDefinition(object arg0, object arg1, object arg2, object arg3)
         {
-            const string Format = @"TF401225: Cannot change parent definition. Service type {0}, identifier {1}, parent service type {2}, identifier {3}";
+            const string Format = @"Cannot change parent definition. Service type {0}, identifier {1}, parent service type {2}, identifier {3}";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1, arg2, arg3);
         }
 
         public static string ParentDefinitionNotFound(object arg0, object arg1, object arg2, object arg3)
         {
-            const string Format = @"TF401226: Cannot save service definition with type {0} identifier {1} because parent definition with type {2} identifier {3} could not be found.";
+            const string Format = @"Cannot save service definition with type {0} identifier {1} because parent definition with type {2} identifier {3} could not be found.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1, arg2, arg3);
         }
     }

--- a/src/Sdk/Resources/PipelineStrings.g.cs
+++ b/src/Sdk/Resources/PipelineStrings.g.cs
@@ -271,13 +271,13 @@ namespace GitHub.DistributedTask.Pipelines
 
         public static string QueueNotFound(object arg0)
         {
-            const string Format = @"Could not find a pool with ID {0}. The pool does not exist or has not been authorized for use. For authorization details, refer to https://aka.ms/yamlauthz.";
+            const string Format = @"Could not find a pool with ID {0}. The pool does not exist or has not been authorized for use.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string QueueNotFoundByName(object arg0)
         {
-            const string Format = @"Could not find a pool with name {0}. The pool does not exist or has not been authorized for use. For authorization details, refer to https://aka.ms/yamlauthz.";
+            const string Format = @"Could not find a pool with name {0}. The pool does not exist or has not been authorized for use.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
@@ -289,25 +289,25 @@ namespace GitHub.DistributedTask.Pipelines
 
         public static string SecureFileNotFound(object arg0)
         {
-            const string Format = @"A secure file with name {0} could not be found. The secure file does not exist or has not been authorized for use. For authorization details, refer to https://aka.ms/yamlauthz.";
+            const string Format = @"A secure file with name {0} could not be found. The secure file does not exist or has not been authorized for use.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string SecureFileNotFoundForInput(object arg0, object arg1, object arg2, object arg3)
         {
-            const string Format = @"Job {0}: Step {1} input {2} references secure file {3} which could not be found. The secure file does not exist or has not been authorized for use. For authorization details, refer to https://aka.ms/yamlauthz.";
+            const string Format = @"Job {0}: Step {1} input {2} references secure file {3} which could not be found. The secure file does not exist or has not been authorized for use.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1, arg2, arg3);
         }
 
         public static string ServiceEndpointNotFound(object arg0)
         {
-            const string Format = @"A service connection with name {0} could not be found. The service connection does not exist or has not been authorized for use. For authorization details, refer to https://aka.ms/yamlauthz.";
+            const string Format = @"A service connection with name {0} could not be found. The service connection does not exist or has not been authorized for use.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string ServiceEndpointNotFoundForInput(object arg0, object arg1, object arg2, object arg3)
         {
-            const string Format = @"Job {0}: Step {1} input {2} references service connection {3} which could not be found. The service connection does not exist or has not been authorized for use. For authorization details, refer to https://aka.ms/yamlauthz.";
+            const string Format = @"Job {0}: Step {1} input {2} references service connection {3} which could not be found. The service connection does not exist or has not been authorized for use.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1, arg2, arg3);
         }
 
@@ -421,13 +421,13 @@ namespace GitHub.DistributedTask.Pipelines
 
         public static string VariableGroupNotFound(object arg0)
         {
-            const string Format = @"Variable group {0} was not found or is not authorized for use. For authorization details, refer to https://aka.ms/yamlauthz.";
+            const string Format = @"Variable group {0} was not found or is not authorized for use.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
         public static string VariableGroupNotFoundForPhase(object arg0, object arg1)
         {
-            const string Format = @"Job {0}: Variable group {1} could not be found. The variable group does not exist or has not been authorized for use. For authorization details, refer to https://aka.ms/yamlauthz";
+            const string Format = @"Job {0}: Variable group {1} could not be found. The variable group does not exist or has not been authorized for use.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
 
@@ -493,7 +493,7 @@ namespace GitHub.DistributedTask.Pipelines
 
         public static string ServiceConnectionUsedInVariableGroupNotValid(object arg0, object arg1)
         {
-            const string Format = @"Service connection : {0} used in variable group : {1} is not valid. Either service connection does not exist or has not been authorized for use. For authorization details, refer to https://aka.ms/yamlauthz.";
+            const string Format = @"Service connection : {0} used in variable group : {1} is not valid. Either service connection does not exist or has not been authorized for use.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
     }

--- a/src/Sdk/Resources/SecurityResources.g.cs
+++ b/src/Sdk/Resources/SecurityResources.g.cs
@@ -13,7 +13,7 @@ namespace GitHub.Services.WebApi
 
         public static string InvalidPermissionsException(object arg0, object arg1)
         {
-            const string Format = @"VS403284: Invalid operation. Unable to set bits '{1}' in security namespace '{0}' as it is reserved by the system.";
+            const string Format = @"Invalid operation. Unable to set bits '{1}' in security namespace '{0}' as it is reserved by the system.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0, arg1);
         }
     }

--- a/src/Sdk/Resources/WebApiResources.g.cs
+++ b/src/Sdk/Resources/WebApiResources.g.cs
@@ -61,13 +61,13 @@ namespace GitHub.Services.WebApi
 
         public static string RelativeLocationMappingErrorMessage()
         {
-            const string Format = @"TF205038: You cannot add location mappings to service definitions that are not part of the FullyQualified type.";
+            const string Format = @"You cannot add location mappings to service definitions that are not part of the FullyQualified type.";
             return Format;
         }
 
         public static string InvalidAccessMappingLocationServiceUrl()
         {
-            const string Format = @"TF205035: The access mapping is not valid and cannot be registered. The location service URL cannot be null or empty.";
+            const string Format = @"The access mapping is not valid and cannot be registered. The location service URL cannot be null or empty.";
             return Format;
         }
 
@@ -79,7 +79,7 @@ namespace GitHub.Services.WebApi
 
         public static string ServiceDefinitionWithNoLocations(object arg0)
         {
-            const string Format = @"TF205046: The service with the following type does not have a location mapping: {0}. You must provide at least one location in order to configure locations for an external service.";
+            const string Format = @"The service with the following type does not have a location mapping: {0}. You must provide at least one location in order to configure locations for an external service.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
@@ -235,7 +235,7 @@ namespace GitHub.Services.WebApi
 
         public static string CollectionDoesNotExistException(object arg0)
         {
-            const string Format = @"VS402844: Collection with name {0} does not exist.";
+            const string Format = @"Collection with name {0} does not exist.";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 
@@ -259,7 +259,7 @@ namespace GitHub.Services.WebApi
 
         public static string GetServiceArgumentError(object arg0)
         {
-            const string Format = @"TF400776: '{0}' must be a non-abstract class with a public parameterless or default constructor in order to use it as parameter 'T' in GetService<T>().";
+            const string Format = @"'{0}' must be a non-abstract class with a public parameterless or default constructor in order to use it as parameter 'T' in GetService<T>().";
             return string.Format(CultureInfo.CurrentCulture, Format, arg0);
         }
 

--- a/src/Sdk/WebApi/WebApi/ProxyAuthenticationRequiredException.cs
+++ b/src/Sdk/WebApi/WebApi/ProxyAuthenticationRequiredException.cs
@@ -24,6 +24,6 @@ namespace GitHub.Services.WebApi
             this.HelpLink = HelpLinkUrl;
         }
 
-        private const string HelpLinkUrl = "https://go.microsoft.com/fwlink/?LinkID=324097";
+        private const string HelpLinkUrl = "";
     }
 }


### PR DESCRIPTION
Not sure if removing TF/VS error codes is necessary or will break certain telemetry/tracing.

I just deleted all fwlinks and aka.ms links based on strings that seemed like they could be surfaced to the user through error messages, and should not impact any behavior 

There are still a lot of references to "VSTS" in code, environment variables, etc that will need to removed but that may have behavioral side-effects 