### PR TITLE
Set http_proxy and related env vars for containers

### DIFF
--- a/src/Runner.Sdk/RunnerWebProxy.cs
+++ b/src/Runner.Sdk/RunnerWebProxy.cs
@@ -21,6 +21,7 @@ namespace GitHub.Runner.Sdk
         private string _httpsProxyAddress;
         private string _httpsProxyUsername;
         private string _httpsProxyPassword;
+        private string _noProxyString;
 
         private readonly List<ByPassInfo> _noProxyList = new List<ByPassInfo>();
         private readonly HashSet<string> _noProxyUnique = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -33,6 +34,7 @@ namespace GitHub.Runner.Sdk
         public string HttpsProxyAddress => _httpsProxyAddress;
         public string HttpsProxyUsername => _httpsProxyUsername;
         public string HttpsProxyPassword => _httpsProxyPassword;
+        public string NoProxyString => _noProxyString;
 
         public List<ByPassInfo> NoProxyList => _noProxyList;
 
@@ -121,6 +123,7 @@ namespace GitHub.Runner.Sdk
 
             if (!string.IsNullOrEmpty(noProxyList))
             {
+                _noProxyString = noProxyList;
                 var noProxyListSplit = noProxyList.Split(',', StringSplitOptions.RemoveEmptyEntries);
                 foreach (string noProxy in noProxyListSplit)
                 {

--- a/src/Runner.Worker/Container/ContainerInfo.cs
+++ b/src/Runner.Worker/Container/ContainerInfo.cs
@@ -63,6 +63,22 @@ namespace GitHub.Runner.Worker.Container
                     UserMountVolumes[volume] = volume;
                 }
             }
+
+            if (!String.IsNullOrEmpty(hostContext.WebProxy.HttpProxyAddress))
+            {
+                // TODO: check if duplicate keys are allowed / could be given in yaml by `env`
+                ContainerEnvironmentVariables.Add("HTTP_PROXY", hostContext.WebProxy.HttpProxyAddress);
+            }
+            if (!String.IsNullOrEmpty(hostContext.WebProxy.HttpsProxyAddress))
+            {
+                // TODO: check if duplicate keys are allowed / could be given in yaml by `env`
+                ContainerEnvironmentVariables.Add("HTTPS_PROXY", hostContext.WebProxy.HttpsProxyAddress);
+            }
+            if (!String.IsNullOrEmpty(hostContext.WebProxy.NoProxyString))
+            {
+                // TODO: check if duplicate keys are allowed / could be given in yaml by `env`
+                ContainerEnvironmentVariables.Add("NO_PROXY", hostContext.WebProxy.NoProxyString);
+            }
         }
 
         public string ContainerId { get; set; }

--- a/src/Runner.Worker/Container/ContainerInfo.cs
+++ b/src/Runner.Worker/Container/ContainerInfo.cs
@@ -64,21 +64,7 @@ namespace GitHub.Runner.Worker.Container
                 }
             }
 
-            if (!String.IsNullOrEmpty(hostContext.WebProxy.HttpProxyAddress))
-            {
-                // TODO: check if duplicate keys are allowed / could be given in yaml by `env`
-                ContainerEnvironmentVariables.Add("HTTP_PROXY", hostContext.WebProxy.HttpProxyAddress);
-            }
-            if (!String.IsNullOrEmpty(hostContext.WebProxy.HttpsProxyAddress))
-            {
-                // TODO: check if duplicate keys are allowed / could be given in yaml by `env`
-                ContainerEnvironmentVariables.Add("HTTPS_PROXY", hostContext.WebProxy.HttpsProxyAddress);
-            }
-            if (!String.IsNullOrEmpty(hostContext.WebProxy.NoProxyString))
-            {
-                // TODO: check if duplicate keys are allowed / could be given in yaml by `env`
-                ContainerEnvironmentVariables.Add("NO_PROXY", hostContext.WebProxy.NoProxyString);
-            }
+            UpdateWebProxyEnv(hostContext.WebProxy);
         }
 
         public string ContainerId { get; set; }
@@ -237,6 +223,26 @@ namespace GitHub.Runner.Worker.Container
         public void AddPathTranslateMapping(string hostCommonPath, string containerCommonPath)
         {
             _pathMappings.Insert(0, new PathMapping(hostCommonPath, containerCommonPath));
+        }
+
+        private void UpdateWebProxyEnv(RunnerWebProxy webProxy)
+        {
+            // Set common forms of proxy variables if configured in Runner and not set directly by container.env
+            if (!String.IsNullOrEmpty(webProxy.HttpProxyAddress))
+            {
+                ContainerEnvironmentVariables.TryAdd("HTTP_PROXY", webProxy.HttpProxyAddress);
+                ContainerEnvironmentVariables.TryAdd("http_proxy", webProxy.HttpProxyAddress);
+            }
+            if (!String.IsNullOrEmpty(webProxy.HttpsProxyAddress))
+            {
+                ContainerEnvironmentVariables.TryAdd("HTTPS_PROXY", webProxy.HttpsProxyAddress);
+                ContainerEnvironmentVariables.TryAdd("https_proxy", webProxy.HttpsProxyAddress);
+            }
+            if (!String.IsNullOrEmpty(webProxy.NoProxyString))
+            {
+                ContainerEnvironmentVariables.TryAdd("NO_PROXY", webProxy.NoProxyString);
+                ContainerEnvironmentVariables.TryAdd("no_proxy", webProxy.NoProxyString);
+            }
         }
     }
 


### PR DESCRIPTION
We dont pass the Runner's environment through to containers so http_proxy is not necessarily picked up

Work for the actionable parts of https://github.com/github/c2c-actions-runtime/issues/339 

Added a variable to track the actual value of no_proxy to avoid having to rebuild it from the parts we split it into

Simple canary workflow:

```
jobs:
  proxy-host:
    runs-on: [ self-hosted, linux ]
    steps:
    - run: |
        printenv
        curl -v httpbin.org/uuid
  proxy-container:
    runs-on: [ self-hosted, linux ]
    container:
      image: ubuntu
    services:
      squid:
        image: dakale/squid
    steps:
    - run: |
        apt-get -o Acquire::http::proxy=false update > /dev/null && apt-get -o Acquire::http::proxy=false install -y curl > /dev/null
        printenv
        curl -v httpbin.org/uuid
```

Traffic through squid is shown by cache headers added by the proxy