### PR TITLE
Expose whether debug is on/off via RUNNER_DEBUG.

### DIFF
--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -107,6 +107,11 @@ namespace GitHub.Runner.Worker
                     return await CompleteJobAsync(jobServer, jobContext, message, TaskResult.Failed);
                 }
 
+                if (jobContext.WriteDebug)
+                {
+                    jobContext.SetRunnerContext("debug", "1");
+                }
+
                 jobContext.SetRunnerContext("os", VarUtil.OS);
 
                 string toolsDirectory = HostContext.GetDirectory(WellKnownDirectory.Tools);


### PR DESCRIPTION
#252

Actions can check env `RUNNER_BEBUG==1` to figure out whether [steps debug](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/managing-a-workflow-run#enabling-step-debug-logging) is turned on for this job.
