### PR TITLE
Dont overwrite workingdir for service containers

### DIFF
--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -199,35 +199,34 @@ namespace GitHub.Runner.Worker
                 throw new InvalidOperationException($"Docker pull failed with exit code {pullExitCode}");
             }
 
-            // Mount folders into container
-            var githubContext = executionContext.ExpressionValues["github"] as GitHubContext;
-            ArgUtil.NotNull(githubContext, nameof(githubContext));
-            var workingDirectory = githubContext["workspace"] as StringContextData;
-            ArgUtil.NotNullOrEmpty(workingDirectory, nameof(workingDirectory));
-            container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Work), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Work))));
-#if OS_WINDOWS
-            container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals))));
-#else
-            container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals)), true));
-#endif
-            container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Temp), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Temp))));
-            container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Actions), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Actions))));
-            container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tools), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tools))));
-
-            var tempHomeDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Temp), "_github_home");
-            Directory.CreateDirectory(tempHomeDirectory);
-            container.MountVolumes.Add(new MountVolume(tempHomeDirectory, "/github/home"));
-            container.AddPathTranslateMapping(tempHomeDirectory, "/github/home");
-            container.ContainerEnvironmentVariables["HOME"] = container.TranslateToContainerPath(tempHomeDirectory);
-
-            var tempWorkflowDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Temp), "_github_workflow");
-            Directory.CreateDirectory(tempWorkflowDirectory);
-            container.MountVolumes.Add(new MountVolume(tempWorkflowDirectory, "/github/workflow"));
-            container.AddPathTranslateMapping(tempWorkflowDirectory, "/github/workflow");
-
-
             if (container.IsJobContainer)
             {
+                // Configure job container - Mount workspace and tools, set up environment, and start long running process
+                var githubContext = executionContext.ExpressionValues["github"] as GitHubContext;
+                ArgUtil.NotNull(githubContext, nameof(githubContext));
+                var workingDirectory = githubContext["workspace"] as StringContextData;
+                ArgUtil.NotNullOrEmpty(workingDirectory, nameof(workingDirectory));
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Work), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Work))));
+#if OS_WINDOWS
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals))));
+#else
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals)), true));
+#endif
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Temp), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Temp))));
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Actions), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Actions))));
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tools), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tools))));
+
+                var tempHomeDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Temp), "_github_home");
+                Directory.CreateDirectory(tempHomeDirectory);
+                container.MountVolumes.Add(new MountVolume(tempHomeDirectory, "/github/home"));
+                container.AddPathTranslateMapping(tempHomeDirectory, "/github/home");
+                container.ContainerEnvironmentVariables["HOME"] = container.TranslateToContainerPath(tempHomeDirectory);
+
+                var tempWorkflowDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Temp), "_github_workflow");
+                Directory.CreateDirectory(tempWorkflowDirectory);
+                container.MountVolumes.Add(new MountVolume(tempWorkflowDirectory, "/github/workflow"));
+                container.AddPathTranslateMapping(tempWorkflowDirectory, "/github/workflow");
+
                 container.ContainerWorkDirectory = container.TranslateToContainerPath(workingDirectory);
                 container.ContainerEntryPoint = "tail";
                 container.ContainerEntryPointArgs = "\"-f\" \"/dev/null\"";


### PR DESCRIPTION
This is something I've considered changing for a while just to clean up, but never saw any real issues in the field

Came across: https://github.community/t5/GitHub-Actions/Github-Actions-services-not-reachable/m-p/30759/highlight/true#M547 

Some services are going to need the correct working directory set, if the startup scripts are relative to the WORKDIR as set in the Dockerfile, and this is an example of one

Overwriting the working dir for services always felt like a bad idea because we dont do any operations in the container relative to it anyways, and it will overwrite one which might be set

It can always be set back using something like:

```yaml
services:
  db:
    image: mydbimage
    options: --workdir ${{ whatever_the_context_for_workspace_is }}
```

or to some other custom location as needed

Issue tracking this: https://github.com/github/pe-actions-runtime/issues/39