### PR TITLE
Switch to use token service instead of SPS for exchanging oauth token.

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -19,6 +19,7 @@ namespace GitHub.Runner.Common
     {
         Runner,
         Credentials,
+        CredentialsV2,
         RSACredentials,
         Service,
         CredentialStore,

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -19,7 +19,7 @@ namespace GitHub.Runner.Common
     {
         Runner,
         Credentials,
-        CredentialsV2,
+        MigratedCredentials,
         RSACredentials,
         Service,
         CredentialStore,

--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -282,10 +282,10 @@ namespace GitHub.Runner.Common
                         ".credentials");
                     break;
 
-                case WellKnownConfigFile.CredentialsV2:
+                case WellKnownConfigFile.MigratedCredentials:
                     path = Path.Combine(
                         GetDirectory(WellKnownDirectory.Root),
-                        ".v2credentials");
+                        ".credentials_migrated");
                     break;
 
                 case WellKnownConfigFile.RSACredentials:

--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -282,6 +282,12 @@ namespace GitHub.Runner.Common
                         ".credentials");
                     break;
 
+                case WellKnownConfigFile.CredentialsV2:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Root),
+                        ".v2credentials");
+                    break;
+
                 case WellKnownConfigFile.RSACredentials:
                     path = Path.Combine(
                         GetDirectory(WellKnownDirectory.Root),

--- a/src/Runner.Common/RunnerServer.cs
+++ b/src/Runner.Common/RunnerServer.cs
@@ -53,6 +53,7 @@ namespace GitHub.Runner.Common
 
         // runner authorization url
         Task<string> GetRunnerAuthUrlAsync(int runnerPoolId, int runnerId);
+        Task ReportRunnerAuthUrlErrorAsync(int runnerPoolId, int runnerId, string error);
     }
 
     public sealed class RunnerServer : RunnerService, IRunnerServer
@@ -345,6 +346,12 @@ namespace GitHub.Runner.Common
         {
             CheckConnection(RunnerConnectionType.MessageQueue);
             return _messageTaskAgentClient.GetAgentAuthUrlAsync(runnerPoolId, runnerId);
+        }
+
+        public Task ReportRunnerAuthUrlErrorAsync(int runnerPoolId, int runnerId, string error)
+        {
+            CheckConnection(RunnerConnectionType.MessageQueue);
+            return _messageTaskAgentClient.ReportAgentAuthUrlMigrationErrorAsync(runnerPoolId, runnerId, error);
         }
     }
 }

--- a/src/Runner.Common/RunnerServer.cs
+++ b/src/Runner.Common/RunnerServer.cs
@@ -50,6 +50,9 @@ namespace GitHub.Runner.Common
 
         // agent update
         Task<TaskAgent> UpdateAgentUpdateStateAsync(int agentPoolId, int agentId, string currentState);
+
+        // runner authorization url
+        Task<string> GetRunnerAuthUrlAsync(int runnerPoolId, int runnerId);
     }
 
     public sealed class RunnerServer : RunnerService, IRunnerServer
@@ -333,6 +336,15 @@ namespace GitHub.Runner.Common
         {
             CheckConnection(RunnerConnectionType.Generic);
             return _genericTaskAgentClient.UpdateAgentUpdateStateAsync(agentPoolId, agentId, currentState);
+        }
+
+        //-----------------------------------------------------------------
+        // Runner Auth Url
+        //-----------------------------------------------------------------
+        public Task<string> GetRunnerAuthUrlAsync(int runnerPoolId, int runnerId)
+        {
+            CheckConnection(RunnerConnectionType.MessageQueue);
+            return _messageTaskAgentClient.GetAgentAuthUrlAsync(runnerPoolId, runnerId);
         }
     }
 }

--- a/src/Runner.Listener/Configuration/CredentialManager.cs
+++ b/src/Runner.Listener/Configuration/CredentialManager.cs
@@ -13,7 +13,7 @@ namespace GitHub.Runner.Listener.Configuration
     public interface ICredentialManager : IRunnerService
     {
         ICredentialProvider GetCredentialProvider(string credType);
-        VssCredentials LoadCredentials();
+        VssCredentials LoadCredentials(bool preferV2 = true);
     }
 
     public class CredentialManager : RunnerService, ICredentialManager
@@ -40,7 +40,7 @@ namespace GitHub.Runner.Listener.Configuration
             return creds;
         }
 
-        public VssCredentials LoadCredentials()
+        public VssCredentials LoadCredentials(bool preferV2 = true)
         {
             IConfigurationStore store = HostContext.GetService<IConfigurationStore>();
 
@@ -50,6 +50,16 @@ namespace GitHub.Runner.Listener.Configuration
             }
 
             CredentialData credData = store.GetCredentials();
+
+            if (preferV2)
+            {
+                var v2Cred = store.GetV2Credentials();
+                if (v2Cred != null)
+                {
+                    credData = v2Cred;
+                }
+            }
+
             ICredentialProvider credProv = GetCredentialProvider(credData.Scheme);
             credProv.CredentialData = credData;
 

--- a/src/Runner.Listener/Configuration/CredentialManager.cs
+++ b/src/Runner.Listener/Configuration/CredentialManager.cs
@@ -13,7 +13,7 @@ namespace GitHub.Runner.Listener.Configuration
     public interface ICredentialManager : IRunnerService
     {
         ICredentialProvider GetCredentialProvider(string credType);
-        VssCredentials LoadCredentials(bool preferV2 = true);
+        VssCredentials LoadCredentials(bool preferMigrated = true);
     }
 
     public class CredentialManager : RunnerService, ICredentialManager
@@ -40,7 +40,7 @@ namespace GitHub.Runner.Listener.Configuration
             return creds;
         }
 
-        public VssCredentials LoadCredentials(bool preferV2 = true)
+        public VssCredentials LoadCredentials(bool preferMigrated = true)
         {
             IConfigurationStore store = HostContext.GetService<IConfigurationStore>();
 
@@ -51,12 +51,12 @@ namespace GitHub.Runner.Listener.Configuration
 
             CredentialData credData = store.GetCredentials();
 
-            if (preferV2)
+            if (preferMigrated)
             {
-                var v2Cred = store.GetV2Credentials();
-                if (v2Cred != null)
+                var migratedCred = store.GetMigratedCredentials();
+                if (migratedCred != null)
                 {
-                    credData = v2Cred;
+                    credData = migratedCred;
                 }
             }
 

--- a/src/Runner.Listener/Configuration/OAuthCredential.cs
+++ b/src/Runner.Listener/Configuration/OAuthCredential.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using GitHub.Runner.Common;
-using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using GitHub.Services.Common;
 using GitHub.Services.OAuth;
@@ -29,7 +28,7 @@ namespace GitHub.Runner.Listener.Configuration
             var authorizationUrl = this.CredentialData.Data.GetValueOrDefault("authorizationUrl", null);
 
             // For back compat with .credential file that doesn't has 'oauthEndpointUrl' section
-            var oathEndpointUrl = this.CredentialData.Data.GetValueOrDefault("oauthEndpointUrl", authorizationUrl);
+            var oauthEndpointUrl = this.CredentialData.Data.GetValueOrDefault("oauthEndpointUrl", authorizationUrl);
 
             ArgUtil.NotNullOrEmpty(clientId, nameof(clientId));
             ArgUtil.NotNullOrEmpty(authorizationUrl, nameof(authorizationUrl));
@@ -39,7 +38,7 @@ namespace GitHub.Runner.Listener.Configuration
             var keyManager = context.GetService<IRSAKeyManager>();
             var signingCredentials = VssSigningCredentials.Create(() => keyManager.GetKey());
             var clientCredential = new VssOAuthJwtBearerClientCredential(clientId, authorizationUrl, signingCredentials);
-            var agentCredential = new VssOAuthCredential(new Uri(oathEndpointUrl, UriKind.Absolute), VssOAuthGrant.ClientCredentials, clientCredential);
+            var agentCredential = new VssOAuthCredential(new Uri(oauthEndpointUrl, UriKind.Absolute), VssOAuthGrant.ClientCredentials, clientCredential);
 
             // Construct a credentials cache with a single OAuth credential for communication. The windows credential
             // is explicitly set to null to ensure we never do that negotiation.

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -562,6 +562,17 @@ namespace GitHub.Runner.Listener
                 {
                     Trace.Error("Fail to get/test new authorization url.");
                     Trace.Error(ex);
+
+                    try
+                    {
+                        await _runnerServer.ReportRunnerAuthUrlErrorAsync(_settings.PoolId, _settings.AgentId, ex.ToString());
+                    }
+                    catch (Exception e)
+                    {
+                        // best effort
+                        Trace.Error("Fail to report the migration error");
+                        Trace.Error(e);
+                    }
                 }
             }
         }

