### PR TITLE
cache actions on premises and download from .com

### DIFF
--- a/src/Runner.Common/ConfigurationStore.cs
+++ b/src/Runner.Common/ConfigurationStore.cs
@@ -15,6 +15,9 @@ namespace GitHub.Runner.Common
     [DataContract]
     public sealed class RunnerSettings
     {
+        [DataMember(Name = "IsHostedServer", EmitDefaultValue = false)]
+        private bool? _isHostedServer;
+
         [DataMember(EmitDefaultValue = false)]
         public int AgentId { get; set; }
 
@@ -42,6 +45,21 @@ namespace GitHub.Runner.Common
         [DataMember(EmitDefaultValue = false)]
         public string MonitorSocketAddress { get; set; }
 
+        [IgnoreDataMember]
+        public bool IsHostedServer
+        {
+            get
+            {
+                // Old runners do not have this property. Hosted runners likely don't have this property either.
+                return _isHostedServer ?? true;
+            }
+
+            set
+            {
+                _isHostedServer = value;
+            }
+        }
+
         /// <summary>
         // Computed property for convenience. Can either return:
         // 1. If runner was configured at the repo level, returns something like: "myorg/myrepo"
@@ -67,6 +85,15 @@ namespace GitHub.Runner.Common
                 }
 
                 return repoOrOrgName;
+            }
+        }
+
+        [OnSerializing]
+        private void OnSerializing(StreamingContext context)
+        {
+            if (_isHostedServer.HasValue && _isHostedServer.Value)
+            {
+                _isHostedServer = null;
             }
         }
     }

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -86,7 +86,6 @@ namespace GitHub.Runner.Listener.Configuration
 
             RunnerSettings runnerSettings = new RunnerSettings();
 
-            bool isHostedServer = false;
             // Loop getting url and creds until you can connect
             ICredentialProvider credProvider = null;
             VssCredentials creds = null;
@@ -117,7 +116,7 @@ namespace GitHub.Runner.Listener.Configuration
                 try
                 {
                     // Determine the service deployment type based on connection data. (Hosted/OnPremises)
-                    isHostedServer = await IsHostedServer(runnerSettings.ServerUrl, creds);
+                    runnerSettings.IsHostedServer = await IsHostedServer(runnerSettings.ServerUrl, creds);
 
                     // Validate can connect.
                     await _runnerServer.ConnectAsync(new Uri(runnerSettings.ServerUrl), creds);
@@ -248,7 +247,7 @@ namespace GitHub.Runner.Listener.Configuration
             {
                 UriBuilder configServerUrl = new UriBuilder(runnerSettings.ServerUrl);
                 UriBuilder oauthEndpointUrlBuilder = new UriBuilder(agent.Authorization.AuthorizationUrl);
-                if (!isHostedServer && Uri.Compare(configServerUrl.Uri, oauthEndpointUrlBuilder.Uri, UriComponents.SchemeAndServer, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) != 0)
+                if (!runnerSettings.IsHostedServer && Uri.Compare(configServerUrl.Uri, oauthEndpointUrlBuilder.Uri, UriComponents.SchemeAndServer, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) != 0)
                 {
                     oauthEndpointUrlBuilder.Scheme = configServerUrl.Scheme;
                     oauthEndpointUrlBuilder.Host = configServerUrl.Host;
@@ -381,7 +380,6 @@ namespace GitHub.Runner.Listener.Configuration
                     }
 
                     // Determine the service deployment type based on connection data. (Hosted/OnPremises)
-                    bool isHostedServer = await IsHostedServer(settings.ServerUrl, creds);
                     await _runnerServer.ConnectAsync(new Uri(settings.ServerUrl), creds);
 
                     var agents = await _runnerServer.GetAgentsAsync(settings.PoolId, settings.AgentName);


### PR DESCRIPTION
This PR enables downloading actions for GHES alpha. The goal is `actions/checkout` works in GHES alpha.

For alpha only, the following changes
- Remove auth header when downloading actions from github.com
- Do not clear the actions cache between jobs (avoid rate limiting for unauthenticated requests)

For beta, a different solution will be used (actions shipped in box).