### PR TITLE
ArgumentNullException: Value cannot be null, for anonymous volume mounts

### DIFF
--- a/src/Runner.Worker/Handlers/StepHost.cs
+++ b/src/Runner.Worker/Handlers/StepHost.cs
@@ -110,9 +110,9 @@ namespace GitHub.Runner.Worker.Handlers
 
             // try to resolve path inside container if the request path is part of the mount volume
 #if OS_WINDOWS
-            if (Container.MountVolumes.Exists(x => path.StartsWith(x.SourceVolumePath, StringComparison.OrdinalIgnoreCase)))
+            if (Container.MountVolumes.Exists(x => x != null && path.StartsWith(x.SourceVolumePath, StringComparison.OrdinalIgnoreCase)))
 #else
-            if (Container.MountVolumes.Exists(x => path.StartsWith(x.SourceVolumePath)))
+            if (Container.MountVolumes.Exists(x => x != null && path.StartsWith(x.SourceVolumePath)))
 #endif
             {
                 return Container.TranslateToContainerPath(path);

--- a/src/Runner.Worker/Handlers/StepHost.cs
+++ b/src/Runner.Worker/Handlers/StepHost.cs
@@ -110,9 +110,9 @@ namespace GitHub.Runner.Worker.Handlers
 
             // try to resolve path inside container if the request path is part of the mount volume
 #if OS_WINDOWS
-            if (Container.MountVolumes.Exists(x => x != null && path.StartsWith(x.SourceVolumePath, StringComparison.OrdinalIgnoreCase)))
+            if (Container.MountVolumes.Exists(x => x.SourceVolumePath != null && path.StartsWith(x.SourceVolumePath, StringComparison.OrdinalIgnoreCase)))
 #else
-            if (Container.MountVolumes.Exists(x => x != null && path.StartsWith(x.SourceVolumePath)))
+            if (Container.MountVolumes.Exists(x => x.SourceVolumePath != null && path.StartsWith(x.SourceVolumePath)))
 #endif
             {
                 return Container.TranslateToContainerPath(path);

--- a/src/Runner.Worker/Handlers/StepHost.cs
+++ b/src/Runner.Worker/Handlers/StepHost.cs
@@ -110,9 +110,9 @@ namespace GitHub.Runner.Worker.Handlers
 
             // try to resolve path inside container if the request path is part of the mount volume
 #if OS_WINDOWS
-            if (Container.MountVolumes.Exists(x => x.SourceVolumePath != null && path.StartsWith(x.SourceVolumePath, StringComparison.OrdinalIgnoreCase)))
+            if (Container.MountVolumes.Exists(x => !string.IsNullOrEmpty(x.SourceVolumePath) && path.StartsWith(x.SourceVolumePath, StringComparison.OrdinalIgnoreCase)))
 #else
-            if (Container.MountVolumes.Exists(x => x.SourceVolumePath != null && path.StartsWith(x.SourceVolumePath)))
+            if (Container.MountVolumes.Exists(x => !string.IsNullOrEmpty(x.SourceVolumePath) && path.StartsWith(x.SourceVolumePath)))
 #endif
             {
                 return Container.TranslateToContainerPath(path);


### PR DESCRIPTION
This was introduced due to https://github.com/actions/runner/pull/384

Given a workflow like:
```yaml
jobs:
  test:
    runs-on: ubuntu-latest
    container:
      image: ubuntu
      volumes:
        - /data
  steps:
  - run: echo hi
```

we now properly mount the anonymous volume per https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontainervolumes 

But anonymous volumes do not have a source path, so the SourceVolume is null and we cant resolve those paths from host to container. We get the following exception:

```
##[error]Value cannot be null. (Parameter 'value')
##[debug]System.ArgumentNullException: Value cannot be null. (Parameter 'value')
##[debug]   at System.String.StartsWith(String value)
##[debug]   at GitHub.Runner.Worker.Handlers.ContainerStepHost.<>c__DisplayClass14_0.<ResolvePathForStepHost>b__0(MountVolume x) in /home/dakale/dev/runner/src/Runner.Worker/Handlers/StepHost.cs:line 115
##[debug]   at System.Collections.Generic.List`1.FindIndex(Int32 startIndex, Int32 count, Predicate`1 match)
##[debug]   at System.Collections.Generic.List`1.Exists(Predicate`1 match)
##[debug]   at GitHub.Runner.Worker.Handlers.ContainerStepHost.ResolvePathForStepHost(String path) in /home/dakale/dev/runner/src/Runner.Worker/Handlers/StepHost.cs:line 115
##[debug]   at GitHub.Runner.Worker.Handlers.ScriptHandler.RunAsync(ActionRunStage stage) in /home/dakale/dev/runner/src/Runner.Worker/Handlers/ScriptHandler.cs:line 225
##[debug]   at GitHub.Runner.Worker.ActionRunner.RunAsync() in /home/dakale/dev/runner/src/Runner.Worker/ActionRunner.cs:line 205
##[debug]   at GitHub.Runner.Worker.StepsRunner.RunStepAsync(IStep step, CancellationToken 
```

If the volume mount is coming from an anonymous volume the target script to run in the container can not possibly exist in that volume on the host, since these volumes are created on the fly, so theres no need to try to resolve the container path for that mount 

I believe this was not an issue in the past due to changing when we expand and add the full MountVolumes objects to the ContainerInfo