### PR TITLE
Replace remaining Agent -> Runner references

### DIFF
--- a/src/Runner.Listener/Configuration/IRSAKeyManager.cs
+++ b/src/Runner.Listener/Configuration/IRSAKeyManager.cs
@@ -6,7 +6,7 @@ using GitHub.Runner.Common;
 namespace GitHub.Runner.Listener.Configuration
 {
     /// <summary>
-    /// Manages an RSA key for the agent using the most appropriate store for the target platform.
+    /// Manages an RSA key for the runner using the most appropriate store for the target platform.
     /// </summary>
 #if OS_WINDOWS
     [ServiceLocator(Default = typeof(RSAEncryptedFileKeyManager))]
@@ -16,10 +16,10 @@ namespace GitHub.Runner.Listener.Configuration
     public interface IRSAKeyManager : IRunnerService
     {
         /// <summary>
-        /// Creates a new <c>RSACryptoServiceProvider</c> instance for the current agent. If a key file is found then the current
+        /// Creates a new <c>RSACryptoServiceProvider</c> instance for the current runner. If a key file is found then the current
         /// key is returned to the caller.
         /// </summary>
-        /// <returns>An <c>RSACryptoServiceProvider</c> instance representing the key for the agent</returns>
+        /// <returns>An <c>RSACryptoServiceProvider</c> instance representing the key for the runner</returns>
         RSACryptoServiceProvider CreateKey();
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace GitHub.Runner.Listener.Configuration
         /// <summary>
         /// Gets the <c>RSACryptoServiceProvider</c> instance currently stored by the key manager. 
         /// </summary>
-        /// <returns>An <c>RSACryptoServiceProvider</c> instance representing the key for the agent</returns>
+        /// <returns>An <c>RSACryptoServiceProvider</c> instance representing the key for the runner</returns>
         /// <exception cref="CryptographicException">No key exists in the store</exception>
         RSACryptoServiceProvider GetKey();
     }

--- a/src/Runner.Listener/Configuration/NativeWindowsServiceHelper.cs
+++ b/src/Runner.Listener/Configuration/NativeWindowsServiceHelper.cs
@@ -447,7 +447,7 @@ namespace GitHub.Runner.Listener.Configuration
         {
             Trace.Entering();
 
-            string agentServiceExecutable = "\"" + Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), WindowsServiceControlManager.WindowsServiceControllerName) + "\"";
+            string runnerServiceExecutable = "\"" + Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), WindowsServiceControlManager.WindowsServiceControllerName) + "\"";
             IntPtr scmHndl = IntPtr.Zero;
             IntPtr svcHndl = IntPtr.Zero;
             IntPtr tmpBuf = IntPtr.Zero;
@@ -468,7 +468,7 @@ namespace GitHub.Runner.Listener.Configuration
                     };
 
                     processInvoker.ExecuteAsync(workingDirectory: string.Empty,
-                                                fileName: agentServiceExecutable,
+                                                fileName: runnerServiceExecutable,
                                                 arguments: "init",
                                                 environment: null,
                                                 requireExitCodeZero: true,
@@ -490,7 +490,7 @@ namespace GitHub.Runner.Listener.Configuration
                                         SERVICE_WIN32_OWN_PROCESS,
                                         ServiceBootFlag.AutoStart,
                                         ServiceError.Normal,
-                                        agentServiceExecutable,
+                                        runnerServiceExecutable,
                                         null,
                                         IntPtr.Zero,
                                         null,

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -80,7 +80,7 @@ namespace GitHub.Runner.Listener
                 Trace.Info($"Attempt to create session.");
                 try
                 {
-                    Trace.Info("Connecting to the Agent Server...");
+                    Trace.Info("Connecting to the Runner Server...");
                     await _runnerServer.ConnectAsync(new Uri(serverUrl), creds);
                     Trace.Info("VssConnection created");
                     
@@ -110,7 +110,7 @@ namespace GitHub.Runner.Listener
                 }
                 catch (TaskAgentAccessTokenExpiredException)
                 {
-                    Trace.Info("Agent OAuth token has been revoked. Session creation failed.");
+                    Trace.Info("Runner OAuth token has been revoked. Session creation failed.");
                     throw;
                 }
                 catch (Exception ex)
@@ -190,7 +190,7 @@ namespace GitHub.Runner.Listener
                 }
                 catch (TaskAgentAccessTokenExpiredException)
                 {
-                    Trace.Info("Agent OAuth token has been revoked. Unable to pull message.");
+                    Trace.Info("Runner OAuth token has been revoked. Unable to pull message.");
                     throw;
                 }
                 catch (Exception ex)
@@ -336,7 +336,7 @@ namespace GitHub.Runner.Listener
         {
             if (ex is TaskAgentNotFoundException)
             {
-                Trace.Info("The agent no longer exists on the server. Stopping the runner.");
+                Trace.Info("The runner no longer exists on the server. Stopping the runner.");
                 _term.WriteError("The runner no longer exists on the server. Please reconfigure the runner.");
                 return false;
             }
@@ -364,7 +364,7 @@ namespace GitHub.Runner.Listener
             }
             else if (ex is VssOAuthTokenRequestException && ex.Message.Contains("Current server time is"))
             {
-                Trace.Info("Local clock might skewed.");
+                Trace.Info("Local clock might be skewed.");
                 _term.WriteError("The local machine's clock may be out of sync with the server time by more than five minutes. Please sync your clock with your domain or internet time and try again.");
                 if (_sessionCreationExceptionTracker.ContainsKey(nameof(VssOAuthTokenRequestException)))
                 {

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -434,7 +434,7 @@ namespace GitHub.Runner.Listener
             }
             catch (TaskAgentAccessTokenExpiredException)
             {
-                Trace.Info("Agent OAuth token has been revoked. Shutting down.");
+                Trace.Info("Runner OAuth token has been revoked. Shutting down.");
             }
 
             return Constants.Runner.ReturnCode.Success;

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -48,7 +48,7 @@ namespace GitHub.Runner.Worker
                                                 displayName: "Stop containers",
                                                 data: data);
             
-            executionContext.Debug($"Register post job cleanup for stoping/deleting containers.");
+            executionContext.Debug($"Register post job cleanup for stopping/deleting containers.");
             executionContext.RegisterPostJobStep(nameof(StopContainersAsync), postJobStep);
 
             // Check whether we are inside a container.
@@ -129,7 +129,7 @@ namespace GitHub.Runner.Worker
                 executionContext.Warning($"Delete stale container networks failed, docker network prune fail with exit code {networkPruneExitCode}");
             }
 
-            // Create local docker network for this job to avoid port conflict when multiple agents run on same machine.
+            // Create local docker network for this job to avoid port conflict when multiple runners run on same machine.
             // All containers within a job join the same network
             var containerNetwork = $"github_network_{Guid.NewGuid().ToString("N")}";
             await CreateContainerNetworkAsync(executionContext, containerNetwork);

--- a/src/Runner.Worker/Handlers/HandlerFactory.cs
+++ b/src/Runner.Worker/Handlers/HandlerFactory.cs
@@ -62,7 +62,7 @@ namespace GitHub.Runner.Worker.Handlers
             }
             else if (data.ExecutionType == ActionExecutionType.Plugin)
             {
-                // Agent plugin
+                // Runner plugin
                 handler = HostContext.CreateService<IRunnerPluginHandler>();
                 (handler as IRunnerPluginHandler).Data = data as PluginActionExecutionData;
             }


### PR DESCRIPTION
Replace every `Agent` reference that's left in the code base, not directly or indirectly referenced by the `TaskAgent` client contracts.