### PR TITLE
More descriptive error message

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -293,7 +293,7 @@ namespace GitHub.Runner.Worker
                 else
                 {
                     var fullPath = IOUtil.ResolvePath(actionDirectory, "."); // resolve full path without access filesystem.
-                    throw new NotSupportedException($"Can't find 'action.yml' or 'Dockerfile' under '{fullPath}'.");
+                    throw new NotSupportedException($"Can't find 'action.yml' or 'Dockerfile' under '{fullPath}'. Did you forget to run actions/checkout before running your local action?");
                 }
             }
             else if (action.Reference.Type == Pipelines.ActionSourceType.Script)
@@ -716,7 +716,7 @@ namespace GitHub.Runner.Worker
             else
             {
                 var fullPath = IOUtil.ResolvePath(actionEntryDirectory, "."); // resolve full path without access filesystem.
-                throw new InvalidOperationException($"Can't find 'action.yml' or 'Dockerfile' under '{fullPath}'.");
+                throw new InvalidOperationException($"Can't find 'action.yml' or 'Dockerfile' under '{fullPath}'. Did you forget to run actions/checkout before running your local action?");
             }
         }
     }


### PR DESCRIPTION
I've noticed that lots of times people try to run local actions without checking the repo out first and the action fails. This provides a little pointer towards that when we can't find the action.

We might also consider trying to run a checkout here if we don't find it? That might be too heavy though.