### PR TITLE
Add event type to credential call

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -136,6 +136,12 @@ namespace GitHub.Runner.Common
             }
         }
 
+        public static class RunnerEvent
+        {
+            public static readonly string Register = "register";
+            public static readonly string Remove = "remove";
+        }
+
         public static class Pipeline
         {
             public static class Path

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -108,7 +108,7 @@ namespace GitHub.Runner.Listener.Configuration
                 {
                     runnerSettings.GitHubUrl = inputUrl;
                     var githubToken = command.GetRunnerRegisterToken();
-                    GitHubAuthResult authResult = await GetTenantCredential(inputUrl, githubToken);
+                    GitHubAuthResult authResult = await GetTenantCredential(inputUrl, githubToken, RunnerCredentialEvents.RegisterRunner);
                     runnerSettings.ServerUrl = authResult.TenantUrl;
                     creds = authResult.ToVssCredentials();
                     Trace.Info("cred retrieved via GitHub auth");
@@ -375,7 +375,7 @@ namespace GitHub.Runner.Listener.Configuration
                     else
                     {
                         var githubToken = command.GetRunnerDeletionToken();
-                        GitHubAuthResult authResult = await GetTenantCredential(settings.GitHubUrl, githubToken);
+                        GitHubAuthResult authResult = await GetTenantCredential(settings.GitHubUrl, githubToken, RunnerCredentialEvents.RemoveRunner);
                         creds = authResult.ToVssCredentials();
                         Trace.Info("cred retrieved via GitHub auth");
                     }
@@ -519,7 +519,7 @@ namespace GitHub.Runner.Listener.Configuration
             }
         }
 
-        private async Task<GitHubAuthResult> GetTenantCredential(string githubUrl, string githubToken)
+        private async Task<GitHubAuthResult> GetTenantCredential(string githubUrl, string githubToken, string runnerEvent)
         {
             var gitHubUrlBuilder = new UriBuilder(githubUrl);
             var githubApiUrl = $"{gitHubUrlBuilder.Scheme}://api.{gitHubUrlBuilder.Host}/actions/runner-registration";
@@ -531,7 +531,8 @@ namespace GitHub.Runner.Listener.Configuration
 
                 var bodyObject = new Dictionary<string, string>()
                 {
-                    {"url", githubUrl}
+                    {"url", githubUrl},
+                    {"runner_event", runnerEvent}
                 };
 
                 var response = await httpClient.PostAsync(githubApiUrl, new StringContent(StringUtil.ConvertToJson(bodyObject), null, "application/json"));
@@ -551,6 +552,12 @@ namespace GitHub.Runner.Listener.Configuration
                     return null;
                 }
             }
+        }
+
+        private static class RunnerCredentialEvents
+        {
+            public const string RegisterRunner = "register";
+            public const string RemoveRunner = "remove";
         }
     }
 }

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -108,7 +108,7 @@ namespace GitHub.Runner.Listener.Configuration
                 {
                     runnerSettings.GitHubUrl = inputUrl;
                     var githubToken = command.GetRunnerRegisterToken();
-                    GitHubAuthResult authResult = await GetTenantCredential(inputUrl, githubToken, RunnerCredentialEvents.RegisterRunner);
+                    GitHubAuthResult authResult = await GetTenantCredential(inputUrl, githubToken, Constants.RunnerEvent.Register);
                     runnerSettings.ServerUrl = authResult.TenantUrl;
                     creds = authResult.ToVssCredentials();
                     Trace.Info("cred retrieved via GitHub auth");
@@ -375,7 +375,7 @@ namespace GitHub.Runner.Listener.Configuration
                     else
                     {
                         var githubToken = command.GetRunnerDeletionToken();
-                        GitHubAuthResult authResult = await GetTenantCredential(settings.GitHubUrl, githubToken, RunnerCredentialEvents.RemoveRunner);
+                        GitHubAuthResult authResult = await GetTenantCredential(settings.GitHubUrl, githubToken, Constants.RunnerEvent.Remove);
                         creds = authResult.ToVssCredentials();
                         Trace.Info("cred retrieved via GitHub auth");
                     }
@@ -552,12 +552,6 @@ namespace GitHub.Runner.Listener.Configuration
                     return null;
                 }
             }
-        }
-
-        private static class RunnerCredentialEvents
-        {
-            public const string RegisterRunner = "register";
-            public const string RemoveRunner = "remove";
         }
     }
 }


### PR DESCRIPTION
To support auditing, we need to know which event is occurring when retrieving the tenant credential. Sending this event type will also allow us to split up the permissions needed for adding and removing a runner (which currently uses the same scopes).