### PR TITLE
Fix Runner.Worker build warnings

### DIFF
--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -541,7 +541,6 @@ namespace GitHub.Runner.Worker
                     break;
                 default:
                     throw new Exception($"Invalid echo command value. Possible values can be: 'on', 'off'. Current value is: '{command.Data}'.");
-                    break;
             }
         }
     }

--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -276,7 +276,9 @@ namespace GitHub.Runner.Worker.Container
             return await ExecuteDockerCommandAsync(context, "exec", $"{options} {containerId} {command}", context.CancellationToken);
         }
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously (method has async logic on only certain platforms)
         public async Task<int> DockerExec(IExecutionContext context, string containerId, string options, string command, List<string> output)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             ArgUtil.NotNull(output, nameof(output));
 
@@ -337,7 +339,9 @@ namespace GitHub.Runner.Worker.Container
             return ExecuteDockerCommandAsync(context, command, options, null, cancellationToken);
         }
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously (method has async logic on only certain platforms)
         private async Task<int> ExecuteDockerCommandAsync(IExecutionContext context, string command, string options, IDictionary<string, string> environment, EventHandler<ProcessDataReceivedEventArgs> stdoutDataReceived, EventHandler<ProcessDataReceivedEventArgs> stderrDataReceived, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             string arg = $"{command} {options}".Trim();
             context.Command($"{DockerPath} {arg}");
@@ -362,7 +366,9 @@ namespace GitHub.Runner.Worker.Container
 #endif
         }
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously (method has async logic on only certain platforms)
         private async Task<int> ExecuteDockerCommandAsync(IExecutionContext context, string command, string options, string workingDirectory, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             string arg = $"{command} {options}".Trim();
             context.Command($"{DockerPath} {arg}");

--- a/src/Runner.Worker/DiagnosticLogManager.cs
+++ b/src/Runner.Worker/DiagnosticLogManager.cs
@@ -31,7 +31,9 @@ namespace GitHub.Runner.Worker
     public sealed class DiagnosticLogManager : RunnerService, IDiagnosticLogManager
     {
         private static string DateTimeFormat = "yyyyMMdd-HHmmss";
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously (method has async logic on only certain platforms)
         public async Task UploadDiagnosticLogsAsync(IExecutionContext executionContext,
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
                                                 IExecutionContext parentContext, 
                                                 Pipelines.AgentJobRequestMessage message,
                                                 DateTime jobStartTimeUtc)

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -22,7 +22,9 @@ namespace GitHub.Runner.Worker.Handlers
     {
         public ContainerActionExecutionData Data { get; set; }
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously (method has async logic on only certain platforms)
         public async Task RunAsync(ActionRunStage stage)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             // Validate args.
             Trace.Entering();


### PR DESCRIPTION
Most of these warnings show up on only certain build OSes because of #ifdefs in the code. The fix is to suppress these warnings.