### PR TITLE
Add Temporary Step to fix build on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    # Set Path workaround for https://github.com/actions/virtual-environments/issues/263
+    - run: |
+        echo "::add-path::C:\Program Files\Git\mingw64\bin"
+        echo "::add-path::C:\Program Files\Git\usr\bin"
+        echo "::add-path::C:\Program Files\Git\bin"
+      if: matrix.os == "windows-latest"
+      name: "Temp step to Set Path for Windows"
+
     # Build runner layout
     - name: Build & Layout Release
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         echo "::add-path::C:\Program Files\Git\mingw64\bin"
         echo "::add-path::C:\Program Files\Git\usr\bin"
         echo "::add-path::C:\Program Files\Git\bin"
-      if: matrix.os == "windows-latest"
+      if: matrix.os == 'windows-latest'
       name: "Temp step to Set Path for Windows"
 
     # Build runner layout


### PR DESCRIPTION
Temporary Workaround for https://github.com/actions/virtual-environments/issues/263, we should remove this as soon as we safely can