--- a/src/Sdk/DTGenerated/Generated/TaskAgentHttpClientBase.cs
+++ b/src/Sdk/DTGenerated/Generated/TaskAgentHttpClientBase.cs
@@ -805,5 +805,39 @@ namespace GitHub.DistributedTask.WebApi
                 userState: userState,
                 cancellationToken: cancellationToken);
         }
+
+        /// <summary>
+        /// [Preview API]
+        /// </summary>
+        /// <param name="poolId"></param>
+        /// <param name="agentId"></param>
+        /// <param name="error"></param>
+        /// <param name="userState"></param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual async Task ReportAgentAuthUrlMigrationErrorAsync(
+            int poolId,
+            int agentId,
+            string error,
+            object userState = null,
+            CancellationToken cancellationToken = default)
+        {
+            HttpMethod httpMethod = new HttpMethod("POST");
+            Guid locationId = new Guid("a82a119c-1e46-44b6-8d75-c82a79cf975b");
+            object routeValues = new { poolId = poolId, agentId = agentId };
+            HttpContent content = new ObjectContent<string>(error, new VssJsonMediaTypeFormatter(true));
+
+            using (HttpResponseMessage response = await SendAsync(
+                httpMethod,
+                locationId,
+                routeValues: routeValues,
+                version: new ApiResourceVersion(6.0, 1),
+                userState: userState,
+                cancellationToken: cancellationToken,
+                content: content).ConfigureAwait(false))
+            {
+                return;
+            }
+        }
     }
 }

--- a/src/Sdk/DTGenerated/Generated/TaskAgentHttpClientBase.cs
+++ b/src/Sdk/DTGenerated/Generated/TaskAgentHttpClientBase.cs
@@ -779,5 +779,31 @@ namespace GitHub.DistributedTask.WebApi
                 userState: userState,
                 cancellationToken: cancellationToken);
         }
+
+        /// <summary>
+        /// [Preview API]
+        /// </summary>
+        /// <param name="poolId"></param>
+        /// <param name="agentId"></param>
+        /// <param name="userState"></param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        public Task<String> GetAgentAuthUrlAsync(
+            int poolId,
+            int agentId,
+            object userState = null,
+            CancellationToken cancellationToken = default)
+        {
+            HttpMethod httpMethod = new HttpMethod("GET");
+            Guid locationId = new Guid("a82a119c-1e46-44b6-8d75-c82a79cf975b");
+            object routeValues = new { poolId = poolId, agentId = agentId };
+
+            return SendAsync<String>(
+                httpMethod,
+                locationId,
+                routeValues: routeValues,
+                version: new ApiResourceVersion(6.0, 1),
+                userState: userState,
+                cancellationToken: cancellationToken);
+        }
     }
 }

--- a/src/Sdk/DTWebApi/WebApi/TaskResourceIds.cs
+++ b/src/Sdk/DTWebApi/WebApi/TaskResourceIds.cs
@@ -260,5 +260,8 @@ namespace GitHub.DistributedTask.WebApi
         public static readonly Guid CheckpointResourcesLocationId = new Guid(CheckpointResourcesLocationIdString);
         public const String CheckpointResourcesResource = "references";
 
+        public static readonly Guid RunnerAuthUrl = new Guid("{A82A119C-1E46-44B6-8D75-C82A79CF975B}");
+        public const string RunnerAuthUrlResource = "authurl";
+
     }
 }

--- a/src/Test/L0/Listener/MessageListenerL0.cs
+++ b/src/Test/L0/Listener/MessageListenerL0.cs
@@ -11,6 +11,8 @@ using Xunit;
 using System.Threading;
 using System.Reflection;
 using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
 
 namespace GitHub.Runner.Common.Tests.Listener
 {
@@ -20,6 +22,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         private Mock<IConfigurationManager> _config;
         private Mock<IRunnerServer> _runnerServer;
         private Mock<ICredentialManager> _credMgr;
+        private Mock<IConfigurationStore> _store;
 
         public MessageListenerL0()
         {
@@ -28,6 +31,7 @@ namespace GitHub.Runner.Common.Tests.Listener
             _config.Setup(x => x.LoadSettings()).Returns(_settings);
             _runnerServer = new Mock<IRunnerServer>();
             _credMgr = new Mock<ICredentialManager>();
+            _store = new Mock<IConfigurationStore>();
         }
 
         private TestHostContext CreateTestContext([CallerMemberName] String testName = "")
@@ -36,6 +40,7 @@ namespace GitHub.Runner.Common.Tests.Listener
             tc.SetSingleton<IConfigurationManager>(_config.Object);
             tc.SetSingleton<IRunnerServer>(_runnerServer.Object);
             tc.SetSingleton<ICredentialManager>(_credMgr.Object);
+            tc.SetSingleton<IConfigurationStore>(_store.Object);
             return tc;
         }
 
@@ -58,7 +63,9 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token))
                     .Returns(Task.FromResult(expectedSession));
 
-                _credMgr.Setup(x => x.LoadCredentials()).Returns(new VssCredentials());
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+                _store.Setup(x => x.GetCredentials()).Returns(new CredentialData() { Scheme = Constants.Configuration.OAuthAccessToken });
+                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -100,7 +107,9 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token))
                     .Returns(Task.FromResult(expectedSession));
 
-                _credMgr.Setup(x => x.LoadCredentials()).Returns(new VssCredentials());
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+                _store.Setup(x => x.GetCredentials()).Returns(new CredentialData() { Scheme = Constants.Configuration.OAuthAccessToken });
+                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -145,7 +154,9 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token))
                     .Returns(Task.FromResult(expectedSession));
 
