### PR TITLE
Change prompt message when removing a runner

### DIFF
--- a/src/Runner.Listener/CommandSettings.cs
+++ b/src/Runner.Listener/CommandSettings.cs
@@ -190,7 +190,7 @@ namespace GitHub.Runner.Listener
         {
             return GetArgOrPrompt(
                 name: Constants.Runner.CommandLine.Args.Token,
-                description: "Enter runner deletion token:",
+                description: "Enter runner remove token:",
                 defaultValue: string.Empty,
                 validator: Validators.NonEmptyValidator);
         }
@@ -291,7 +291,7 @@ namespace GitHub.Runner.Listener
             if (!string.IsNullOrEmpty(result))
             {
                 // After read the arg from input commandline args, remove it from Arg dictionary,
-                // This will help if bad arg value passed through CommandLine arg, when ConfigurationManager ask CommandSetting the second time, 
+                // This will help if bad arg value passed through CommandLine arg, when ConfigurationManager ask CommandSetting the second time,
                 // It will prompt for input instead of continue use the bad input.
                 _trace.Info($"Remove {name} from Arg dictionary.");
                 RemoveArg(name);

--- a/src/Test/L0/Listener/CommandSettingsL0.cs
+++ b/src/Test/L0/Listener/CommandSettingsL0.cs
@@ -498,7 +498,7 @@ namespace GitHub.Runner.Common.Tests
                 _promptManager
                     .Setup(x => x.ReadValue(
                         Constants.Runner.CommandLine.Args.Token, // argName
-                        "Enter runner deletion token:", // description
+                        "Enter runner remove token:", // description
                         true, // secret
                         string.Empty, // defaultValue
                         Validators.NonEmptyValidator, // validator


### PR DESCRIPTION
Closes https://github.com/github/c2c-actions-experience/issues/2128

To be consistent with the API and the UI we've decided to use `remove token` instead of `deletion token`.