### PR TITLE
Update --help

### DIFF
--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -474,9 +474,6 @@ Config Options:
     _term.WriteLine($@" --windowslogonpassword string  Password for the service account. Requires runasservice");
 #endif
     _term.WriteLine($@"
-Run Options:
- --once  Exit after completing a job. Does not remove the runner
-
 Examples:
  Configure a runner non-interactively:
   .{separator}config.{ext} --unattended --url <url> --token <token>

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -450,7 +450,7 @@ namespace GitHub.Runner.Listener
             separator = "/";
             ext = "sh";
 #endif
-           _term.WriteLine($@"
+            _term.WriteLine($@"
 Commands:
  .{separator}config.{ext}         Configures the runner
  .{separator}config.{ext} remove  Unconfigures the runner

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -450,17 +450,42 @@ namespace GitHub.Runner.Listener
             separator = "/";
             ext = "sh";
 #endif
-            _term.WriteLine($@"
-Commands:,
- .{separator}config.{ext}          Configures the runner
- .{separator}config.{ext} remove   Unconfigures the runner
- .{separator}run.{ext}             Runs the runner interactively. Does not require any options.
+           _term.WriteLine($@"
+Commands:
+ .{separator}config.{ext}         Configures the runner
+ .{separator}config.{ext} remove  Unconfigures the runner
+ .{separator}run.{ext}            Runs the runner interactively. Does not require any options.
 
 Options:
+ --help     Prints the help for each command
  --version  Prints the runner version
  --commit   Prints the runner commit
- --help     Prints the help for each command
-");
+
+Config Options:
+ --unattended     Disable interactive prompts for missing arguments. Defaults will be used for missing options
+ --url string     Repository to add the runner to. Required if unattended
+ --token string   Registration token. Required if unattended
+ --name string    Name of the runner to configure (default {Environment.MachineName ?? "myrunner"})
+ --work string    Relative runner work directory (default {Constants.Path.WorkDirectory})
+ --replace        Replace any existing runner with the same name (default false)");
+#if OS_WINDOWS
+    _term.WriteLine($@" --runasservice   Run the runner as a service");
+    _term.WriteLine($@" --windowslogonaccount string   Account to run the service as. Requires runasservice");
+    _term.WriteLine($@" --windowslogonpassword string  Password for the service account. Requires runasservice");
+#endif
+    _term.WriteLine($@"
+Run Options:
+ --once  Exit after completing a job. Does not remove the runner
+
+Examples:
+ Configure a runner non-interactively:
+  .{separator}config.{ext} --unattended --url <url> --token <token>
+ Configure a runner non-interactively, replacing any existing runner with the same name:
+  .{separator}config.{ext} --unattended --url <url> --token <token> --replace [--name <name>]");
+#if OS_WINDOWS
+    _term.WriteLine($@" Configure a runner to run as a service:");
+    _term.WriteLine($@"  .{separator}config.{ext} --url <url> --token <token> --runasservice");
+#endif
         }
     }
 }


### PR DESCRIPTION
Updates --help document to separate out common/config/run options that are exposed by these helper scripts

Separates options that are only useful on Windows (for running as service)

Omits internal binary flags that arent a public api, monitorsocketaddress and startuptype.
Omits auth because I think only one auth type is supported right now. 
Omits username and pool which seem to be unused.

Provides basic examples for common scenarios (unattended, scripted setup)

Windows/Unix:
```
Commands:
 .\config.cmd         Configures the runner
 .\config.cmd remove  Unconfigures the runner
 .\run.cmd            Runs the runner interactively. Does not require any options.

Options:
 --help     Prints the help for each command
 --version  Prints the runner version
 --commit   Prints the runner commit

Config Options:
 --unattended     Disable interactive prompts for missing arguments. Defaults will be used for missing options
 --url string     Repository to add the runner to. Required if unattended
 --token string   Registration token. Required if unattended
 --name string    Name of the runner to configure (default DAKALE-WORK)
 --work string    Relative runner work directory (default _work)
 --replace        Replace any existing runner with the same name (default false)
 --runasservice   Run the runner as a service
 --windowslogonaccount string   Account to run the service as. Requires runasservice
 --windowslogonpassword string  Password for the service account. Requires runasservice

Run Options:
 --once  Exit after completing a job. Does not remove the runner

Examples:
 Configure a runner non-interactively:
  .\config.cmd --unattended --url <url> --token <token>
 Configure a runner non-interactively, replacing any existing runner with the same name:
  .\config.cmd --unattended --url <url> --token <token> --replace [--name <name>]
 Configure a runner to run as a service:
  .\config.cmd --url <url> --token <token> --runasservice

--------------------------------------------------------------------------------------------------------------------

Commands:
 ./config.sh         Configures the runner
 ./config.sh remove  Unconfigures the runner
 ./run.sh            Runs the runner interactively. Does not require any options.

Options:
 --help     Prints the help for each command
 --version  Prints the runner version
 --commit   Prints the runner commit

Config Options:
 --unattended     Disable interactive prompts for missing arguments. Defaults will be used for missing options
 --url string     Repository to add the runner to. Required if unattended
 --token string   Registration token. Required if unattended
 --name string    Name of the runner to configure (default DAKALE-WORK)
 --work string    Relative runner work directory (default _work)
 --replace        Replace any existing runner with the same name (default false)

Run Options:
 --once  Exit after completing a job. Does not remove the runner

Examples:
 Configure a runner non-interactively:
  ./config.sh --unattended --url <url> --token <token>
 Configure a runner non-interactively, replacing any existing runner with the same name:
  ./config.sh --unattended --url <url> --token <token> --replace [--name <name>]
```