### PR TITLE
Fix build warnings in Test project

### DIFF
--- a/src/Test/L0/CommandLineParserL0.cs
+++ b/src/Test/L0/CommandLineParserL0.cs
@@ -47,8 +47,8 @@ namespace GitHub.Runner.Common.Tests
                 });
 
                 // Assert.
-                Assert.Equal(hc.SecretMasker.MaskSecrets("secret value 1"), "***");
-                Assert.Equal(hc.SecretMasker.MaskSecrets("secret value 2"), "***");
+                Assert.Equal("***", hc.SecretMasker.MaskSecrets("secret value 1"));
+                Assert.Equal("***", hc.SecretMasker.MaskSecrets("secret value 2"));
             }
         }
 
@@ -90,9 +90,9 @@ namespace GitHub.Runner.Common.Tests
                 trace.Info("Args: {0}", clp.Args.Count);
                 Assert.True(clp.Args.Count == 2);
                 Assert.True(clp.Args.ContainsKey("arg1"));
-                Assert.Equal(clp.Args["arg1"], "arg1val");
+                Assert.Equal("arg1val", clp.Args["arg1"]);
                 Assert.True(clp.Args.ContainsKey("arg2"));
-                Assert.Equal(clp.Args["arg2"], "arg2val");
+                Assert.Equal("arg2val", clp.Args["arg2"]);
             }
         }
 
@@ -113,8 +113,8 @@ namespace GitHub.Runner.Common.Tests
 
                 trace.Info("Args: {0}", clp.Flags.Count);
                 Assert.True(clp.Flags.Count == 2);
-                Assert.True(clp.Flags.Contains("flag1"));
-                Assert.True(clp.Flags.Contains("flag2"));
+                Assert.Contains("flag1", clp.Flags);
+                Assert.Contains("flag2", clp.Flags);
             }
         }
 

--- a/src/Test/L0/Container/DockerUtilL0.cs
+++ b/src/Test/L0/Container/DockerUtilL0.cs
@@ -36,10 +36,10 @@ namespace GitHub.Runner.Common.Tests.Worker.Container
 
             // Assert
             Assert.NotNull(result0);
-            Assert.Equal(result0.Count, 0);
+            Assert.Equal(0, result0.Count);
 
             Assert.NotNull(result1);
-            Assert.Equal(result1.Count, 1);
+            Assert.Equal(1, result1.Count);
             var result1Port80Mapping = result1.Find(pm =>
                 string.Equals(pm.ContainerPort, "80") &&
                 string.Equals(pm.HostPort, "32881") &&
@@ -48,10 +48,10 @@ namespace GitHub.Runner.Common.Tests.Worker.Container
             Assert.NotNull(result1Port80Mapping);
 
             Assert.NotNull(result1Empty);
-            Assert.Equal(result1Empty.Count, 0);
+            Assert.Equal(0, result1Empty.Count);
 
             Assert.NotNull(result2);
-            Assert.Equal(result2.Count, 2);
+            Assert.Equal(2, result2.Count);
             var result2Port80Mapping = result2.Find(pm =>
                 string.Equals(pm.ContainerPort, "80") &&
                 string.Equals(pm.HostPort, "32881") &&

--- a/src/Test/L0/HostContextL0.cs
+++ b/src/Test/L0/HostContextL0.cs
@@ -107,7 +107,7 @@ namespace GitHub.Runner.Common.Tests
             }
         }
 
-        public void Setup([CallerMemberName] string testName = "")
+        private void Setup([CallerMemberName] string testName = "")
         {
             _tokenSource = new CancellationTokenSource();
             _hc = new HostContext(
@@ -115,7 +115,7 @@ namespace GitHub.Runner.Common.Tests
                 logFile: Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), $"trace_{nameof(HostContextL0)}_{testName}.log"));
         }
 
