### PR TITLE
better repo matching for issue file path

### DIFF
--- a/src/Runner.Worker/Handlers/OutputManager.cs
+++ b/src/Runner.Worker/Handlers/OutputManager.cs
@@ -341,7 +341,7 @@ namespace GitHub.Runner.Worker.Handlers
                 {
                     // Check if the config contains the workflow repository url
                     var qualifiedRepository = _executionContext.GetGitHubContext("repository");
-                    var configMatch =  $"url = https://github.com/{qualifiedRepository}";
+                    var configMatch = $"url = https://github.com/{qualifiedRepository}";
                     var content = File.ReadAllText(gitConfigPath);
                     foreach (var line in content.Split("\n").Select(x => x.Trim()))
                     {

--- a/src/Test/L0/Worker/OutputManagerL0.cs
+++ b/src/Test/L0/Worker/OutputManagerL0.cs
@@ -890,12 +890,12 @@ namespace GitHub.Runner.Common.Tests.Worker
             var gitPath = WhichUtil.Which("git", true);
             var environment = new Dictionary<string, string>();
 
-            using(var processInvoker = new ProcessInvoker(hostConetxt.GetTrace()))
+            using (var processInvoker = new ProcessInvoker(hostConetxt.GetTrace()))
             {
                 await processInvoker.ExecuteAsync(path, gitPath, "init", environment, CancellationToken.None);
             }
 
-            using(var processInvoker = new ProcessInvoker(hostConetxt.GetTrace()))
+            using (var processInvoker = new ProcessInvoker(hostConetxt.GetTrace()))
             {
                 await processInvoker.ExecuteAsync(path, gitPath, $"remote add origin {url}", environment, CancellationToken.None);
             }


### PR DESCRIPTION
This change is related to checkout v2. Since `github.workspace` may not match where the workflow repo is checked out, this change provides a more accurate way to resolve file paths for issues. The file path associated with issues should always be relative to the workflow repo.