### PR TITLE
Trace javascript action exit code instead of user logs

### DIFF
--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -193,9 +193,9 @@ namespace GitHub.Runner.Worker.Handlers
             using (var stderrManager = new OutputManager(ExecutionContext, ActionCommandManager, container))
             {
                 var runExitCode = await dockerManger.DockerRun(ExecutionContext, container, stdoutManager.OnDataReceived, stderrManager.OnDataReceived);
+                ExecutionContext.Debug($"Docker Action run completed with exit code {runExitCode}");
                 if (runExitCode != 0)
                 {
-                    ExecutionContext.Error($"Docker run failed with exit code {runExitCode}");
                     ExecutionContext.Result = TaskResult.Failed;
                 }
             }

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -122,7 +122,7 @@ namespace GitHub.Runner.Worker.Handlers
                 else
                 {
                     var exitCode = await step;
-                    Trace.Info($"Node Action run completed with exit code {exitCode}");
+                    ExecutionContext.Debug($"Node Action run completed with exit code {exitCode}");
                     if (exitCode != 0)
                     {
                         ExecutionContext.Result = TaskResult.Failed;

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -122,9 +122,9 @@ namespace GitHub.Runner.Worker.Handlers
                 else
                 {
                     var exitCode = await step;
+                    Trace.Info($"Node Action run completed with exit code {exitCode}");
                     if (exitCode != 0)
                     {
-                        ExecutionContext.Error($"Node run failed with exit code {exitCode}");
                         ExecutionContext.Result = TaskResult.Failed;
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/actions/runner/issues/283

Consuming actions from the graph should not imply knowledge of their runtime be it javascript, container etc

We use the exit code to determine step failure/success so tracing that info out is still useful for diagnostics 