### PR TITLE
Add expanded volumes strings to container mounts

### DIFF
--- a/src/Runner.Worker/Container/ContainerInfo.cs
+++ b/src/Runner.Worker/Container/ContainerInfo.cs
@@ -61,6 +61,7 @@ namespace GitHub.Runner.Worker.Container
                 foreach (var volume in container.Volumes)
                 {
                     UserMountVolumes[volume] = volume;
+                    MountVolumes.Add(new MountVolume(volume));
                 }
             }
 


### PR DESCRIPTION
We track the "user" vs "actual", eg UserMountVolumes and MountVolumes for the values given in a workflow vs their expanded values, and the expanded values are what are actually sent to docker when starting the container. 

We lost some history when we forked (https://github.com/actions/runner/blob/c8afc848403652f31f84eb362fc0696ee23cffca/src/Runner.Worker/JobRunner.cs#L124) 
so its unclear why this was removed in the first place

This does not just add it directly back because we moved where the expansion happens, bit the functionality is the same. Now, the values are expanded bu the time we create the ContainerInfo object 

Fixes https://github.com/actions/runner/issues/322