### PR TITLE
Use the input url scheme in the register runner url

### DIFF
--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -522,8 +522,8 @@ namespace GitHub.Runner.Listener.Configuration
         private async Task<GitHubAuthResult> GetTenantCredential(string githubUrl, string githubToken)
         {
             var gitHubUrlBuilder = new UriBuilder(githubUrl);
-            var githubApiUrl = $"https://api.{gitHubUrlBuilder.Host}/actions/runner-registration";
-           using (var httpClientHandler = HostContext.CreateHttpClientHandler())
+            var githubApiUrl = $"{gitHubUrlBuilder.Scheme}://api.{gitHubUrlBuilder.Host}/actions/runner-registration";
+            using (var httpClientHandler = HostContext.CreateHttpClientHandler())
             using (var httpClient = new HttpClient(httpClientHandler))
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("RemoteAuth", githubToken);


### PR DESCRIPTION
### Issue
The current runner registration URL defaults to `HTTPS`, which can make it difficult to test locally when using `HTTP` URLs.

This change uses the input URL's scheme for the runner registration API URL.

### Testing

Tested with a runner connected to `http://github.localhost` and verified that the runner was successfully registered.