### PR TITLE
Fix windows directions in release notes

### DIFF
--- a/releaseNote.md
+++ b/releaseNote.md
@@ -24,7 +24,7 @@
   - Treat warnings as errors during compile (#249) 
 
 ## Windows x64
-We recommend configuring the runner under "<DRIVE>:\actions-runner". This will help avoid issues related to service identity folder permissions and long file path restrictions on Windows
+We recommend configuring the runner in a root folder of the Windows drive (e.g. "C:\actions-runner"). This will help avoid issues related to service identity folder permissions and long file path restrictions on Windows
 ``` 
 // Create a folder under the drive root
 mkdir \actions-runner ; cd \actions-runner
@@ -32,7 +32,7 @@ mkdir \actions-runner ; cd \actions-runner
 Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/v<RUNNER_VERSION>/actions-runner-win-x64-<RUNNER_VERSION>.zip -OutFile actions-runner-win-x64-<RUNNER_VERSION>.zip
 // Extract the installer
 Add-Type -AssemblyName System.IO.Compression.FileSystem ; 
-[System.IO.Compression.ZipFile]::ExtractToDirectory("$HOME\Downloads\actions-runner-win-x64-<RUNNER_VERSION>.zip", "$PWD")
+[System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD\actions-runner-win-x64-<RUNNER_VERSION>.zip", "$PWD")
 ```
 
 ## OSX


### PR DESCRIPTION
If you follow the directions explicitly they fail. I'm confident that people can figure this out on their own, but it just makes it nicer when copying and pasting :-)