-        public void Teardown()
+        private void Teardown()
         {
             _hc?.Dispose();
             _tokenSource?.Dispose();

--- a/src/Test/L0/Listener/CommandSettingsL0.cs
+++ b/src/Test/L0/Listener/CommandSettingsL0.cs
@@ -52,7 +52,7 @@ namespace GitHub.Runner.Common.Tests
                     // Assert.
                     Assert.Equal("some agent", actual);
                     Assert.Equal(string.Empty, Environment.GetEnvironmentVariable("ACTIONS_RUNNER_INPUT_AGENT") ?? string.Empty); // Should remove.
-                    Assert.Equal(hc.SecretMasker.MaskSecrets("some agent"), "some agent");
+                    Assert.Equal("some agent", hc.SecretMasker.MaskSecrets("some agent"));
                 }
                 finally
                 {
@@ -80,7 +80,7 @@ namespace GitHub.Runner.Common.Tests
                     // Assert.
                     Assert.Equal("some secret token value", actual);
                     Assert.Equal(string.Empty, Environment.GetEnvironmentVariable("ACTIONS_RUNNER_INPUT_TOKEN") ?? string.Empty); // Should remove.
-                    Assert.Equal(hc.SecretMasker.MaskSecrets("some secret token value"), "***");
+                    Assert.Equal("***", hc.SecretMasker.MaskSecrets("some secret token value"));
                 }
                 finally
                 {
@@ -250,7 +250,7 @@ namespace GitHub.Runner.Common.Tests
                     bool actual = command.Unattended;
 
                     // Assert.
-                    Assert.Equal(true, actual);
+                    Assert.True(actual);
                     Assert.Equal(string.Empty, Environment.GetEnvironmentVariable("ACTIONS_RUNNER_INPUT_UNATTENDED") ?? string.Empty); // Should remove.
                 }
                 finally
@@ -720,7 +720,7 @@ namespace GitHub.Runner.Common.Tests
                 var command = new CommandSettings(hc, args: new string[] { "badcommand" });
 
                 // Assert.
-                Assert.True(command.Validate().Contains("badcommand"));
+                Assert.Contains("badcommand", command.Validate());
             }
         }
 
@@ -735,7 +735,7 @@ namespace GitHub.Runner.Common.Tests
                 var command = new CommandSettings(hc, args: new string[] { "--badflag" });
 
                 // Assert.
-                Assert.True(command.Validate().Contains("badflag"));
+                Assert.Contains("badflag", command.Validate());
             }
         }
 
@@ -750,7 +750,7 @@ namespace GitHub.Runner.Common.Tests
                 var command = new CommandSettings(hc, args: new string[] { "--badargname", "bad arg value" });
 
                 // Assert.
-                Assert.True(command.Validate().Contains("badargname"));
+                Assert.Contains("badargname", command.Validate());
             }
         }
 

--- a/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
+++ b/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
@@ -43,10 +43,6 @@ namespace GitHub.Runner.Common.Tests.Listener.Configuration
         private string _expectedServerUrl = "https://localhost";
         private string _expectedAgentName = "expectedAgentName";
         private string _expectedPoolName = "poolName";
-        private string _expectedCollectionName = "testCollectionName";
-        private string _expectedProjectName = "testProjectName";
-        private string _expectedProjectId = "edf3f94e-d251-49df-bfce-602d6c967409";
-        private string _expectedMachineGroupName = "testMachineGroupName";
         private string _expectedAuthType = "pat";
         private string _expectedWorkFolder = "_work";
         private int _expectedPoolId = 1;

--- a/src/Test/L0/PagingLoggerL0.cs
+++ b/src/Test/L0/PagingLoggerL0.cs
@@ -64,7 +64,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                                 string line;
                                 while ((line = freader.ReadLine()) != null)
                                 {
-                                    Assert.True(line.EndsWith(LogData));
+                                    Assert.EndsWith(LogData, line);
                                     bytesWritten += logDataSize;
                                 }
                             }

--- a/src/Test/L0/Util/VssUtilL0.cs
+++ b/src/Test/L0/Util/VssUtilL0.cs
@@ -31,8 +31,8 @@ namespace GitHub.Runner.Common.Tests.Util
                     var connect = VssUtil.CreateConnection(new Uri("https://github.com/actions/runner"), new VssCredentials());
 
                     // Assert.
-                    Assert.Equal(connect.Settings.MaxRetryRequest.ToString(), "10");
-                    Assert.Equal(connect.Settings.SendTimeout.TotalSeconds.ToString(), "360");
+                    Assert.Equal("10", connect.Settings.MaxRetryRequest.ToString());
+                    Assert.Equal("360", connect.Settings.SendTimeout.TotalSeconds.ToString());
 
                     trace.Info("Set httpretry to 100.");
                     Environment.SetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_HTTP_RETRY", "100");
