### PR TITLE
Verify that Windows runner service has started successfully

### DIFF
--- a/src/Runner.Listener/Configuration/NativeWindowsServiceHelper.cs
+++ b/src/Runner.Listener/Configuration/NativeWindowsServiceHelper.cs
@@ -678,6 +678,17 @@ namespace GitHub.Runner.Listener.Configuration
                 if (service != null)
                 {
                     service.Start();
+
+                    try
+                    {
+                        _term.WriteLine("Waiting for service to start...");
+                        service.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(60));
+                    }
+                    catch (System.ServiceProcess.TimeoutException)
+                    {
+                        throw new InvalidOperationException($"Cannot start the service {serviceName} in a timely fashion.");
+                    }
+
                     _term.WriteLine($"Service {serviceName} started successfully");
                 }
                 else


### PR DESCRIPTION
Before this change, the runner was sending the command to start the runner, but it never verified that the service had actually started successfully. Now it waits for a successful `Running` status.

Fixes #194
