### PR TITLE
Print out the virtual environment version if available.

### DIFF
--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -50,6 +50,13 @@ namespace GitHub.Runner.Worker
                     context.Start();
                     context.Debug($"Starting: Set up job");
                     context.Output($"Current runner version: '{BuildConstants.RunnerPackage.Version}'");
+                    
+                    string virtualEnvironmentVersion = Environment.GetEnvironmentVariable("ImageVersion");
+                    if (!string.IsNullOrEmpty(virtualEnvironmentVersion))
+                    {
+                        context.Output($"Virtual Environment version: '{virtualEnvironmentVersion}'");
+                    }
+
                     var repoFullName = context.GetGitHubContext("repository");
                     ArgUtil.NotNull(repoFullName, nameof(repoFullName));
                     context.Debug($"Primary repository: {repoFullName}");


### PR DESCRIPTION
Linux and Windows images include the ImageVersion environment variable and this has proven valuable in diagnosing and debugging customer issues. We should print it out since it can affect the build similar to how the agent version could affect it.

The only downside I see here is that ImageVersion is not universal for all agents, only for actions-hosted ones, so  self-hosted ones won't necessarily have this information (though now there's a place where customers can plug in the version if they wish).