### PR TITLE
Simplify container start / keep-alive script

### DIFF
--- a/src/Runner.Worker/Container/ContainerInfo.cs
+++ b/src/Runner.Worker/Container/ContainerInfo.cs
@@ -76,7 +76,6 @@ namespace GitHub.Runner.Worker.Container
         public string ContainerEntryPointArgs { get; set; }
         public string ContainerEntryPoint { get; set; }
         public string ContainerWorkDirectory { get; set; }
-        public string ContainerBringNodePath { get; set; }
         public string ContainerCreateOptions { get; private set; }
         public bool IsJobContainer { get; set; }
 

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -23,7 +23,6 @@ namespace GitHub.Runner.Worker
 
     public class ContainerOperationProvider : RunnerService, IContainerOperationProvider
     {
-        private const string _nodeJsPathLabel = "github.actions.runner.node.path";
         private IDockerCommandManager _dockerManger;
 
         public override void Initialize(IHostContext hostContext)
@@ -230,22 +229,8 @@ namespace GitHub.Runner.Worker
 
             if (container.IsJobContainer)
             {
-                // See if this container brings its own Node.js
-                container.ContainerBringNodePath = await _dockerManger.DockerInspect(context: executionContext,
-                                                                    dockerObject: container.ContainerImage,
-                                                                    options: $"--format=\"{{{{index .Config.Labels \\\"{_nodeJsPathLabel}\\\"}}}}\"");
-
-                string node;
-                if (!string.IsNullOrEmpty(container.ContainerBringNodePath))
-                {
-                    node = container.ContainerBringNodePath;
-                }
-                else
-                {
-                    node = container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node12", "bin", $"node{IOUtil.ExeExtension}"));
-                }
-                container.ContainerEntryPoint = node;
-                container.ContainerEntryPointArgs = $"-e \"setInterval(function(){{}}, 24 * 60 * 60 * 1000);\"";
+                container.ContainerEntryPoint = "tail";
+                container.ContainerEntryPointArgs = "\"-f\" \"/dev/null\"";
             }
 
             container.ContainerId = await _dockerManger.DockerCreate(executionContext, container);

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -57,16 +57,7 @@ namespace GitHub.Runner.Worker.Handlers
                 workingDirectory = HostContext.GetDirectory(WellKnownDirectory.Work);
             }
 
-            string file;
-            if (!string.IsNullOrEmpty(ExecutionContext.Container?.ContainerBringNodePath))
-            {
-                file = ExecutionContext.Container.ContainerBringNodePath;
-            }
-            else
-            {
-                file = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node12", "bin", $"node{IOUtil.ExeExtension}");
-
-            }
+            string file = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node12", "bin", $"node{IOUtil.ExeExtension}");
 
             // Format the arguments passed to node.
             // 1) Wrap the script file path in double quotes.


### PR DESCRIPTION
Talked with bryan about getting rid of the old "bring your own node" cruft 

This simplifies how we start and keep containers alive, according to https://github.com/github/pe-actions-runtime/pull/26 (this is part 1)

Tested with: alpine, ubuntu, debian, and centos 