### PR TITLE
Revoke GITHUB_TOKEN at the end of the job.

### DIFF
--- a/src/Runner.Common/GitHubServer.cs
+++ b/src/Runner.Common/GitHubServer.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GitHub.Services.Common;
+
+namespace GitHub.Runner.Common
+{
+
+    public class GitHubResult
+    {
+        public HttpStatusCode StatusCode { get; set; }
+        public String Message { get; set; }
+        public HttpResponseHeaders Headers { get; set; }
+    }
+
+
+    [ServiceLocator(Default = typeof(GitHubServer))]
+    public interface IGitHubServer : IRunnerService
+    {
+        Task<GitHubResult> RevokeInstallationToken(string GithubApiUrl, string AccessToken);
+    }
+
+    public class GitHubServer : RunnerService, IGitHubServer
+    {
+        public async Task<GitHubResult> RevokeInstallationToken(string GithubApiUrl, string AccessToken)
+        {
+            var result = new GitHubResult();
+            var requestUrl = new UriBuilder(GithubApiUrl);
+            requestUrl.Path = requestUrl.Path.TrimEnd('/') + "/installation/token";
+
+            using (var httpClientHandler = HostContext.CreateHttpClientHandler())
+            using (var httpClient = HttpClientFactory.Create(httpClientHandler, new VssHttpRetryMessageHandler(3)))
+            {
+                httpClient.DefaultRequestHeaders.UserAgent.Add(HostContext.UserAgent);
+                var base64EncodingToken = Convert.ToBase64String(Encoding.UTF8.GetBytes($"x-access-token:{AccessToken}"));
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64EncodingToken);
+                var count = 1;
+                while (true)
+                {
+                    try
+                    {
+                        using (HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Delete, requestUrl.Uri))
+                        {
+                            requestMessage.Headers.Add("Accept", "application/vnd.github.gambit-preview+json");
+                            var response = await httpClient.SendAsync(requestMessage, CancellationToken.None);
+                            result.StatusCode = response.StatusCode;
+                            result.Headers = response.Headers;
+                            result.Message = await response.Content.ReadAsStringAsync();
+                            return result;
+                        }
+                    }
+                    catch (Exception ex) when (count++ < 3)
+                    {
+                        Trace.Error("Fail to revoke GITHUB_TOKEN, will try again later");
+                        Trace.Error(ex);
+                        var backoff = BackoffTimerHelper.GetRandomBackoff(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15));
+                        await Task.Delay(backoff);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -184,7 +184,7 @@ namespace GitHub.Runner.Worker
                 finally
                 {
                     Trace.Info("Finalize job.");
-                    jobExtension.FinalizeJob(jobContext, message, jobStartTimeUtc);
+                    await jobExtension.FinalizeJobAsync(jobContext, message, jobStartTimeUtc);
                 }
 
                 Trace.Info($"Job result after all job steps finish: {jobContext.Result ?? TaskResult.Succeeded}");

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -207,7 +207,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public void UploadDiganosticLogIfEnvironmentVariableSet()
+        public async Task UploadDiganosticLogIfEnvironmentVariableSet()
         {
             using (TestHostContext hc = CreateTestContext())
             {
@@ -220,7 +220,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 _jobEc.Initialize(hc);
                 _jobEc.InitializeJob(_message, _tokenSource.Token);
 
-                jobExtension.FinalizeJob(_jobEc, _message, DateTime.UtcNow);
+                await jobExtension.FinalizeJobAsync(_jobEc, _message, DateTime.UtcNow);
 
                 _diagnosticLogManager.Verify(x =>
                     x.UploadDiagnosticLogs(
@@ -235,7 +235,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public void DontUploadDiagnosticLogIfEnvironmentVariableFalse()
+        public async Task DontUploadDiagnosticLogIfEnvironmentVariableFalse()
         {
             using (TestHostContext hc = CreateTestContext())
             {
@@ -248,7 +248,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 _jobEc.Initialize(hc);
                 _jobEc.InitializeJob(_message, _tokenSource.Token);
 
-                jobExtension.FinalizeJob(_jobEc, _message, DateTime.UtcNow);
+                await jobExtension.FinalizeJobAsync(_jobEc, _message, DateTime.UtcNow);
 
                 _diagnosticLogManager.Verify(x =>
                     x.UploadDiagnosticLogs(
@@ -263,14 +263,14 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public void DontUploadDiagnosticLogIfEnvironmentVariableMissing()
+        public async Task DontUploadDiagnosticLogIfEnvironmentVariableMissing()
         {
             using (TestHostContext hc = CreateTestContext())
             {
                 var jobExtension = new JobExtension();
                 jobExtension.Initialize(hc);
 
-                jobExtension.FinalizeJob(_jobEc, _message, DateTime.UtcNow);
+                await jobExtension.FinalizeJobAsync(_jobEc, _message, DateTime.UtcNow);
 
                 _diagnosticLogManager.Verify(x =>
                     x.UploadDiagnosticLogs(


### PR DESCRIPTION
To prevent accidental exposure of GITHUB_TOKEN in the log.
We will revoke the token as soon as we finish the job on the runner.