-                _credMgr.Setup(x => x.LoadCredentials()).Returns(new VssCredentials());
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+                _store.Setup(x => x.GetCredentials()).Returns(new CredentialData() { Scheme = Constants.Configuration.OAuthAccessToken });
+                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -198,6 +209,1315 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _runnerServer
                     .Verify(x => x.GetAgentMessageAsync(
                         _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token), Times.Exactly(arMessages.Length));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithV1Credential()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var expectedSession = new TaskAgentSession();
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                _runnerServer
+                    .Setup(x => x.GetRunnerAuthUrlAsync(
+                        _settings.PoolId,
+                        _settings.AgentId))
+                    .Returns(async () =>
+                    {
+                        await Task.Delay(10);
+                        return "";
+                    });
+
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+
+                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v1Cred.Data["authorizationUrl"] = "https://s.server";
+                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
+                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+
+                // Act.
+                MessageListener listener = new MessageListener();
+                listener.Initialize(tc);
+
+                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert.
+                Assert.True(result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Once());
+
+                Assert.False(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.True(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithV2Credential()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var expectedSession = new TaskAgentSession();
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+
+                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v1Cred.Data["authorizationUrl"] = "https://s.server";
+                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v2Cred.Data["authorizationUrl"] = "https://t.server";
+                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
+                _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+
+                // Act.
+                MessageListener listener = new MessageListener();
+                listener.Initialize(tc);
+
+                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert.
+                Assert.True(result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Once());
+
+                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithHostedCredential()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var expectedSession = new TaskAgentSession();
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+
+                _store.Setup(x => x.GetCredentials()).Returns(new CredentialData() { Scheme = Constants.Configuration.OAuthAccessToken });
+                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+
+                // Act.
+                MessageListener listener = new MessageListener();
+                listener.Initialize(tc);
+
+                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert.
+                Assert.True(result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Once());
+
+                Assert.False(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithV2CredentialFallBackV1Succeed()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var expectedSession = new TaskAgentSession();
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        123,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Callback(() => { _settings.PoolId = 1234; })
+                    .Throws(new TaskAgentPoolNotFoundException("L0 Pool not found"));
+
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        1234,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                var v1VssCred = new VssCredentials();
+                var v2VssCred = new VssCredentials();
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(v2VssCred);
+                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(v1VssCred);
+
+                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v1Cred.Data["authorizationUrl"] = "https://s.server";
+                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v2Cred.Data["authorizationUrl"] = "https://t.server";
+                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
+                _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+
+                // Act.
+                MessageListener listener = new MessageListener();
+                listener.Initialize(tc);
+
+                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert.
+                Assert.True(result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        It.IsAny<int>(),
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Exactly(2));
+                _runnerServer
+                    .Verify(x => x.ConnectAsync(
+                        It.IsAny<Uri>(),
+                        v1VssCred), Times.Once);
+                _runnerServer
+                    .Verify(x => x.ConnectAsync(
+                        It.IsAny<Uri>(),
+                        v2VssCred), Times.Once);
+
+                Assert.False(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.NotNull(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithV2CredentialFallBackV1StillFailed()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var expectedSession = new TaskAgentSession();
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Throws(new TaskAgentPoolNotFoundException("L0 Pool not found"));
+
+                var v1VssCred = new VssCredentials();
+                var v2VssCred = new VssCredentials();
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(v2VssCred);
+                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(v1VssCred);
+
+                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v1Cred.Data["authorizationUrl"] = "https://s.server";
+                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v2Cred.Data["authorizationUrl"] = "https://t.server";
+                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
+                _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+
+                // Act.
+                MessageListener listener = new MessageListener();
+                listener.Initialize(tc);
+
+                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert.
+                Assert.False(result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Exactly(2));
+                _runnerServer
+                    .Verify(x => x.ConnectAsync(
+                        It.IsAny<Uri>(),
+                        v1VssCred), Times.Once);
+                _runnerServer
+                    .Verify(x => x.ConnectAsync(
+                        It.IsAny<Uri>(),
+                        v2VssCred), Times.Once);
+
+                Assert.False(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.NotNull(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithV1GetMessageWaitForMigtateToV2()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var expectedSession = new TaskAgentSession();
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                _runnerServer
+                    .Setup(x => x.GetRunnerAuthUrlAsync(
+                        _settings.PoolId,
+                        _settings.AgentId))
+                    .Returns(async () =>
+                    {
+                        await Task.Delay(10);
+                        return "";
+                    });
+
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+
+                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v1Cred.Data["authorizationUrl"] = "https://s.server";
+                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
+                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+
+                // Act.
+                MessageListener listener = new MessageListener();
+                listener.Initialize(tc);
+
+                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert.
+                Assert.True(result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Once());
+
+                Assert.False(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.True(listener._needToCheckAuthorizationUrlUpdate);
+
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
+
+                var arMessages = new TaskAgentMessage[]
+                                {
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody1",
+                            MessageId = 4234,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        },
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody2",
+                            MessageId = 4235,
+                            MessageType = JobCancelMessage.MessageType
+                        },
+                        null,  //should be skipped by GetNextMessageAsync implementation
+                        null,
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody3",
+                            MessageId = 4236,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        }
+                                };
+                var messages = new Queue<TaskAgentMessage>(arMessages);
+
+                _runnerServer
+                    .Setup(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token))
+                    .Returns(async (Int32 poolId, Guid sessionId, Int64? lastMessageId, CancellationToken cancellationToken) =>
+                    {
+                        await Task.Delay(200);
+                        return messages.Dequeue();
+                    });
+
+                TaskAgentMessage message1 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message2 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message3 = await listener.GetNextMessageAsync(tokenSource.Token);
+                Assert.Equal(arMessages[0], message1);
+                Assert.Equal(arMessages[1], message2);
+                Assert.Equal(arMessages[4], message3);
+
+                //Assert
+                _runnerServer
+                    .Verify(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token), Times.Exactly(arMessages.Length));
+
+                _runnerServer
+                    .Verify(x => x.GetRunnerAuthUrlAsync(_settings.PoolId, _settings.AgentId), Times.AtLeast(2));
+
+                _runnerServer
+                    .Verify(x => x.ConnectAsync(
+                        It.IsAny<Uri>(),
+                        It.IsAny<VssCredentials>()), Times.Once);
+
+                var tempLog = Path.GetTempFileName();
+                File.Copy(tc.TraceFileName, tempLog, true);
+                var traceContent = File.ReadAllLines(tempLog);
+                Assert.DoesNotContain(traceContent, x => x.Contains("Try connect service with v2 OAuth endpoint."));
+
+                Assert.False(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.True(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithV1GetMessageMigtateToV2()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var expectedSession = new TaskAgentSession();
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                _runnerServer
+                    .Setup(x => x.GetRunnerAuthUrlAsync(
+                        _settings.PoolId,
+                        _settings.AgentId))
+                    .Returns(async () =>
+                    {
+                        await Task.Delay(10);
+                        return "https://t.server";
+                    });
+
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+
+                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v1Cred.Data["authorizationUrl"] = "https://s.server";
+                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
+                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+
+                // Act.
+                MessageListener listener = new MessageListener();
+                listener.Initialize(tc);
+
+                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert.
+                Assert.True(result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Once());
+
+                Assert.False(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.True(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
+
+                var arMessages = new TaskAgentMessage[]
+                                {
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody1",
+                            MessageId = 4234,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        },
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody2",
+                            MessageId = 4235,
+                            MessageType = JobCancelMessage.MessageType
+                        },
+                        null,  //should be skipped by GetNextMessageAsync implementation
+                        null,
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody3",
+                            MessageId = 4236,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        }
+                                };
+                var messages = new Queue<TaskAgentMessage>(arMessages);
+
+                _runnerServer
+                    .Setup(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token))
+                    .Returns(async (Int32 poolId, Guid sessionId, Int64? lastMessageId, CancellationToken cancellationToken) =>
+                    {
+                        await Task.Delay(200);
+                        return messages.Dequeue();
+                    });
+
+                var newRunnerServer = new Mock<IRunnerServer>();
+                tc.EnqueueInstance<IRunnerServer>(newRunnerServer.Object);
+
+                var keyManager = new Mock<IRSAKeyManager>();
+                keyManager.Setup(x => x.GetKey()).Returns(new RSACryptoServiceProvider(2048));
+                tc.SetSingleton(keyManager.Object);
+
+                tc.SetSingleton<IJobDispatcher>(new Mock<IJobDispatcher>().Object);
+                tc.SetSingleton<ISelfUpdater>(new Mock<ISelfUpdater>().Object);
+
+                TaskAgentMessage message1 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message2 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message3 = await listener.GetNextMessageAsync(tokenSource.Token);
+                Assert.Equal(arMessages[0], message1);
+                Assert.Equal(arMessages[1], message2);
+                Assert.Equal(arMessages[4], message3);
+
+                //Assert
+                _runnerServer
+                    .Verify(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token), Times.Exactly(arMessages.Length));
+
+                _runnerServer
+                    .Verify(x => x.GetRunnerAuthUrlAsync(_settings.PoolId, _settings.AgentId), Times.Once);
+
+                _runnerServer
+                    .Verify(x => x.ConnectAsync(
+                        It.IsAny<Uri>(),
+                        It.IsAny<VssCredentials>()), Times.Exactly(2));
+
+                newRunnerServer
+                    .Verify(x => x.ConnectAsync(
+                            It.IsAny<Uri>(),
+                            It.IsAny<VssCredentials>()), Times.Once);
+
+                newRunnerServer
+                    .Verify(x => x.GetAgentPoolsAsync(null, TaskAgentPoolType.Automation), Times.Once);
+
+                var tempLog = Path.GetTempFileName();
+                File.Copy(tc.TraceFileName, tempLog, true);
+                var traceContent = File.ReadAllLines(tempLog);
+                Assert.Contains(traceContent, x => x.Contains("Try connect service with v2 OAuth endpoint."));
+
+                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithV1GetMessageMigtateToV2WaitForIdle()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var expectedSession = new TaskAgentSession();
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                _runnerServer
+                    .Setup(x => x.GetRunnerAuthUrlAsync(
+                        _settings.PoolId,
+                        _settings.AgentId))
+                    .Returns(async () =>
+                    {
+                        await Task.Delay(10);
+                        return "https://t.server";
+                    });
+
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+
+                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v1Cred.Data["authorizationUrl"] = "https://s.server";
+                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
+                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+
+                // Act.
+                MessageListener listener = new MessageListener();
+                listener.Initialize(tc);
+
+                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert.
+                Assert.True(result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Once());
+
+                Assert.False(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.True(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
+
+                var arMessages = new TaskAgentMessage[]
+                                {
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody1",
+                            MessageId = 4234,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        },
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody2",
+                            MessageId = 4235,
+                            MessageType = JobCancelMessage.MessageType
+                        },
+                        null,  //should be skipped by GetNextMessageAsync implementation
+                        null,
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody3",
+                            MessageId = 4236,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        }
+                                };
+                var messages = new Queue<TaskAgentMessage>(arMessages);
+
+                var busy = true;
+                var counter = 0;
+                _runnerServer
+                    .Setup(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token))
+                    .Returns(async (Int32 poolId, Guid sessionId, Int64? lastMessageId, CancellationToken cancellationToken) =>
+                    {
+                        await Task.Delay(200);
+                        if (++counter == 4)
+                        {
+                            busy = false;
+                        }
+                        return messages.Dequeue();
+                    });
+
+                var newRunnerServer = new Mock<IRunnerServer>();
+                tc.EnqueueInstance<IRunnerServer>(newRunnerServer.Object);
+
+                var keyManager = new Mock<IRSAKeyManager>();
+                keyManager.Setup(x => x.GetKey()).Returns(new RSACryptoServiceProvider(2048));
+                tc.SetSingleton(keyManager.Object);
+
+                var jobDispatcher = new Mock<IJobDispatcher>();
+
+                jobDispatcher.Setup(x => x.Busy).Returns(() =>
+                {
+                    return busy;
+                });
+                tc.SetSingleton<IJobDispatcher>(jobDispatcher.Object);
+                tc.SetSingleton<ISelfUpdater>(new Mock<ISelfUpdater>().Object);
+
+                TaskAgentMessage message1 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message2 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message3 = await listener.GetNextMessageAsync(tokenSource.Token);
+                Assert.Equal(arMessages[0], message1);
+                Assert.Equal(arMessages[1], message2);
+                Assert.Equal(arMessages[4], message3);
+
+                //Assert
+                _runnerServer
+                    .Verify(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token), Times.Exactly(arMessages.Length));
+
+                _runnerServer
+                    .Verify(x => x.GetRunnerAuthUrlAsync(_settings.PoolId, _settings.AgentId), Times.Once);
+
+                _runnerServer
+                    .Verify(x => x.ConnectAsync(
+                        It.IsAny<Uri>(),
+                        It.IsAny<VssCredentials>()), Times.Exactly(2));
+
+                newRunnerServer
+                    .Verify(x => x.ConnectAsync(
+                            It.IsAny<Uri>(),
+                            It.IsAny<VssCredentials>()), Times.Once);
+
+                newRunnerServer
+                    .Verify(x => x.GetAgentPoolsAsync(null, TaskAgentPoolType.Automation), Times.Once);
+
+                var tempLog = Path.GetTempFileName();
+                File.Copy(tc.TraceFileName, tempLog, true);
+                var traceContent = File.ReadAllLines(tempLog);
+                Assert.Contains(traceContent, x => x.Contains("Job or runner updates in progress, update credentials next time."));
+                Assert.Contains(traceContent, x => x.Contains("Try connect service with v2 OAuth endpoint."));
+
+                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithV2GetMessageNotMigrateAgain()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var expectedSession = new TaskAgentSession();
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                _runnerServer
+                    .Setup(x => x.GetRunnerAuthUrlAsync(
+                        _settings.PoolId,
+                        _settings.AgentId))
+                    .Returns(async () =>
+                    {
+                        await Task.Delay(10);
+                        return "https://t.server";
+                    });
+
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+
+                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v2Cred.Data["authorizationUrl"] = "https://t.server";
+                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                _store.Setup(x => x.GetCredentials()).Returns(v2Cred);
+                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+
+                // Act.
+                MessageListener listener = new MessageListener();
+                listener.Initialize(tc);
+
+                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert.
+                Assert.True(result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Once());
+
+                Assert.False(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.True(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
+
+                var arMessages = new TaskAgentMessage[]
+                                {
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody1",
+                            MessageId = 4234,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        },
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody2",
+                            MessageId = 4235,
+                            MessageType = JobCancelMessage.MessageType
+                        },
+                        null,  //should be skipped by GetNextMessageAsync implementation
+                        null,
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody3",
+                            MessageId = 4236,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        }
+                                };
+                var messages = new Queue<TaskAgentMessage>(arMessages);
+
+                _runnerServer
+                    .Setup(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token))
+                    .Returns(async (Int32 poolId, Guid sessionId, Int64? lastMessageId, CancellationToken cancellationToken) =>
+                    {
+                        await Task.Delay(200);
+                        return messages.Dequeue();
+                    });
+
+                var newRunnerServer = new Mock<IRunnerServer>();
+                tc.EnqueueInstance<IRunnerServer>(newRunnerServer.Object);
+
+                var keyManager = new Mock<IRSAKeyManager>();
+                keyManager.Setup(x => x.GetKey()).Returns(new RSACryptoServiceProvider(2048));
+                tc.SetSingleton(keyManager.Object);
+
+                tc.SetSingleton<IJobDispatcher>(new Mock<IJobDispatcher>().Object);
+                tc.SetSingleton<ISelfUpdater>(new Mock<ISelfUpdater>().Object);
+
+                TaskAgentMessage message1 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message2 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message3 = await listener.GetNextMessageAsync(tokenSource.Token);
+                Assert.Equal(arMessages[0], message1);
+                Assert.Equal(arMessages[1], message2);
+                Assert.Equal(arMessages[4], message3);
+
+                //Assert
+                _runnerServer
+                    .Verify(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token), Times.Exactly(arMessages.Length));
+
+                _runnerServer
+                    .Verify(x => x.GetRunnerAuthUrlAsync(_settings.PoolId, _settings.AgentId), Times.Once);
+
+                _runnerServer
+                    .Verify(x => x.ConnectAsync(
+                        It.IsAny<Uri>(),
+                        It.IsAny<VssCredentials>()), Times.Once);
+
+                newRunnerServer
+                    .Verify(x => x.ConnectAsync(
+                            It.IsAny<Uri>(),
+                            It.IsAny<VssCredentials>()), Times.Never);
+
+                newRunnerServer
+                    .Verify(x => x.GetAgentPoolsAsync(null, TaskAgentPoolType.Automation), Times.Never);
+
+                var tempLog = Path.GetTempFileName();
+                File.Copy(tc.TraceFileName, tempLog, true);
+                var traceContent = File.ReadAllLines(tempLog);
+                Assert.Contains(traceContent, x => x.Contains("No needs to update authorization url"));
+
+                Assert.False(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.True(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithV1GetMessageMigrateToV2FallbackToV1()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var expectedSession = new TaskAgentSession();
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                var v1VssCred = new VssCredentials();
+                var v2VssCred = new VssCredentials();
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(v2VssCred);
+                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(v1VssCred);
+
+                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v1Cred.Data["authorizationUrl"] = "https://s.server";
+                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v2Cred.Data["authorizationUrl"] = "https://t.server";
+                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
+                _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+
+                // Act.
+                MessageListener listener = new MessageListener();
+                listener.Initialize(tc);
+
+                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert.
+                Assert.True(result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Once());
+
+                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+
+                var arMessages = new TaskAgentMessage[]
+                                {
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody1",
+                            MessageId = 4234,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        },
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody2",
+                            MessageId = 4235,
+                            MessageType = JobCancelMessage.MessageType
+                        },
+                        null,  //should be skipped by GetNextMessageAsync implementation
+                        null,
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody3",
+                            MessageId = 4236,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        }
+                                };
+                var messages = new Queue<TaskAgentMessage>(arMessages);
+
+                var counter = 0;
+                _runnerServer
+                    .Setup(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token))
+                    .Returns(async (Int32 poolId, Guid sessionId, Int64? lastMessageId, CancellationToken cancellationToken) =>
+                    {
+                        await Task.Delay(200);
+                        counter++;
+
+                        if (counter == 5)
+                        {
+                            throw new TaskAgentNotFoundException("L0 runner not found");
+                        }
+
+                        if (counter == 6)
+                        {
+                            Assert.NotNull(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                            Assert.False(listener._useV2Credentials);
+                        }
+
+                        return messages.Dequeue();
+                    });
+
+                var newRunnerServer = new Mock<IRunnerServer>();
+                tc.EnqueueInstance<IRunnerServer>(newRunnerServer.Object);
+
+                var keyManager = new Mock<IRSAKeyManager>();
+                keyManager.Setup(x => x.GetKey()).Returns(new RSACryptoServiceProvider(2048));
+                tc.SetSingleton(keyManager.Object);
+
+                tc.SetSingleton<IJobDispatcher>(new Mock<IJobDispatcher>().Object);
+                tc.SetSingleton<ISelfUpdater>(new Mock<ISelfUpdater>().Object);
+
+                TaskAgentMessage message1 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message2 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message3 = await listener.GetNextMessageAsync(tokenSource.Token);
+                Assert.Equal(arMessages[0], message1);
+                Assert.Equal(arMessages[1], message2);
+                Assert.Equal(arMessages[4], message3);
+
+                //Assert
+                _runnerServer
+                    .Verify(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token), Times.Exactly(arMessages.Length + 1));
+
+                _runnerServer
+                    .Verify(x => x.GetRunnerAuthUrlAsync(_settings.PoolId, _settings.AgentId), Times.Never);
+
+                _runnerServer
+                    .Verify(x => x.ConnectAsync(
+                        It.IsAny<Uri>(),
+                        It.IsAny<VssCredentials>()), Times.AtLeast(2));
+
+                newRunnerServer
+                    .Verify(x => x.ConnectAsync(
+                            It.IsAny<Uri>(),
+                            It.IsAny<VssCredentials>()), Times.Never);
+
+                newRunnerServer
+                    .Verify(x => x.GetAgentPoolsAsync(null, TaskAgentPoolType.Automation), Times.Never);
+
+                var tempLog = Path.GetTempFileName();
+                File.Copy(tc.TraceFileName, tempLog, true);
+                var traceContent = File.ReadAllLines(tempLog);
+                Assert.Contains(traceContent, x => x.Contains("Fallback to v1 credentials and try again."));
+
+                Assert.True(listener._v1CredentialsExists);
+                Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithV1GetMessageMigrateToV2FallbackToV1ReattemptV2()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var expectedSession = new TaskAgentSession();
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                var v1VssCred = new VssCredentials();
+                var v2VssCred = new VssCredentials();
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(v2VssCred);
+                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(v1VssCred);
+
+                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v1Cred.Data["authorizationUrl"] = "https://s.server";
+                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                v2Cred.Data["authorizationUrl"] = "https://t.server";
+                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
+                _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+
+                // Act.
+                MessageListener listener = new MessageListener();
+                listener.Initialize(tc);
+
+                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert.
+                Assert.True(result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Once());
+
+                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+
+                var arMessages = new TaskAgentMessage[]
+                                {
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody1",
+                            MessageId = 4234,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        },
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody2",
+                            MessageId = 4235,
+                            MessageType = JobCancelMessage.MessageType
+                        },
+                        null,  //should be skipped by GetNextMessageAsync implementation
+                        null,
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody3",
+                            MessageId = 4236,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        }
+                                };
+                var messages = new Queue<TaskAgentMessage>(arMessages);
+
+                var counter = 0;
+                _runnerServer
+                    .Setup(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token))
+                    .Returns(async (Int32 poolId, Guid sessionId, Int64? lastMessageId, CancellationToken cancellationToken) =>
+                    {
+                        await Task.Delay(200);
+                        counter++;
+
+                        if (counter == 2)
+                        {
+                            throw new TaskAgentNotFoundException("L0 runner not found");
+                        }
+
+                        if (counter == 3)
+                        {
+                            Assert.NotNull(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                        }
+
+                        return messages.Dequeue();
+                    });
+
+                var newRunnerServer = new Mock<IRunnerServer>();
+                tc.EnqueueInstance<IRunnerServer>(newRunnerServer.Object);
+
+                var keyManager = new Mock<IRSAKeyManager>();
+                keyManager.Setup(x => x.GetKey()).Returns(new RSACryptoServiceProvider(2048));
+                tc.SetSingleton(keyManager.Object);
+
+                tc.SetSingleton<IJobDispatcher>(new Mock<IJobDispatcher>().Object);
+                tc.SetSingleton<ISelfUpdater>(new Mock<ISelfUpdater>().Object);
+
+                TaskAgentMessage message1 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message2 = await listener.GetNextMessageAsync(tokenSource.Token);
+                TaskAgentMessage message3 = await listener.GetNextMessageAsync(tokenSource.Token);
+                Assert.Equal(arMessages[0], message1);
+                Assert.Equal(arMessages[1], message2);
+                Assert.Equal(arMessages[4], message3);
+
+                //Assert
+                _runnerServer
+                    .Verify(x => x.GetAgentMessageAsync(
+                        _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token), Times.Exactly(arMessages.Length + 1));
+
+                _runnerServer
+                    .Verify(x => x.GetRunnerAuthUrlAsync(_settings.PoolId, _settings.AgentId), Times.Never);
+
+                _runnerServer
+                    .Verify(x => x.ConnectAsync(
+                        It.IsAny<Uri>(),
+                        It.IsAny<VssCredentials>()), Times.Exactly(3));
+
+                newRunnerServer
+                    .Verify(x => x.ConnectAsync(
+                            It.IsAny<Uri>(),
+                            It.IsAny<VssCredentials>()), Times.Never);
+
+                newRunnerServer
+                    .Verify(x => x.GetAgentPoolsAsync(null, TaskAgentPoolType.Automation), Times.Never);
+
+                var tempLog = Path.GetTempFileName();
+                File.Copy(tc.TraceFileName, tempLog, true);
+                var traceContent = File.ReadAllLines(tempLog);
+                Assert.Contains(traceContent, x => x.Contains("Fallback to v1 credentials and try again."));
+                Assert.Contains(traceContent, x => x.Contains("Re-attempt to use v2 credential"));
+
+                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._v1CredentialsExists);
+                Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void CreateSessionWithV1GetMessageWithV1EnvOverwrite()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_LEGACYAUTHURL", "1");
+                using (TestHostContext tc = CreateTestContext())
+                using (var tokenSource = new CancellationTokenSource())
+                {
+                    Tracing trace = tc.GetTrace();
+
+                    // Arrange.
+                    var expectedSession = new TaskAgentSession();
+                    _runnerServer
+                        .Setup(x => x.CreateAgentSessionAsync(
+                            _settings.PoolId,
+                            It.Is<TaskAgentSession>(y => y != null),
+                            tokenSource.Token))
+                        .Returns(Task.FromResult(expectedSession));
+
+                    var v1VssCred = new VssCredentials();
+                    var v2VssCred = new VssCredentials();
+                    _credMgr.Setup(x => x.LoadCredentials(false)).Returns(v1VssCred);
+                    _credMgr.Setup(x => x.LoadCredentials(true)).Returns(v2VssCred);
+
+                    var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                    v1Cred.Data["authorizationUrl"] = "https://s.server";
+                    v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                    var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                    v2Cred.Data["authorizationUrl"] = "https://t.server";
+                    v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+
+                    _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
+                    _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+
+                    // Act.
+                    MessageListener listener = new MessageListener();
+                    listener.Initialize(tc);
+
+                    bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                    trace.Info("result: {0}", result);
+
+                    // Assert.
+                    Assert.True(result);
+                    _runnerServer
+                        .Verify(x => x.CreateAgentSessionAsync(
+                            _settings.PoolId,
+                            It.Is<TaskAgentSession>(y => y != null),
+                            tokenSource.Token), Times.Once());
+
+                    Assert.False(listener._useV2Credentials);
+                    Assert.True(listener._v1CredentialsExists);
+                    Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                    Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                    Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+
+                    var arMessages = new TaskAgentMessage[]
+                                    {
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody1",
+                            MessageId = 4234,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        },
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody2",
+                            MessageId = 4235,
+                            MessageType = JobCancelMessage.MessageType
+                        },
+                        null,  //should be skipped by GetNextMessageAsync implementation
+                        null,
+                        new TaskAgentMessage
+                        {
+                            Body = "somebody3",
+                            MessageId = 4236,
+                            MessageType = JobRequestMessageTypes.PipelineAgentJobRequest
+                        }
+                                    };
+                    var messages = new Queue<TaskAgentMessage>(arMessages);
+
+                    _runnerServer
+                        .Setup(x => x.GetAgentMessageAsync(
+                            _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token))
+                        .Returns(async (Int32 poolId, Guid sessionId, Int64? lastMessageId, CancellationToken cancellationToken) =>
+                        {
+                            await Task.Delay(1);
+                            return messages.Dequeue();
+                        });
+
+                    TaskAgentMessage message1 = await listener.GetNextMessageAsync(tokenSource.Token);
+                    TaskAgentMessage message2 = await listener.GetNextMessageAsync(tokenSource.Token);
+                    TaskAgentMessage message3 = await listener.GetNextMessageAsync(tokenSource.Token);
+                    Assert.Equal(arMessages[0], message1);
+                    Assert.Equal(arMessages[1], message2);
+                    Assert.Equal(arMessages[4], message3);
+
+                    //Assert
+                    _runnerServer
+                        .Verify(x => x.GetAgentMessageAsync(
+                            _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token), Times.Exactly(arMessages.Length));
+
+                    _runnerServer
+                        .Verify(x => x.GetRunnerAuthUrlAsync(_settings.PoolId, _settings.AgentId), Times.Never);
+
+                    _runnerServer
+                        .Verify(x => x.ConnectAsync(
+                            It.IsAny<Uri>(),
+                            It.IsAny<VssCredentials>()), Times.Once);
+
+                    Assert.False(listener._useV2Credentials);
+                    Assert.True(listener._v1CredentialsExists);
+                    Assert.False(listener._needToCheckAuthorizationUrlUpdate);
+                    Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
+                    Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_LEGACYAUTHURL", null);
             }
         }
     }

