### PR TITLE
launch middleman process on macOS to workaround SIP limit

### DIFF
--- a/src/Misc/layoutbin/macos-run-invoker.js
+++ b/src/Misc/layoutbin/macos-run-invoker.js
@@ -1,0 +1,13 @@
+const { spawn } = require('child_process');
+// argv[0] = node
+// argv[1] = macos-run-invoker.js
+var shell = process.argv[2];
+var args = process.argv.slice(3);
+console.log(`::debug::macos-run-invoker: ${shell}`);
+console.log(`::debug::macos-run-invoker: ${JSON.stringify(args)}`);
+var launch = spawn(shell, args, { stdio: 'inherit' });
+launch.on('exit', function (code) {
+    if (code !== 0) {
+        process.exit(code);
+    }
+});

--- a/src/Runner.Worker/Handlers/ScriptHandler.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandler.cs
@@ -259,6 +259,16 @@ namespace GitHub.Runner.Worker.Handlers
 
             // dump out the command
             var fileName = isContainerStepHost ? shellCommand : commandPath;
+#if OS_OSX
+            if (Environment.ContainsKey("DYLD_INSERT_LIBRARIES"))  // We don't check `isContainerStepHost` because we don't support container on macOS
+            {
+                // launch `node macOSRunInvoker.js shell args` instead of `shell args` to avoid macOS SIP remove `DYLD_INSERT_LIBRARIES` when launch process
+                string node12 = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node12", "bin", $"node{IOUtil.ExeExtension}");
+                string macOSRunInvoker = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), "macos-run-invoker.js");
+                arguments = $"\"{macOSRunInvoker.Replace("\"", "\\\"")}\" \"{fileName.Replace("\"", "\\\"")}\" {arguments}";
+                fileName = node12;
+            }
+#endif
             ExecutionContext.Debug($"{fileName} {arguments}");
 
             using (var stdoutManager = new OutputManager(ExecutionContext, ActionCommandManager))


### PR DESCRIPTION
When `DYLD_INSERT_LIBRARIES` set on macOS, SIP will remove it when launch process that under `/usr/bin`, ex: `bash`

We will use `node` as a proxy process on macOS when `DYLD_INSERT_LIBRARIES` is set to execute `runs` script.

More detail:
https://github.com/github/c2c-actions-runtime/issues/447