### PR TITLE
add github.url and github.api_url for ghes alpha

### DIFF
--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -10,6 +10,7 @@ namespace GitHub.Runner.Worker
         {
             "action",
             "actor",
+            "api_url", // temp for GHES alpha release
             "base_ref",
             "event_name",
             "event_path",
@@ -21,6 +22,7 @@ namespace GitHub.Runner.Worker
             "run_id",
             "run_number",
             "sha",
+            "url", // temp for GHES alpha release
             "workflow",
             "workspace",
         };


### PR DESCRIPTION
For GHES alpha release, expose GHES server URL and API URL for actions (e.g. where checkout should clone from)