### PR TITLE
Make release notes code blocks copy-paste-able

### DIFF
--- a/releaseNote.md
+++ b/releaseNote.md
@@ -8,13 +8,15 @@
   - N/A
 
 ## Windows x64
-We recommend configuring the runner in a root folder of the Windows drive (e.g. "C:\actions-runner"). This will help avoid issues related to service identity folder permissions and long file path restrictions on Windows
-``` 
-// Create a folder under the drive root
+We recommend configuring the runner in a root folder of the Windows drive (e.g. "C:\actions-runner"). This will help avoid issues related to service identity folder permissions and long file path restrictions on Windows.
+
+The following snipped needs to be run on `powershell`:
+``` powershell
+# Create a folder under the drive root
 mkdir \actions-runner ; cd \actions-runner
-// Download the latest runner package
+# Download the latest runner package
 Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/v<RUNNER_VERSION>/actions-runner-win-x64-<RUNNER_VERSION>.zip -OutFile actions-runner-win-x64-<RUNNER_VERSION>.zip
-// Extract the installer
+# Extract the installer
 Add-Type -AssemblyName System.IO.Compression.FileSystem ; 
 [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD\actions-runner-win-x64-<RUNNER_VERSION>.zip", "$PWD")
 ```
@@ -22,44 +24,44 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem ;
 ## OSX
 
 ``` bash
-// Create a folder
+# Create a folder
 mkdir actions-runner && cd actions-runner
-// Download the latest runner package
+# Download the latest runner package
 curl -O -L https://github.com/actions/runner/releases/download/v<RUNNER_VERSION>/actions-runner-osx-x64-<RUNNER_VERSION>.tar.gz
-// Extract the installer
+# Extract the installer
 tar xzf ./actions-runner-osx-x64-<RUNNER_VERSION>.tar.gz
 ```
 
 ## Linux x64
 
 ``` bash
-// Create a folder
+# Create a folder
 mkdir actions-runner && cd actions-runner
-// Download the latest runner package
+# Download the latest runner package
 curl -O -L https://github.com/actions/runner/releases/download/v<RUNNER_VERSION>/actions-runner-linux-x64-<RUNNER_VERSION>.tar.gz
-// Extract the installer
+# Extract the installer
 tar xzf ./actions-runner-linux-x64-<RUNNER_VERSION>.tar.gz
 ```
 
 ## Linux arm64 (Pre-release)
 
 ``` bash
-// Create a folder
+# Create a folder
 mkdir actions-runner && cd actions-runner
-// Download the latest runner package
+# Download the latest runner package
 curl -O -L https://github.com/actions/runner/releases/download/v<RUNNER_VERSION>/actions-runner-linux-arm64-<RUNNER_VERSION>.tar.gz
-// Extract the installer
+# Extract the installer
 tar xzf ./actions-runner-linux-arm64-<RUNNER_VERSION>.tar.gz
 ```
 
 ## Linux arm (Pre-release)
 
 ``` bash
-// Create a folder
+# Create a folder
 mkdir actions-runner && cd actions-runner
-// Download the latest runner package
+# Download the latest runner package
 curl -O -L https://github.com/actions/runner/releases/download/v<RUNNER_VERSION>/actions-runner-linux-arm-<RUNNER_VERSION>.tar.gz
-// Extract the installer
+# Extract the installer
 tar xzf ./actions-runner-linux-arm-<RUNNER_VERSION>.tar.gz
 ```
 


### PR DESCRIPTION
The release notes used C-style comments (`//`) instead of shell-style (`#`),
causing the code snippet to not be easily copy-paste-able.

Additionally, the code fence for Windows had the extra `powershell` added,
as well as a comment to direct users towards `powershell` over `cmd`.