--- a/src/Test/L0/Listener/MessageListenerL0.cs
+++ b/src/Test/L0/Listener/MessageListenerL0.cs
@@ -266,7 +266,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token), Times.Once());
 
                 Assert.False(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -321,7 +320,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token), Times.Once());
 
                 Assert.True(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -368,7 +366,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token), Times.Once());
 
                 Assert.False(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -442,7 +439,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                         v2VssCred), Times.Once);
 
                 Assert.False(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.NotNull(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -508,7 +504,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                         v2VssCred), Times.Once);
 
                 Assert.False(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.NotNull(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -569,7 +564,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token), Times.Once());
 
                 Assert.False(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
 
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
@@ -635,7 +629,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                 Assert.DoesNotContain(traceContent, x => x.Contains("Try connect service with v2 OAuth endpoint."));
 
                 Assert.False(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -696,7 +689,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token), Times.Once());
 
                 Assert.False(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -779,7 +771,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                 Assert.Contains(traceContent, x => x.Contains("Try connect service with v2 OAuth endpoint."));
 
                 Assert.True(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -840,7 +831,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token), Times.Once());
 
                 Assert.False(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -936,7 +926,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                 Assert.Contains(traceContent, x => x.Contains("Try connect service with v2 OAuth endpoint."));
 
                 Assert.True(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -997,7 +986,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token), Times.Once());
 
                 Assert.False(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -1080,7 +1068,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                 Assert.Contains(traceContent, x => x.Contains("No needs to update authorization url"));
 
                 Assert.False(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -1138,7 +1125,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token), Times.Once());
 
                 Assert.True(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -1234,7 +1220,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                 var traceContent = File.ReadAllLines(tempLog);
                 Assert.Contains(traceContent, x => x.Contains("Fallback to v1 credentials and try again."));
 
-                Assert.True(listener._v1CredentialsExists);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
             }
