### PR TITLE
add-mask is leaking a secret in master if debug or ::echo::on is set

### DIFF
--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -405,7 +405,7 @@ namespace GitHub.Runner.Worker
     public sealed class DebugCommandExtension : RunnerService, IActionCommandExtension
     {
         public string Command => "debug";
-        public bool OmitEcho => false;
+        public bool OmitEcho => true;
 
         public Type ExtensionType => typeof(IActionCommandExtension);
 
@@ -433,7 +433,7 @@ namespace GitHub.Runner.Worker
     {
         public abstract IssueType Type { get; }
         public abstract string Command { get; }
-        public bool OmitEcho => false;
+        public bool OmitEcho => true;
 
         public Type ExtensionType => typeof(IActionCommandExtension);
 


### PR DESCRIPTION
If debug variable is set or echo::on is used, add-mask will echo before the secret is registered and it will leak the secret.  This bug did not ship and was caught in the release branch

Resolves #159, #157