### PR TITLE
Set Minimum Length on base64 trimming to > 2 pre-encoded characters

### DIFF
--- a/src/Sdk/DTLogging/Logging/ValueEncoders.cs
+++ b/src/Sdk/DTLogging/Logging/ValueEncoders.cs
@@ -118,7 +118,8 @@ namespace GitHub.DistributedTask.Logging
             if (value.EndsWith('='))
             {
                 var trimmed = value.TrimEnd('=');
-                if (trimmed.Length > 1)
+                // Minimum length to make sure we don't register 1 or 2 characters as a secret.
+                if (trimmed.Length > 3)
                 {
                     // If a base64 string ends in '=' it indicates that the base 64 character is only using 2 or 4 of the six bytes and will change if another character is added
                     // For example 'ab' is 'YWI=' in base 64

--- a/src/Test/L0/HostContextL0.cs
+++ b/src/Test/L0/HostContextL0.cs
@@ -112,7 +112,7 @@ namespace GitHub.Runner.Common.Tests
                 Assert.Equal("YWJjOlBh***Tph", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"abc:Password123!:a"))));
                 Assert.Equal("YWJjOlBh***Tph", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"abc:Password123!:a"))));
                 Assert.Equal("***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes("{"))));
-                                Assert.Equal("***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes("3ch"))));
+                Assert.Equal("***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes("3ch"))));
                 Assert.Equal("a ***", _hc.SecretMasker.MaskSecrets("a aA==")); // h is "aA==" in base64, we should not mask the trimmed version only the full
                 Assert.Equal("Y2 ***", _hc.SecretMasker.MaskSecrets("Y2 Y2g=")); // ch is "Y2g=" in base64, we should not mask the trimmed version only the full
                 

--- a/src/Test/L0/HostContextL0.cs
+++ b/src/Test/L0/HostContextL0.cs
@@ -85,6 +85,8 @@ namespace GitHub.Runner.Common.Tests
                 _hc.SecretMasker.AddValue("Pass word 123!");
                 _hc.SecretMasker.AddValue("Pass<word>123!");
                 _hc.SecretMasker.AddValue("Pass'word'123!");
+                _hc.SecretMasker.AddValue("3ch");
+                _hc.SecretMasker.AddValue("{");
 
                 // Assert.
                 Assert.Equal("123***123", _hc.SecretMasker.MaskSecrets("123Password123!123"));
@@ -108,6 +110,12 @@ namespace GitHub.Runner.Common.Tests
                 Assert.Equal("OlBh***To=", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($":Password123!:"))));
                 Assert.Equal("YTpQ***E6YQ==", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"a:Password123!:a"))));
                 Assert.Equal("YWJjOlBh***Tph", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"abc:Password123!:a"))));
+                Assert.Equal("YWJjOlBh***Tph", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"abc:Password123!:a"))));
+                Assert.Equal("***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes("{"))));
+                                Assert.Equal("***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes("3ch"))));
+                Assert.Equal("a ***", _hc.SecretMasker.MaskSecrets("a aA==")); // h is "aA==" in base64, we should not mask the trimmed version only the full
+                Assert.Equal("Y2 ***", _hc.SecretMasker.MaskSecrets("Y2 Y2g=")); // ch is "Y2g=" in base64, we should not mask the trimmed version only the full
+                
             }
             finally
             {

--- a/src/Test/L0/HostContextL0.cs
+++ b/src/Test/L0/HostContextL0.cs
@@ -85,8 +85,9 @@ namespace GitHub.Runner.Common.Tests
                 _hc.SecretMasker.AddValue("Pass word 123!");
                 _hc.SecretMasker.AddValue("Pass<word>123!");
                 _hc.SecretMasker.AddValue("Pass'word'123!");
-                _hc.SecretMasker.AddValue("3ch");
                 _hc.SecretMasker.AddValue("{");
+                _hc.SecretMasker.AddValue("}");
+                _hc.SecretMasker.AddValue("3ch");
 
                 // Assert.
                 Assert.Equal("123***123", _hc.SecretMasker.MaskSecrets("123Password123!123"));
@@ -110,8 +111,8 @@ namespace GitHub.Runner.Common.Tests
                 Assert.Equal("OlBh***To=", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($":Password123!:"))));
                 Assert.Equal("YTpQ***E6YQ==", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"a:Password123!:a"))));
                 Assert.Equal("YWJjOlBh***Tph", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"abc:Password123!:a"))));
-                Assert.Equal("YWJjOlBh***Tph", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"abc:Password123!:a"))));
-                Assert.Equal("***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes("{"))));
+                Assert.Equal("e ew ew= ***", _hc.SecretMasker.MaskSecrets("e ew ew= ew==")); // { is "ew==" in base64, we should not mask the trimmed version for short secrets only the full
+                Assert.Equal("f fQ fQ= ***", _hc.SecretMasker.MaskSecrets("f fQ fQ= fQ==")); // } is "fQ==" in base64, we should not mask the trimmed version for short secrets only the full
                 Assert.Equal("***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes("3ch"))));
                 Assert.Equal("a ***", _hc.SecretMasker.MaskSecrets("a aA==")); // h is "aA==" in base64, we should not mask the trimmed version only the full
                 Assert.Equal("Y2 ***", _hc.SecretMasker.MaskSecrets("Y2 Y2g=")); // ch is "Y2g=" in base64, we should not mask the trimmed version only the full


### PR DESCRIPTION
Resolves #326 