@@ -1291,7 +1276,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token), Times.Once());
 
                 Assert.True(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -1388,7 +1372,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                 Assert.Contains(traceContent, x => x.Contains("Re-attempt to use v2 credential"));
 
                 Assert.True(listener._useV2Credentials);
-                Assert.True(listener._v1CredentialsExists);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -1449,7 +1432,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                             tokenSource.Token), Times.Once());
 
                     Assert.False(listener._useV2Credentials);
-                    Assert.True(listener._v1CredentialsExists);
                     Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                     Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                     Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -1509,7 +1491,6 @@ namespace GitHub.Runner.Common.Tests.Listener
                             It.IsAny<VssCredentials>()), Times.Once);
 
                     Assert.False(listener._useV2Credentials);
-                    Assert.True(listener._v1CredentialsExists);
                     Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                     Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                     Assert.Null(listener._authorizationUrlMigrationBackgroundTask);

--- a/src/Test/L0/Listener/MessageListenerL0.cs
+++ b/src/Test/L0/Listener/MessageListenerL0.cs
@@ -65,7 +65,7 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
                 _store.Setup(x => x.GetCredentials()).Returns(new CredentialData() { Scheme = Constants.Configuration.OAuthAccessToken });
-                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -109,7 +109,7 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
                 _store.Setup(x => x.GetCredentials()).Returns(new CredentialData() { Scheme = Constants.Configuration.OAuthAccessToken });