@@ -42,8 +42,8 @@ namespace GitHub.Runner.Common.Tests.Util
                     connect = VssUtil.CreateConnection(new Uri("https://github.com/actions/runner"), new VssCredentials());
 
                     // Assert.
-                    Assert.Equal(connect.Settings.MaxRetryRequest.ToString(), "10");
-                    Assert.Equal(connect.Settings.SendTimeout.TotalSeconds.ToString(), "1200");
+                    Assert.Equal("10", connect.Settings.MaxRetryRequest.ToString());
+                    Assert.Equal("1200", connect.Settings.SendTimeout.TotalSeconds.ToString());
                 }
                 finally
                 {

--- a/src/Test/L0/Worker/ActionManifestManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManifestManagerL0.cs
@@ -37,25 +37,25 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 //Assert
 
-                Assert.Equal(result.Name, "Hello World");
-                Assert.Equal(result.Description, "Greet the world and record the time");
-                Assert.Equal(result.Inputs.Count, 2);
-                Assert.Equal(result.Inputs[0].Key.AssertString("key").Value, "greeting");
-                Assert.Equal(result.Inputs[0].Value.AssertString("value").Value, "Hello");
-                Assert.Equal(result.Inputs[1].Key.AssertString("key").Value, "entryPoint");
-                Assert.Equal(result.Inputs[1].Value.AssertString("value").Value, "");
+                Assert.Equal("Hello World", result.Name);
+                Assert.Equal("Greet the world and record the time", result.Description);
+                Assert.Equal(2, result.Inputs.Count);
+                Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
+                Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
+                Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
 
-                Assert.Equal(result.Execution.ExecutionType, ActionExecutionType.Container);
+                Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
                 var containerAction = result.Execution as ContainerActionExecutionData;
 
-                Assert.Equal(containerAction.Image, "Dockerfile");
-                Assert.Equal(containerAction.EntryPoint, "main.sh");
-                Assert.Equal(containerAction.Arguments[0].ToString(), "bzz");
-                Assert.Equal(containerAction.Environment[0].Key.ToString(), "Token");
-                Assert.Equal(containerAction.Environment[0].Value.ToString(), "foo");
-                Assert.Equal(containerAction.Environment[1].Key.ToString(), "Url");
-                Assert.Equal(containerAction.Environment[1].Value.ToString(), "bar");
+                Assert.Equal("Dockerfile", containerAction.Image);
+                Assert.Equal("main.sh", containerAction.EntryPoint);
+                Assert.Equal("bzz", containerAction.Arguments[0].ToString());
+                Assert.Equal("Token", containerAction.Environment[0].Key.ToString());
+                Assert.Equal("foo", containerAction.Environment[0].Value.ToString());
+                Assert.Equal("Url", containerAction.Environment[1].Key.ToString());
+                Assert.Equal("bar", containerAction.Environment[1].Value.ToString());
             }
             finally
             {
@@ -81,27 +81,27 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 //Assert
 
-                Assert.Equal(result.Name, "Hello World");
-                Assert.Equal(result.Description, "Greet the world and record the time");
-                Assert.Equal(result.Inputs.Count, 2);
-                Assert.Equal(result.Inputs[0].Key.AssertString("key").Value, "greeting");
-                Assert.Equal(result.Inputs[0].Value.AssertString("value").Value, "Hello");
-                Assert.Equal(result.Inputs[1].Key.AssertString("key").Value, "entryPoint");
-                Assert.Equal(result.Inputs[1].Value.AssertString("value").Value, "");
+                Assert.Equal("Hello World", result.Name);
+                Assert.Equal("Greet the world and record the time", result.Description);
+                Assert.Equal(2, result.Inputs.Count);
+                Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
+                Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
+                Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
 
-                Assert.Equal(result.Execution.ExecutionType, ActionExecutionType.Container);
+                Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
                 var containerAction = result.Execution as ContainerActionExecutionData;
 
-                Assert.Equal(containerAction.Image, "Dockerfile");
-                Assert.Equal(containerAction.EntryPoint, "main.sh");
-                Assert.Equal(containerAction.Cleanup, "cleanup.sh");
-                Assert.Equal(containerAction.CleanupCondition, "failure()");
-                Assert.Equal(containerAction.Arguments[0].ToString(), "bzz");
-                Assert.Equal(containerAction.Environment[0].Key.ToString(), "Token");
-                Assert.Equal(containerAction.Environment[0].Value.ToString(), "foo");
-                Assert.Equal(containerAction.Environment[1].Key.ToString(), "Url");
-                Assert.Equal(containerAction.Environment[1].Value.ToString(), "bar");
+                Assert.Equal("Dockerfile", containerAction.Image);
+                Assert.Equal("main.sh", containerAction.EntryPoint);
+                Assert.Equal("cleanup.sh", containerAction.Cleanup);
+                Assert.Equal("failure()", containerAction.CleanupCondition);
+                Assert.Equal("bzz", containerAction.Arguments[0].ToString());
+                Assert.Equal("Token", containerAction.Environment[0].Key.ToString());
+                Assert.Equal("foo", containerAction.Environment[0].Value.ToString());
+                Assert.Equal("Url", containerAction.Environment[1].Key.ToString());
+                Assert.Equal("bar", containerAction.Environment[1].Value.ToString());
             }
             finally
             {
@@ -126,19 +126,19 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var result = actionManifest.Load(_ec.Object, Path.Combine(TestUtil.GetTestDataPath(), "dockerfileaction_noargs_noenv_noentrypoint.yml"));
 
                 //Assert
-                Assert.Equal(result.Name, "Hello World");
-                Assert.Equal(result.Description, "Greet the world and record the time");
-                Assert.Equal(result.Inputs.Count, 2);
-                Assert.Equal(result.Inputs[0].Key.AssertString("key").Value, "greeting");
-                Assert.Equal(result.Inputs[0].Value.AssertString("value").Value, "Hello");
-                Assert.Equal(result.Inputs[1].Key.AssertString("key").Value, "entryPoint");
-                Assert.Equal(result.Inputs[1].Value.AssertString("value").Value, "");
+                Assert.Equal("Hello World", result.Name);
+                Assert.Equal("Greet the world and record the time", result.Description);
+                Assert.Equal(2, result.Inputs.Count);
+                Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
+                Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
+                Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
 
-                Assert.Equal(result.Execution.ExecutionType, ActionExecutionType.Container);
+                Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
                 var containerAction = result.Execution as ContainerActionExecutionData;
 
-                Assert.Equal(containerAction.Image, "Dockerfile");
+                Assert.Equal("Dockerfile", containerAction.Image);
             }
             finally
             {
@@ -164,25 +164,25 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 //Assert
 
-                Assert.Equal(result.Name, "Hello World");
-                Assert.Equal(result.Description, "Greet the world and record the time");
-                Assert.Equal(result.Inputs.Count, 2);
-                Assert.Equal(result.Inputs[0].Key.AssertString("key").Value, "greeting");
-                Assert.Equal(result.Inputs[0].Value.AssertString("value").Value, "Hello");
-                Assert.Equal(result.Inputs[1].Key.AssertString("key").Value, "entryPoint");
-                Assert.Equal(result.Inputs[1].Value.AssertString("value").Value, "");
+                Assert.Equal("Hello World", result.Name);
+                Assert.Equal("Greet the world and record the time", result.Description);
+                Assert.Equal(2, result.Inputs.Count);
+                Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
+                Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
+                Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
 
-                Assert.Equal(result.Execution.ExecutionType, ActionExecutionType.Container);
+                Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
                 var containerAction = result.Execution as ContainerActionExecutionData;
 
-                Assert.Equal(containerAction.Image, "Dockerfile");
-                Assert.Equal(containerAction.EntryPoint, "main.sh");
-                Assert.Equal(containerAction.Arguments[0].ToString(), "${{ inputs.greeting }}");
-                Assert.Equal(containerAction.Environment[0].Key.ToString(), "Token");
-                Assert.Equal(containerAction.Environment[0].Value.ToString(), "foo");
-                Assert.Equal(containerAction.Environment[1].Key.ToString(), "Url");
-                Assert.Equal(containerAction.Environment[1].Value.ToString(), "${{ inputs.entryPoint }}");
+                Assert.Equal("Dockerfile", containerAction.Image);
+                Assert.Equal("main.sh", containerAction.EntryPoint);
+                Assert.Equal("${{ inputs.greeting }}", containerAction.Arguments[0].ToString());
+                Assert.Equal("Token", containerAction.Environment[0].Key.ToString());
+                Assert.Equal("foo", containerAction.Environment[0].Value.ToString());
+                Assert.Equal("Url", containerAction.Environment[1].Key.ToString());
+                Assert.Equal("${{ inputs.entryPoint }}", containerAction.Environment[1].Value.ToString());
             }
             finally
             {
@@ -207,25 +207,25 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var result = actionManifest.Load(_ec.Object, Path.Combine(TestUtil.GetTestDataPath(), "dockerhubaction.yml"));
 
                 //Assert
-                Assert.Equal(result.Name, "Hello World");
-                Assert.Equal(result.Description, "Greet the world and record the time");
-                Assert.Equal(result.Inputs.Count, 2);
-                Assert.Equal(result.Inputs[0].Key.AssertString("key").Value, "greeting");
-                Assert.Equal(result.Inputs[0].Value.AssertString("value").Value, "Hello");
-                Assert.Equal(result.Inputs[1].Key.AssertString("key").Value, "entryPoint");
-                Assert.Equal(result.Inputs[1].Value.AssertString("value").Value, "");
+                Assert.Equal("Hello World", result.Name);
+                Assert.Equal("Greet the world and record the time", result.Description);
+                Assert.Equal(2, result.Inputs.Count);
+                Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
+                Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
+                Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
 
-                Assert.Equal(result.Execution.ExecutionType, ActionExecutionType.Container);
+                Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
                 var containerAction = result.Execution as ContainerActionExecutionData;
 
-                Assert.Equal(containerAction.Image, "docker://ubuntu:18.04");
-                Assert.Equal(containerAction.EntryPoint, "main.sh");
-                Assert.Equal(containerAction.Arguments[0].ToString(), "bzz");
-                Assert.Equal(containerAction.Environment[0].Key.ToString(), "Token");
-                Assert.Equal(containerAction.Environment[0].Value.ToString(), "foo");
-                Assert.Equal(containerAction.Environment[1].Key.ToString(), "Url");
-                Assert.Equal(containerAction.Environment[1].Value.ToString(), "bar");
+                Assert.Equal("docker://ubuntu:18.04", containerAction.Image);
+                Assert.Equal("main.sh", containerAction.EntryPoint);
+                Assert.Equal("bzz", containerAction.Arguments[0].ToString());
+                Assert.Equal("Token", containerAction.Environment[0].Key.ToString());
+                Assert.Equal("foo", containerAction.Environment[0].Value.ToString());
+                Assert.Equal("Url", containerAction.Environment[1].Key.ToString());
+                Assert.Equal("bar", containerAction.Environment[1].Value.ToString());
             }
             finally
             {
@@ -250,24 +250,24 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var result = actionManifest.Load(_ec.Object, Path.Combine(TestUtil.GetTestDataPath(), "nodeaction.yml"));
 
                 //Assert
-                Assert.Equal(result.Name, "Hello World");
-                Assert.Equal(result.Description, "Greet the world and record the time");
-                Assert.Equal(result.Inputs.Count, 2);
-                Assert.Equal(result.Inputs[0].Key.AssertString("key").Value, "greeting");
-                Assert.Equal(result.Inputs[0].Value.AssertString("value").Value, "Hello");
-                Assert.Equal(result.Inputs[1].Key.AssertString("key").Value, "entryPoint");
-                Assert.Equal(result.Inputs[1].Value.AssertString("value").Value, "");
-                Assert.Equal(result.Deprecated.Count, 1);
+                Assert.Equal("Hello World", result.Name);
+                Assert.Equal("Greet the world and record the time", result.Description);
+                Assert.Equal(2, result.Inputs.Count);
+                Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
+                Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
+                Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal(1, result.Deprecated.Count);
 
                 Assert.True(result.Deprecated.ContainsKey("greeting"));
                 result.Deprecated.TryGetValue("greeting", out string value);
-                Assert.Equal(value, "This property has been deprecated");
+                Assert.Equal("This property has been deprecated", value);
 
-                Assert.Equal(result.Execution.ExecutionType, ActionExecutionType.NodeJS);
+                Assert.Equal(ActionExecutionType.NodeJS, result.Execution.ExecutionType);
 
                 var nodeAction = result.Execution as NodeJSActionExecutionData;
 
-                Assert.Equal(nodeAction.Script, "main.js");
+                Assert.Equal("main.js", nodeAction.Script);
             }
             finally
             {
@@ -292,26 +292,26 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var result = actionManifest.Load(_ec.Object, Path.Combine(TestUtil.GetTestDataPath(), "nodeaction_cleanup.yml"));
 
                 //Assert
-                Assert.Equal(result.Name, "Hello World");
-                Assert.Equal(result.Description, "Greet the world and record the time");
-                Assert.Equal(result.Inputs.Count, 2);
-                Assert.Equal(result.Inputs[0].Key.AssertString("key").Value, "greeting");
-                Assert.Equal(result.Inputs[0].Value.AssertString("value").Value, "Hello");
-                Assert.Equal(result.Inputs[1].Key.AssertString("key").Value, "entryPoint");
-                Assert.Equal(result.Inputs[1].Value.AssertString("value").Value, "");
-                Assert.Equal(result.Deprecated.Count, 1);
+                Assert.Equal("Hello World", result.Name);
+                Assert.Equal("Greet the world and record the time", result.Description);
+                Assert.Equal(2, result.Inputs.Count);
+                Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
+                Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
+                Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal(1, result.Deprecated.Count);
 
                 Assert.True(result.Deprecated.ContainsKey("greeting"));
                 result.Deprecated.TryGetValue("greeting", out string value);
-                Assert.Equal(value, "This property has been deprecated");
+                Assert.Equal("This property has been deprecated", value);
 
-                Assert.Equal(result.Execution.ExecutionType, ActionExecutionType.NodeJS);
+                Assert.Equal(ActionExecutionType.NodeJS, result.Execution.ExecutionType);
 
                 var nodeAction = result.Execution as NodeJSActionExecutionData;
 
-                Assert.Equal(nodeAction.Script, "main.js");
-                Assert.Equal(nodeAction.Cleanup, "cleanup.js");
-                Assert.Equal(nodeAction.CleanupCondition, "cancelled()");
+                Assert.Equal("main.js", nodeAction.Script);
+                Assert.Equal("cleanup.js", nodeAction.Cleanup);
+                Assert.Equal("cancelled()", nodeAction.CleanupCondition);
             }
             finally
             {
@@ -336,19 +336,19 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var result = actionManifest.Load(_ec.Object, Path.Combine(TestUtil.GetTestDataPath(), "pluginaction.yml"));
 
                 //Assert
-                Assert.Equal(result.Name, "Hello World");
-                Assert.Equal(result.Description, "Greet the world and record the time");
-                Assert.Equal(result.Inputs.Count, 2);
-                Assert.Equal(result.Inputs[0].Key.AssertString("key").Value, "greeting");
-                Assert.Equal(result.Inputs[0].Value.AssertString("value").Value, "Hello");
-                Assert.Equal(result.Inputs[1].Key.AssertString("key").Value, "entryPoint");
-                Assert.Equal(result.Inputs[1].Value.AssertString("value").Value, "");
+                Assert.Equal("Hello World", result.Name);
+                Assert.Equal("Greet the world and record the time", result.Description);
+                Assert.Equal(2, result.Inputs.Count);
+                Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
+                Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
+                Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
 
-                Assert.Equal(result.Execution.ExecutionType, ActionExecutionType.Plugin);
+                Assert.Equal(ActionExecutionType.Plugin, result.Execution.ExecutionType);
 
                 var pluginAction = result.Execution as PluginActionExecutionData;
 
-                Assert.Equal(pluginAction.Plugin, "someplugin");
+                Assert.Equal("someplugin", pluginAction.Plugin);
             }
             finally
             {
@@ -383,9 +383,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var result = actionManifest.EvaluateContainerArguments(_ec.Object, arguments, evaluateContext);
 
                 //Assert
-                Assert.Equal(result[0], "hello");
-                Assert.Equal(result[1], "test");
-                Assert.Equal(result.Count, 2);
+                Assert.Equal("hello", result[0]);
+                Assert.Equal("test", result[1]);
+                Assert.Equal(2, result.Count);
             }
             finally
             {
@@ -420,9 +420,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var result = actionManifest.EvaluateContainerEnvironment(_ec.Object, environment, evaluateContext);
 
                 //Assert
-                Assert.Equal(result["hello"], "hello");
-                Assert.Equal(result["test"], "test");
-                Assert.Equal(result.Count, 2);
+                Assert.Equal("hello", result["hello"]);
+                Assert.Equal("test", result["test"]);
+                Assert.Equal(2, result.Count);
             }
             finally
             {
@@ -459,13 +459,13 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var result = actionManifest.EvaluateDefaultInput(_ec.Object, "testInput", new StringToken(null, null, null, "defaultValue"), evaluateContext);
 
                 //Assert
-                Assert.Equal(result, "defaultValue");
+                Assert.Equal("defaultValue", result);
 
                 //Act
                 result = actionManifest.EvaluateDefaultInput(_ec.Object, "testInput", new BasicExpressionToken(null, null, null, "github.ref"), evaluateContext);
 
                 //Assert
-                Assert.Equal(result, "refs/heads/master");
+                Assert.Equal("refs/heads/master", result);
             }
             finally
             {

--- a/src/Test/L0/Worker/ActionRunnerL0.cs
+++ b/src/Test/L0/Worker/ActionRunnerL0.cs
@@ -31,7 +31,6 @@ namespace GitHub.Runner.Common.Tests.Worker
         private TestHostContext _hc;
         private ActionRunner _actionRunner;
         private IActionManifestManager _actionManifestManager;
-        private string _workFolder;
         private DictionaryContextData _context = new DictionaryContextData();
 
         [Fact]
@@ -75,9 +74,9 @@ namespace GitHub.Runner.Common.Tests.Worker
             }
 
             //Assert
