### PR TITLE
Allow vswhere to find VS pre-releases, if available

### DIFF
--- a/src/dev.sh
+++ b/src/dev.sh
@@ -218,7 +218,7 @@ bash ./Misc/externals.sh $RUNTIME_ID "Pre-Cache" || checkRC "externals.sh Pre-Ca
 
 if [[ "$CURRENT_PLATFORM" == 'windows' ]]; then
     vswhere=$(find "$DOWNLOAD_DIR" -name vswhere.exe | head -1)
-    vs_location=$("$vswhere" -latest -property installationPath)
+    vs_location=$("$vswhere" -prerelease -latest -property installationPath)
     msbuild_location="$vs_location""\MSBuild\15.0\Bin\msbuild.exe"
 
     if [[ ! -e "${msbuild_location}" ]]; then


### PR DESCRIPTION
Starting with [vswhere 2.0.2](https://github.com/microsoft/vswhere/releases/tag/2.0.2), there was a breaking change where by default, vswhere filtered out VS pre-release installations from the list of search results.

Adding the `-prerelease` flag will restore the previous behavior from vswhere 1.x versions.