### PR TITLE
Best effort to hide user/pass in urls

### DIFF
--- a/src/Runner.Worker/Worker.cs
+++ b/src/Runner.Worker/Worker.cs
@@ -188,7 +188,7 @@ namespace GitHub.Runner.Worker
                     HostContext.SecretMasker.AddValue(file.Ticket);
                 }
             }
-
+            // TODO: evaluate where this lives long term as we evaluate longer term secret detection
             HostContext.SecretMasker.AddRegex(@"https?:\/\/([a-zA-Z\d\-._~\!$&'()*+,;=%]+):([a-zA-Z\d\-._~\!$&'()*+,;=:%]*)@");
         }
 


### PR DESCRIPTION
In my opinion, we should view this as a short term solution to react to some of the launch difficulties we have faced.

Longer term, we should group this in as a part of a larger secret detection strategy. doing all of these as regex parsers inside the runner would not scale well, but this works as a stopgap for that time.