-            Assert.Equal(finialInputs["input1"], "test1");
-            Assert.Equal(finialInputs["input2"], "test2");
-            Assert.Equal(finialInputs["input3"], "github");
+            Assert.Equal("test1", finialInputs["input1"]);
+            Assert.Equal("test2", finialInputs["input2"]);
+            Assert.Equal("github", finialInputs["input3"]);
         }
 
         [Fact]
@@ -276,24 +275,6 @@ namespace GitHub.Runner.Common.Tests.Worker
             Assert.False(didUpdateDisplayName);
             // Should use the pretty display name until we can eval
             Assert.Equal("${{ matrix.node }}", _actionRunner.DisplayName);
-        }
-
-        private void CreateAction(string yamlContent, out Pipelines.ActionStep instance, out string directory)
-        {
-            directory = Path.Combine(_workFolder, Constants.Path.ActionsDirectory, "GitHub/actions".Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), "master");
-            string file = Path.Combine(directory, Constants.Path.ActionManifestFile);
-            Directory.CreateDirectory(Path.GetDirectoryName(file));
-            File.WriteAllText(file, yamlContent);
-            instance = new Pipelines.ActionStep()
-            {
-                Id = Guid.NewGuid(),
-                Reference = new Pipelines.RepositoryPathReference()
-                {
-                    Name = "GitHub/actions",
-                    Ref = "master",
-                    RepositoryType = Pipelines.RepositoryTypes.GitHub
-                }
-            };
         }
 
         private void Setup([CallerMemberName] string name = "")

--- a/src/Test/L0/Worker/VariablesL0.cs
+++ b/src/Test/L0/Worker/VariablesL0.cs
@@ -150,7 +150,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 string actual = variables.Get("no such");
 
                 // Assert.
-                Assert.Equal(null, actual);
+                Assert.Null(actual);
             }
         }
 


### PR DESCRIPTION
The build warnings were of these type (mostly reported by xUnit's Code Analyzers):
- Fixed wrong parameter order in xUnit assertions (can lead to poor error reporting in test failures)
- Unused code was removed
- Correct assertions were used (e.g. Assert.True/.Contains/.EndsWith)
- Public non-test methods on test classes were made private