-                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -156,7 +156,7 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
                 _store.Setup(x => x.GetCredentials()).Returns(new CredentialData() { Scheme = Constants.Configuration.OAuthAccessToken });
-                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -215,7 +215,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
-        public async void CreateSessionWithV1Credential()
+        public async void CreateSessionWithOriginalCredential()
         {
             using (TestHostContext tc = CreateTestContext())
             using (var tokenSource = new CancellationTokenSource())
@@ -243,12 +243,12 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
 
-                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v1Cred.Data["authorizationUrl"] = "https://s.server";
-                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var originalCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                originalCred.Data["authorizationUrl"] = "https://s.server";
+                originalCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
-                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+                _store.Setup(x => x.GetCredentials()).Returns(originalCred);
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -265,7 +265,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                         It.Is<TaskAgentSession>(y => y != null),
                         tokenSource.Token), Times.Once());
 
-                Assert.False(listener._useV2Credentials);
+                Assert.False(listener._useMigratedCredentials);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -275,7 +275,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
-        public async void CreateSessionWithV2Credential()
+        public async void CreateSessionWithMigratedCredential()
         {
             using (TestHostContext tc = CreateTestContext())
             using (var tokenSource = new CancellationTokenSource())
@@ -293,16 +293,16 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
 
-                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v1Cred.Data["authorizationUrl"] = "https://s.server";
-                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var originalCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                originalCred.Data["authorizationUrl"] = "https://s.server";
+                originalCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v2Cred.Data["authorizationUrl"] = "https://t.server";
-                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var migratedCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                migratedCred.Data["authorizationUrl"] = "https://t.server";
+                migratedCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
-                _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+                _store.Setup(x => x.GetCredentials()).Returns(originalCred);
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(migratedCred);
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -319,7 +319,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                         It.Is<TaskAgentSession>(y => y != null),
                         tokenSource.Token), Times.Once());
 
-                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._useMigratedCredentials);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -348,7 +348,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
 
                 _store.Setup(x => x.GetCredentials()).Returns(new CredentialData() { Scheme = Constants.Configuration.OAuthAccessToken });
-                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -365,7 +365,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                         It.Is<TaskAgentSession>(y => y != null),
                         tokenSource.Token), Times.Once());
 
-                Assert.False(listener._useV2Credentials);
+                Assert.False(listener._useMigratedCredentials);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -375,7 +375,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
-        public async void CreateSessionWithV2CredentialFallBackV1Succeed()
+        public async void CreateSessionWithMigratedCredentialFallBackOriginalSucceed()
         {
             using (TestHostContext tc = CreateTestContext())
             using (var tokenSource = new CancellationTokenSource())
@@ -399,21 +399,21 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token))
                     .Returns(Task.FromResult(expectedSession));
 
-                var v1VssCred = new VssCredentials();
-                var v2VssCred = new VssCredentials();
-                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(v2VssCred);
-                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(v1VssCred);
+                var originalVssCred = new VssCredentials();
+                var migratedVssCred = new VssCredentials();
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(migratedVssCred);
+                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(originalVssCred);
 
