### PR TITLE
Add the runner name as a label

### DIFF
--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -472,6 +472,7 @@ namespace GitHub.Runner.Listener.Configuration
             agent.Labels.Add("self-hosted");
             agent.Labels.Add(VarUtil.OS);
             agent.Labels.Add(VarUtil.OSArchitecture);
+            agent.Labels.Add(agent.Name);
 
             return agent;
         }
@@ -492,6 +493,7 @@ namespace GitHub.Runner.Listener.Configuration
             agent.Labels.Add("self-hosted");
             agent.Labels.Add(VarUtil.OS);
             agent.Labels.Add(VarUtil.OSArchitecture);
+            agent.Labels.Add(agent.Name);
 
             return agent;
         }


### PR DESCRIPTION
This PR adds the runner name as a label, so that it can be selected by it's name in a workflow, e.g.:
```yaml
runs-on: [self-hosted, my-runner-name]
```
Use cases for this being any time when you have multiple runners attached to a single repo, but need to distinguish between them. For example, you could have a runner with a GPU for testing machine learning models, and another without a GPU for general loads - this would enable you to run your ML tests specifically on the runner with the GPU.

This could be thought of as a first-step, "minimum viable solution" for some of the use cases for custom labels that would allow more people to get started sooner - https://github.com/actions/runner/issues/262