### PR TITLE
Report git sha

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -393,7 +393,8 @@ namespace GitHub.Runner.Worker
             ArgUtil.NotNull(setupInfo, nameof(setupInfo));
             ArgUtil.NotNullOrEmpty(setupInfo.Container.Dockerfile, nameof(setupInfo.Container.Dockerfile));
 
-            executionContext.Output($"Build container for action use: '{setupInfo.Container.Dockerfile}'.");
+            string sourceVersion = executionContext.GetGitHubContext("sha");
+            executionContext.Output($"Build container for action use: '{setupInfo.Container.Dockerfile}' (git: {sourceVersion}).");
 
             // Build docker image with retry up to 3 times
             var dockerManger = HostContext.GetService<IDockerCommandManager>();


### PR DESCRIPTION
Currently if someone uses a github action by tag (as opposed to sha), there's no way to know what precise version of the action was used.

I'm not sure if this works as written, but I'd like something like this to be implemented.