### PR TITLE
relax project id restriction

### DIFF
--- a/src/Runner.Plugins/Artifact/DownloadArtifact.cs
+++ b/src/Runner.Plugins/Artifact/DownloadArtifact.cs
@@ -42,7 +42,6 @@ namespace GitHub.Runner.Plugins.Artifact
 
             // Project ID
             Guid projectId = new Guid(context.Variables.GetValueOrDefault(BuildVariables.TeamProjectId)?.Value ?? Guid.Empty.ToString());
-            ArgUtil.NotEmpty(projectId, nameof(projectId));
 
             // Build ID
             string buildIdStr = context.Variables.GetValueOrDefault(BuildVariables.BuildId)?.Value ?? string.Empty;

--- a/src/Runner.Plugins/Artifact/PublishArtifact.cs
+++ b/src/Runner.Plugins/Artifact/PublishArtifact.cs
@@ -47,7 +47,6 @@ namespace GitHub.Runner.Plugins.Artifact
 
             // Project ID
             Guid projectId = new Guid(context.Variables.GetValueOrDefault(BuildVariables.TeamProjectId)?.Value ?? Guid.Empty.ToString());
-            ArgUtil.NotEmpty(projectId, nameof(projectId));
 
             // Build ID
             string buildIdStr = context.Variables.GetValueOrDefault(BuildVariables.BuildId)?.Value ?? string.Empty;


### PR DESCRIPTION
when we get rid of TFS we won't have project id.  some apis still require it but we accept guid.empty now.