### PR TITLE
Update node external to 12.13.1

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -139,7 +139,7 @@ fi
 # Download the external tools for Linux PACKAGERUNTIMEs.
 if [[ "$PACKAGERUNTIME" == "linux-x64" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE12_VERSION}/node-v${NODE12_VERSION}-linux-x64.tar.gz" node12 fix_nested_dir
-    acquireExternalTool "https://vstsagenttools.blob.core.windows.net/tools/nodejs/${NODE12_VERSION}/alpine/x64/node-v${NODE12_VERSION}-alpine-x64.tar.gz" node12_alpine
+    acquireExternalTool "https://vstsagenttools.blob.core.windows.net/tools/nodejs/${NODE12_VERSION}/alpine/x64/node-${NODE12_VERSION}-alpine-x64.tar.gz" node12_alpine
 fi
 
 if [[ "$PACKAGERUNTIME" == "linux-arm64" ]]; then


### PR DESCRIPTION
Bumps external node runtime to 12.13.1 / latest LTS