### PR TITLE
ADR for expose runner's machine info in log.

### DIFF
--- a/docs/adrs/0353-runner-machine-info.md
+++ b/docs/adrs/0353-runner-machine-info.md
@@ -1,0 +1,35 @@
+# ADR 353: Expose runner machine info
+
+**Date**: 2020-03-02
+
+**Status**: Pending
+
+## Context
+
+- Provide an mechanism in the runner to include extra information in `Set up job` step's log.
+  Ex: Include OS/Software info from Hosted image.
+
+## Decision
+
+The runner will looking for a file `.extra_setup_info` under runner's root directory, the file could be a JSON with a simple schema.
+```json
+[
+  {
+    "group": "OS Detail",
+    "detail": "........"
+  },
+  {
+    "group": "Software Detail",
+    "detail": "........"
+  }
+]
+```
+The runner will use `##[group]` and `##[endgroup]` to fold all detail info into an expandable group.
+
+Both [virtual-environments](https://github.com/actions/virtual-environments) and self-hosted runner can leverage this mechanism to add extra logging info to `Set up job` step's log.
+
+## Consequences
+
+1. Change the runner to best effort read/parse `.extra_setup_info` file under runner root directory.
+2. [virtual-environments](https://github.com/actions/virtual-environments) generate the file during image generation.
+3. Change MMS provisioner to properly copy the file to runner root directory at runtime.

--- a/docs/adrs/0354-runner-machine-info.md
+++ b/docs/adrs/0354-runner-machine-info.md
@@ -11,7 +11,7 @@
 
 ## Decision
 
-The runner will looking for a file `.extra_setup_info` under runner's root directory, the file could be a JSON with a simple schema.
+The runner will look for a file `.extra_setup_info` under the runner's root directory, The file can be a JSON with a simple schema.
 ```json
 [
   {

--- a/docs/adrs/0354-runner-machine-info.md
+++ b/docs/adrs/0354-runner-machine-info.md
@@ -11,7 +11,7 @@
 
 ## Decision
 
-The runner will look for a file `.extra_setup_info` under the runner's root directory, The file can be a JSON with a simple schema.
+The runner will look for a file `.setup_info` under the runner's root directory, The file can be a JSON with a simple schema.
 ```json
 [
   {

--- a/docs/adrs/0354-runner-machine-info.md
+++ b/docs/adrs/0354-runner-machine-info.md
@@ -26,7 +26,7 @@ The runner will look for a file `.extra_setup_info` under the runner's root dire
 ```
 The runner will use `##[group]` and `##[endgroup]` to fold all detail info into an expandable group.
 
-Both [virtual-environments](https://github.com/actions/virtual-environments) and self-hosted runner can leverage this mechanism to add extra logging info to `Set up job` step's log.
+Both [virtual-environments](https://github.com/actions/virtual-environments) and self-hosted runners can use this mechanism to add extra logging info to the `Set up job` step's log.
 
 ## Consequences
 

--- a/docs/adrs/0354-runner-machine-info.md
+++ b/docs/adrs/0354-runner-machine-info.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-- Provide an mechanism in the runner to include extra information in `Set up job` step's log.
+- Provide a mechanism in the runner to include extra information in `Set up job` step's log.
   Ex: Include OS/Software info from Hosted image.
 
 ## Decision

--- a/docs/adrs/0354-runner-machine-info.md
+++ b/docs/adrs/0354-runner-machine-info.md
@@ -1,4 +1,4 @@
-# ADR 353: Expose runner machine info
+# ADR 354: Expose runner machine info
 
 **Date**: 2020-03-02
 


### PR DESCRIPTION
💥  [Rendered](https://github.com/actions/runner/blob/users/tihuang/extralog/docs/adrs/0354-runner-machine-info.md) 💥 

https://github.com/actions/runner/issues/346