### PR TITLE
Fix optional parameter for unattended

### DIFF
--- a/src/Runner.Listener/Configuration/PromptManager.cs
+++ b/src/Runner.Listener/Configuration/PromptManager.cs
@@ -72,6 +72,10 @@ namespace GitHub.Runner.Listener.Configuration
                 {
                     return defaultValue;
                 }
+                else if (isOptional) 
+                {
+                    return string.Empty;
+                }
 
                 // Otherwise throw.
                 throw new Exception($"Invalid configuration provided for {argName}. Terminating unattended configuration.");


### PR DESCRIPTION
Sets optional parameter to `string.Empty` for unattended.