-                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v1Cred.Data["authorizationUrl"] = "https://s.server";
-                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var originalCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                originalCred.Data["authorizationUrl"] = "https://s.server";
+                originalCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v2Cred.Data["authorizationUrl"] = "https://t.server";
-                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var migratedCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                migratedCred.Data["authorizationUrl"] = "https://t.server";
+                migratedCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
-                _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+                _store.Setup(x => x.GetCredentials()).Returns(originalCred);
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(migratedCred);
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -432,13 +432,13 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _runnerServer
                     .Verify(x => x.ConnectAsync(
                         It.IsAny<Uri>(),
-                        v1VssCred), Times.Once);
+                        originalVssCred), Times.Once);
                 _runnerServer
                     .Verify(x => x.ConnectAsync(
                         It.IsAny<Uri>(),
-                        v2VssCred), Times.Once);
+                        migratedVssCred), Times.Once);
 
-                Assert.False(listener._useV2Credentials);
+                Assert.False(listener._useMigratedCredentials);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.NotNull(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -448,7 +448,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
-        public async void CreateSessionWithV2CredentialFallBackV1StillFailed()
+        public async void CreateSessionWithMigratedCredentialFallBackOriginalStillFailed()
         {
             using (TestHostContext tc = CreateTestContext())
             using (var tokenSource = new CancellationTokenSource())
@@ -464,21 +464,21 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token))
                     .Throws(new TaskAgentPoolNotFoundException("L0 Pool not found"));
 
-                var v1VssCred = new VssCredentials();
-                var v2VssCred = new VssCredentials();
-                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(v2VssCred);
-                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(v1VssCred);
+                var originalVssCred = new VssCredentials();
+                var migratedVssCred = new VssCredentials();
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(migratedVssCred);
+                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(originalVssCred);
 
-                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v1Cred.Data["authorizationUrl"] = "https://s.server";
-                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var originalCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                originalCred.Data["authorizationUrl"] = "https://s.server";
+                originalCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v2Cred.Data["authorizationUrl"] = "https://t.server";
-                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var migratedCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                migratedCred.Data["authorizationUrl"] = "https://t.server";
+                migratedCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
-                _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+                _store.Setup(x => x.GetCredentials()).Returns(originalCred);
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(migratedCred);
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -497,13 +497,13 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _runnerServer
                     .Verify(x => x.ConnectAsync(
                         It.IsAny<Uri>(),
-                        v1VssCred), Times.Once);
+                        originalVssCred), Times.Once);
                 _runnerServer
                     .Verify(x => x.ConnectAsync(
                         It.IsAny<Uri>(),
-                        v2VssCred), Times.Once);
+                        migratedVssCred), Times.Once);
 
-                Assert.False(listener._useV2Credentials);
+                Assert.False(listener._useMigratedCredentials);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.NotNull(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -513,7 +513,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
-        public async void CreateSessionWithV1GetMessageWaitForMigtateToV2()
+        public async void CreateSessionWithOriginalGetMessageWaitForMigtateToMigrated()
         {
             using (TestHostContext tc = CreateTestContext())
             using (var tokenSource = new CancellationTokenSource())
@@ -541,12 +541,12 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
 
-                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v1Cred.Data["authorizationUrl"] = "https://s.server";
-                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var originalCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                originalCred.Data["authorizationUrl"] = "https://s.server";
+                originalCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
-                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+                _store.Setup(x => x.GetCredentials()).Returns(originalCred);
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -563,7 +563,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                         It.Is<TaskAgentSession>(y => y != null),
                         tokenSource.Token), Times.Once());
 
-                Assert.False(listener._useV2Credentials);
+                Assert.False(listener._useMigratedCredentials);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
 
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
@@ -626,9 +626,9 @@ namespace GitHub.Runner.Common.Tests.Listener
                 var tempLog = Path.GetTempFileName();
                 File.Copy(tc.TraceFileName, tempLog, true);
                 var traceContent = File.ReadAllLines(tempLog);
-                Assert.DoesNotContain(traceContent, x => x.Contains("Try connect service with v2 OAuth endpoint."));
+                Assert.DoesNotContain(traceContent, x => x.Contains("Try connect service with migrated OAuth endpoint."));
 
-                Assert.False(listener._useV2Credentials);
+                Assert.False(listener._useMigratedCredentials);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -638,7 +638,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
-        public async void CreateSessionWithV1GetMessageMigtateToV2()
+        public async void CreateSessionWithOriginalGetMessageMigtateToMigrated()
         {
             using (TestHostContext tc = CreateTestContext())
             using (var tokenSource = new CancellationTokenSource())
@@ -666,12 +666,12 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
 
-                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v1Cred.Data["authorizationUrl"] = "https://s.server";
-                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var originalCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                originalCred.Data["authorizationUrl"] = "https://s.server";
+                originalCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
-                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+                _store.Setup(x => x.GetCredentials()).Returns(originalCred);
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -688,7 +688,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                         It.Is<TaskAgentSession>(y => y != null),
                         tokenSource.Token), Times.Once());
 
-                Assert.False(listener._useV2Credentials);
+                Assert.False(listener._useMigratedCredentials);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -768,9 +768,9 @@ namespace GitHub.Runner.Common.Tests.Listener
                 var tempLog = Path.GetTempFileName();
                 File.Copy(tc.TraceFileName, tempLog, true);
                 var traceContent = File.ReadAllLines(tempLog);
-                Assert.Contains(traceContent, x => x.Contains("Try connect service with v2 OAuth endpoint."));
+                Assert.Contains(traceContent, x => x.Contains("Try connect service with Token Service OAuth endpoint."));
 
-                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._useMigratedCredentials);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -780,7 +780,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
-        public async void CreateSessionWithV1GetMessageMigtateToV2WaitForIdle()
+        public async void CreateSessionWithOriginalGetMessageMigtateToMigratedWaitForIdle()
         {
             using (TestHostContext tc = CreateTestContext())
             using (var tokenSource = new CancellationTokenSource())
@@ -808,12 +808,12 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
 
-                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v1Cred.Data["authorizationUrl"] = "https://s.server";
-                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var originalCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                originalCred.Data["authorizationUrl"] = "https://s.server";
+                originalCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
-                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+                _store.Setup(x => x.GetCredentials()).Returns(originalCred);
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -830,7 +830,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                         It.Is<TaskAgentSession>(y => y != null),
                         tokenSource.Token), Times.Once());
 
-                Assert.False(listener._useV2Credentials);
+                Assert.False(listener._useMigratedCredentials);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -923,9 +923,9 @@ namespace GitHub.Runner.Common.Tests.Listener
                 File.Copy(tc.TraceFileName, tempLog, true);
                 var traceContent = File.ReadAllLines(tempLog);
                 Assert.Contains(traceContent, x => x.Contains("Job or runner updates in progress, update credentials next time."));
-                Assert.Contains(traceContent, x => x.Contains("Try connect service with v2 OAuth endpoint."));
+                Assert.Contains(traceContent, x => x.Contains("Try connect service with Token Service OAuth endpoint."));
 
-                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._useMigratedCredentials);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -935,7 +935,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
-        public async void CreateSessionWithV2GetMessageNotMigrateAgain()
+        public async void CreateSessionWithMigratedGetMessageNotMigrateAgain()
         {
             using (TestHostContext tc = CreateTestContext())
             using (var tokenSource = new CancellationTokenSource())
@@ -963,12 +963,12 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
 
-                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v2Cred.Data["authorizationUrl"] = "https://t.server";
-                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var migratedCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                migratedCred.Data["authorizationUrl"] = "https://t.server";
+                migratedCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                _store.Setup(x => x.GetCredentials()).Returns(v2Cred);
-                _store.Setup(x => x.GetV2Credentials()).Returns(default(CredentialData));
+                _store.Setup(x => x.GetCredentials()).Returns(migratedCred);
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(default(CredentialData));
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -985,7 +985,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                         It.Is<TaskAgentSession>(y => y != null),
                         tokenSource.Token), Times.Once());
 
-                Assert.False(listener._useV2Credentials);
+                Assert.False(listener._useMigratedCredentials);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -1067,7 +1067,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 var traceContent = File.ReadAllLines(tempLog);
                 Assert.Contains(traceContent, x => x.Contains("No needs to update authorization url"));
 
-                Assert.False(listener._useV2Credentials);
+                Assert.False(listener._useMigratedCredentials);
                 Assert.True(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.NotNull(listener._authorizationUrlMigrationBackgroundTask);
@@ -1077,7 +1077,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
-        public async void CreateSessionWithV1GetMessageMigrateToV2FallbackToV1()
+        public async void CreateSessionWithOriginalGetMessageMigrateToMigratedFallbackToOriginal()
         {
             using (TestHostContext tc = CreateTestContext())
             using (var tokenSource = new CancellationTokenSource())
@@ -1093,21 +1093,21 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token))
                     .Returns(Task.FromResult(expectedSession));
 
