### PR TITLE
Allow using Docker actions when running within a Docker container

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -118,6 +118,7 @@ namespace GitHub.Runner.Common
                 //validFlags array as well present in the CommandSettings.cs
                 public static class Flags
                 {
+                    public static readonly string AllowDockerInDocker = "allow-docker-in-docker";
                     public static readonly string Commit = "commit";
                     public static readonly string Help = "help";
                     public static readonly string Replace = "replace";

--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -36,6 +36,7 @@ namespace GitHub.Runner.Common
         event EventHandler Unloading;
         void ShutdownRunner(ShutdownReason reason);
         void WritePerfCounter(string counter);
+        bool AllowDockerInDocker { get; set; }
     }
 
     public enum StartupType
@@ -65,6 +66,7 @@ namespace GitHub.Runner.Common
         private IDisposable _httpTraceSubscription;
         private IDisposable _diagListenerSubscription;
         private StartupType _startupType;
+        private bool _allowDockerInDocker;
         private string _perfFile;
         private RunnerWebProxy _webProxy = new RunnerWebProxy();
 
@@ -437,6 +439,18 @@ namespace GitHub.Runner.Common
             set
             {
                 _startupType = value;
+            }
+        }
+
+        public bool AllowDockerInDocker
+        {
+            get
+            {
+                return _allowDockerInDocker;
+            }
+            set
+            {
+                _allowDockerInDocker = value;
             }
         }
 

--- a/src/Runner.Listener/CommandSettings.cs
+++ b/src/Runner.Listener/CommandSettings.cs
@@ -27,6 +27,7 @@ namespace GitHub.Runner.Listener
 
         private readonly string[] validFlags =
         {
+            Constants.Runner.CommandLine.Flags.AllowDockerInDocker,
             Constants.Runner.CommandLine.Flags.Commit,
             Constants.Runner.CommandLine.Flags.Help,
             Constants.Runner.CommandLine.Flags.Replace,
@@ -64,6 +65,8 @@ namespace GitHub.Runner.Listener
         public bool Version => TestFlag(Constants.Runner.CommandLine.Flags.Version);
 
         public bool RunOnce => TestFlag(Constants.Runner.CommandLine.Flags.Once);
+
+        public bool AllowDockerInDocker => TestFlag(Constants.Runner.CommandLine.Flags.AllowDockerInDocker);
 
         // Constructor.
         public CommandSettings(IHostContext context, string[] args)

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -192,6 +192,9 @@ namespace GitHub.Runner.Listener
                     Trace.Info($"Set runner startup type - {startType}");
                     HostContext.StartupType = startType;
 
+                    Trace.Info($"Set runner allowDockerInDocker - {command.AllowDockerInDocker}");
+                    HostContext.AllowDockerInDocker = command.AllowDockerInDocker;
+
                     // Run the runner interactively or as service
                     return await RunAsync(settings, command.RunOnce);
                 }

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -29,6 +29,7 @@ namespace GitHub.Runner.Common.Tests
         private AssemblyLoadContext _loadContext;
         private string _tempDirectoryRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("D"));
         private StartupType _startupType;
+        private bool _allowDockerInDocker;
         public event EventHandler Unloading;
         public CancellationToken RunnerShutdownToken => _runnerShutdownTokenSource.Token;
         public ShutdownReason RunnerShutdownReason { get; private set; }
@@ -83,6 +84,18 @@ namespace GitHub.Runner.Common.Tests
             set
             {
                 _startupType = value;
+            }
+        }
+
+        public bool AllowDockerInDocker
+        {
+            get
+            {
+                return _allowDockerInDocker;
+            }
+            set
+            {
+                _allowDockerInDocker = value;
             }
         }
 


### PR DESCRIPTION
Add `--allow-docker-in-docker` flag to optionally disable the `Container feature is not supported when runner is already running inside container` constraint.

This resolves an issue described in https://github.com/actions/runner/issues/367#issuecomment-597742895.

I am successfully using this change on my self-hosted runner infrastructure which mounts the host's docker socket into the container where the actions runner executes. 