### PR TITLE
Replace user-facing 'Agent' references with 'Runner'

### DIFF
--- a/src/Misc/layoutroot/config.cmd
+++ b/src/Misc/layoutroot/config.cmd
@@ -10,20 +10,8 @@ if defined VERBOSE_ARG (
   set VERBOSE_ARG='SilentlyContinue'
 )
 
-rem Unblock the following types of files:
-rem 1) The files in the root of the layout folder. E.g. .cmd files.
-rem
-rem 2) The PowerShell scripts delivered with the runner. E.g. capability scan scripts under "bin\"
-rem and legacy handler scripts under "externals\vstshost\".
-rem
-rem 3) The DLLs potentially loaded from a PowerShell script (e.g. DLLs in Agent.ServerOMDirectory).
-rem Otherwise, Add-Type may result in the following error:
-rem   Add-Type : Could not load file or assembly 'file:///[...].dll' or one of its dependencies.
-rem   Operation is not supported.
-rem Reproduced on Windows 8 in PowerShell 4. Changing the execution policy did not appear to make
-rem a difference. The error reproduced even with the execution policy set to Bypass. It may be a
-rem a policy setting.
-powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$VerbosePreference = %VERBOSE_ARG% ; Get-ChildItem -LiteralPath '%~dp0' | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null ; Get-ChildItem -Recurse -LiteralPath '%~dp0bin', '%~dp0externals' | Where-Object { $_ -match '\.(ps1|psd1|psm1)$' } | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null ; if (Test-Path -LiteralPath '%~dp0externals\vstsom' -PathType Container) { Get-ChildItem -LiteralPath '%~dp0externals\vstsom' | Where-Object { $_ -match '\.(dll|exe)$' } | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null }; if (Test-Path -LiteralPath '%~dp0externals\vstshost' -PathType Container) { Get-ChildItem -LiteralPath '%~dp0externals\vstshost' | Where-Object { $_ -match '\.(dll|exe)$' } | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null }"
+rem Unblock files in the root of the layout folder. E.g. .cmd files.
+powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$VerbosePreference = %VERBOSE_ARG% ; Get-ChildItem -LiteralPath '%~dp0' | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null"
 
 if /i "%~1" equ "remove" (
     rem ********************************************************************************

--- a/src/Misc/layoutroot/run.cmd
+++ b/src/Misc/layoutroot/run.cmd
@@ -10,20 +10,8 @@ if defined VERBOSE_ARG (
   set VERBOSE_ARG='SilentlyContinue'
 )
 
-rem Unblock the following types of files:
-rem 1) The files in the root of the layout folder. E.g. .cmd files.
-rem
-rem 2) The PowerShell scripts delivered with the runner. E.g. capability scan scripts under "bin\"
-rem and legacy handler scripts under "externals\vstshost\".
-rem
-rem 3) The DLLs potentially loaded from a PowerShell script (e.g. DLLs in Agent.ServerOMDirectory).
-rem Otherwise, Add-Type may result in the following error:
-rem   Add-Type : Could not load file or assembly 'file:///[...].dll' or one of its dependencies.
-rem   Operation is not supported.
-rem Reproduced on Windows 8 in PowerShell 4. Changing the execution policy did not appear to make
-rem a difference. The error reproduced even with the execution policy set to Bypass. It may be a
-rem a policy setting.
-powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$VerbosePreference = %VERBOSE_ARG% ; Get-ChildItem -LiteralPath '%~dp0' | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null ; Get-ChildItem -Recurse -LiteralPath '%~dp0bin', '%~dp0externals' | Where-Object { $_ -match '\.(ps1|psd1|psm1)$' } | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null ; if (Test-Path -LiteralPath '%~dp0externals\vstsom' -PathType Container) { Get-ChildItem -LiteralPath '%~dp0externals\vstsom' | Where-Object { $_ -match '\.(dll|exe)$' } | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null }; if (Test-Path -LiteralPath '%~dp0externals\vstshost' -PathType Container) { Get-ChildItem -LiteralPath '%~dp0externals\vstshost' | Where-Object { $_ -match '\.(dll|exe)$' } | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null }"
+rem Unblock files in the root of the layout folder. E.g. .cmd files.
+powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$VerbosePreference = %VERBOSE_ARG% ; Get-ChildItem -LiteralPath '%~dp0' | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null"
 
 if /i "%~1" equ "localRun" (
     rem ********************************************************************************


### PR DESCRIPTION
There were a few "user-facing" references to `Agent`, namely in both the `run` and `config` scripts, so I renamed them to `Runner` for consistency.

I also simplified the 'file unblocking' in `config.cmd` and `run.cmd` to remove the no-longer-needed Agent files while I'm here.

I decided to leave the code references (e.g. variable names) as `Agent`, as some of the server types include `Agent` in there. Replacing with `runner` would mean looking at code like this:

```cs
var taskRunnerSession = new TaskAgentSession(sessionName, runner, systemCapabilities);
```

...which I find more awkward than just leaving them as `agent`.