-                var v1VssCred = new VssCredentials();
-                var v2VssCred = new VssCredentials();
-                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(v2VssCred);
-                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(v1VssCred);
+                var originalVssCred = new VssCredentials();
+                var migratedVssCred = new VssCredentials();
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(migratedVssCred);
+                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(originalVssCred);
 
-                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v1Cred.Data["authorizationUrl"] = "https://s.server";
-                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var originalCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                originalCred.Data["authorizationUrl"] = "https://s.server";
+                originalCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v2Cred.Data["authorizationUrl"] = "https://t.server";
-                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var migratedCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                migratedCred.Data["authorizationUrl"] = "https://t.server";
+                migratedCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
-                _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+                _store.Setup(x => x.GetCredentials()).Returns(originalCred);
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(migratedCred);
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -1124,7 +1124,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                         It.Is<TaskAgentSession>(y => y != null),
                         tokenSource.Token), Times.Once());
 
-                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._useMigratedCredentials);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -1171,7 +1171,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                         if (counter == 6)
                         {
                             Assert.NotNull(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
-                            Assert.False(listener._useV2Credentials);
+                            Assert.False(listener._useMigratedCredentials);
                         }
 
                         return messages.Dequeue();
@@ -1218,7 +1218,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 var tempLog = Path.GetTempFileName();
                 File.Copy(tc.TraceFileName, tempLog, true);
                 var traceContent = File.ReadAllLines(tempLog);
-                Assert.Contains(traceContent, x => x.Contains("Fallback to v1 credentials and try again."));
+                Assert.Contains(traceContent, x => x.Contains("Fallback to original credentials and try again."));
 
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -1228,7 +1228,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
-        public async void CreateSessionWithV1GetMessageMigrateToV2FallbackToV1ReattemptV2()
+        public async void CreateSessionWithOriginalGetMessageMigrateToMigratedFallbackToOriginalReattemptMigrated()
         {
             using (TestHostContext tc = CreateTestContext())
             using (var tokenSource = new CancellationTokenSource())
@@ -1244,21 +1244,21 @@ namespace GitHub.Runner.Common.Tests.Listener
                         tokenSource.Token))
                     .Returns(Task.FromResult(expectedSession));
 
-                var v1VssCred = new VssCredentials();
-                var v2VssCred = new VssCredentials();
-                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(v2VssCred);
-                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(v1VssCred);
+                var originalVssCred = new VssCredentials();
+                var migratedVssCred = new VssCredentials();
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(migratedVssCred);
+                _credMgr.Setup(x => x.LoadCredentials(false)).Returns(originalVssCred);
 
-                var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v1Cred.Data["authorizationUrl"] = "https://s.server";
-                v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var originalCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                originalCred.Data["authorizationUrl"] = "https://s.server";
+                originalCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                v2Cred.Data["authorizationUrl"] = "https://t.server";
-                v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                var migratedCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                migratedCred.Data["authorizationUrl"] = "https://t.server";
+                migratedCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
-                _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+                _store.Setup(x => x.GetCredentials()).Returns(originalCred);
+                _store.Setup(x => x.GetMigratedCredentials()).Returns(migratedCred);
 
                 // Act.
                 MessageListener listener = new MessageListener();
@@ -1275,7 +1275,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                         It.Is<TaskAgentSession>(y => y != null),
                         tokenSource.Token), Times.Once());
 
-                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._useMigratedCredentials);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -1368,10 +1368,10 @@ namespace GitHub.Runner.Common.Tests.Listener
                 var tempLog = Path.GetTempFileName();
                 File.Copy(tc.TraceFileName, tempLog, true);
                 var traceContent = File.ReadAllLines(tempLog);
-                Assert.Contains(traceContent, x => x.Contains("Fallback to v1 credentials and try again."));
-                Assert.Contains(traceContent, x => x.Contains("Re-attempt to use v2 credential"));
+                Assert.Contains(traceContent, x => x.Contains("Fallback to original credentials and try again."));
+                Assert.Contains(traceContent, x => x.Contains("Re-attempt to use migrated credential"));
 
-                Assert.True(listener._useV2Credentials);
+                Assert.True(listener._useMigratedCredentials);
                 Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                 Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                 Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -1381,11 +1381,11 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
-        public async void CreateSessionWithV1GetMessageWithV1EnvOverwrite()
+        public async void CreateSessionWithOriginalGetMessageWithOriginalEnvOverwrite()
         {
             try
             {
-                Environment.SetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_LEGACYAUTHURL", "1");
+                Environment.SetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_SPSAUTHURL", "1");
                 using (TestHostContext tc = CreateTestContext())
                 using (var tokenSource = new CancellationTokenSource())
                 {
@@ -1400,21 +1400,21 @@ namespace GitHub.Runner.Common.Tests.Listener
                             tokenSource.Token))
                         .Returns(Task.FromResult(expectedSession));
 
-                    var v1VssCred = new VssCredentials();
-                    var v2VssCred = new VssCredentials();
-                    _credMgr.Setup(x => x.LoadCredentials(false)).Returns(v1VssCred);
-                    _credMgr.Setup(x => x.LoadCredentials(true)).Returns(v2VssCred);
+                    var originalVssCred = new VssCredentials();
+                    var migratedVssCred = new VssCredentials();
+                    _credMgr.Setup(x => x.LoadCredentials(false)).Returns(originalVssCred);
+                    _credMgr.Setup(x => x.LoadCredentials(true)).Returns(migratedVssCred);
 
-                    var v1Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                    v1Cred.Data["authorizationUrl"] = "https://s.server";
-                    v1Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                    var originalCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                    originalCred.Data["authorizationUrl"] = "https://s.server";
+                    originalCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                    var v2Cred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
-                    v2Cred.Data["authorizationUrl"] = "https://t.server";
-                    v2Cred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
+                    var migratedCred = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                    migratedCred.Data["authorizationUrl"] = "https://t.server";
+                    migratedCred.Data["clientId"] = "d842fd7b-61b0-4a80-96b4-f2797c353897";
 
-                    _store.Setup(x => x.GetCredentials()).Returns(v1Cred);
-                    _store.Setup(x => x.GetV2Credentials()).Returns(v2Cred);
+                    _store.Setup(x => x.GetCredentials()).Returns(originalCred);
+                    _store.Setup(x => x.GetMigratedCredentials()).Returns(migratedCred);
 
                     // Act.
                     MessageListener listener = new MessageListener();
@@ -1431,7 +1431,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                             It.Is<TaskAgentSession>(y => y != null),
                             tokenSource.Token), Times.Once());
 
-                    Assert.False(listener._useV2Credentials);
+                    Assert.False(listener._useMigratedCredentials);
                     Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                     Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                     Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -1490,7 +1490,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                             It.IsAny<Uri>(),
                             It.IsAny<VssCredentials>()), Times.Once);
 
-                    Assert.False(listener._useV2Credentials);
+                    Assert.False(listener._useMigratedCredentials);
                     Assert.False(listener._needToCheckAuthorizationUrlUpdate);
                     Assert.Null(listener._authorizationUrlRollbackReattemptDelayBackgroundTask);
                     Assert.Null(listener._authorizationUrlMigrationBackgroundTask);
@@ -1498,7 +1498,7 @@ namespace GitHub.Runner.Common.Tests.Listener
             }
             finally
             {
-                Environment.SetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_LEGACYAUTHURL", null);
+                Environment.SetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_SPSAUTHURL", null);
             }
         }
     }

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -198,7 +198,7 @@ namespace GitHub.Runner.Common.Tests
 
                 case WellKnownDirectory.Tools:
                     path = Environment.GetEnvironmentVariable("RUNNER_TOOL_CACHE");
-                    
+
                     if (string.IsNullOrEmpty(path))
                     {
                         path = Path.Combine(


### PR DESCRIPTION
https://github.com/github/c2c-actions-runtime/pull/348

Goal: Migrate existing runner to use Authorization url from Token service instead of SPS.

FF:
1. For newly configured runner, service base on FF to send initial authorization url from Token or SPS back during config.
2. Start migration all self-hosted runner for a single repository.