### PR TITLE
Update Runner Register GitHub API URL to Support Org-level Runner

### DIFF
--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -522,13 +522,12 @@ namespace GitHub.Runner.Listener.Configuration
         private async Task<GitHubAuthResult> GetTenantCredential(string githubUrl, string githubToken)
         {
             var gitHubUrlBuilder = new UriBuilder(githubUrl);
-            var githubApiUrl = $"https://api.{gitHubUrlBuilder.Host}/actions/register-runner";
-            using (var httpClientHandler = HostContext.CreateHttpClientHandler())
+            var githubApiUrl = $"https://api.{gitHubUrlBuilder.Host}/actions/runner-registration";
+           using (var httpClientHandler = HostContext.CreateHttpClientHandler())
             using (var httpClient = new HttpClient(httpClientHandler))
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("RemoteAuth", githubToken);
                 httpClient.DefaultRequestHeaders.UserAgent.Add(HostContext.UserAgent);
-                httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.shuri-preview+json"));
 
                 var bodyObject = new Dictionary<string, string>()
                 {

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -5,17 +5,14 @@ using GitHub.Runner.Sdk;
 using GitHub.Services.Common;
 using GitHub.Services.OAuth;
 using GitHub.Services.WebApi;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Threading.Tasks;
-using System.Runtime.InteropServices;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
 
 namespace GitHub.Runner.Listener.Configuration
 {
@@ -524,7 +521,8 @@ namespace GitHub.Runner.Listener.Configuration
 
         private async Task<GitHubAuthResult> GetTenantCredential(string githubUrl, string githubToken)
         {
-            var githubApiUrl = "https://api.github.com/actions/register-runner";
+            var gitHubUrlBuilder = new UriBuilder(githubUrl);
+            var githubApiUrl = $"https://api.{gitHubUrlBuilder.Host}/actions/register-runner";
             using (var httpClientHandler = HostContext.CreateHttpClientHandler())
             using (var httpClient = new HttpClient(httpClientHandler))
             {
@@ -532,12 +530,12 @@ namespace GitHub.Runner.Listener.Configuration
                 httpClient.DefaultRequestHeaders.UserAgent.Add(HostContext.UserAgent);
                 httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.shuri-preview+json"));
 
-                var bodyObject = new JObject
+                var bodyObject = new Dictionary<string, string>()
                 {
-                    new JProperty( "url", githubUrl)
+                    {"url", githubUrl}
                 };
 
-                var response = await httpClient.PostAsync(githubApiUrl, new StringContent(JsonConvert.SerializeObject(bodyObject), null, "application/json"));
+                var response = await httpClient.PostAsync(githubApiUrl, new StringContent(StringUtil.ConvertToJson(bodyObject), null, "application/json"));
 
                 if (response.IsSuccessStatusCode)
                 {


### PR DESCRIPTION
Draft PR

Updated GitHub API request as per this -> https://github.com/github/c2c-actions-runtime/issues/373#issuecomment-588394924

Sample request

```
POST https://api.github.com/actions/runner-registration HTTP/1.1
Host: api.github.com
Authorization: RemoteAuth AAO2GDSAMPLEIQLJBOI2BZ26JXCTA
User-Agent: GitHubActionsRunner-win-x64/2.165.0
Content-Type: application/json; charset=utf-8
Content-Length: 50

{"url":"https://github.com/bbq-beets/logopu-test"}
```