### PR TITLE
Use the API_URL and munge action URLs for GHES

### DIFF
--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -614,9 +614,7 @@ namespace GitHub.Runner.Common
         public static HttpClientHandler CreateHttpClientHandler(this IHostContext context)
         {
             var handlerFactory = context.GetService<IHttpClientHandlerFactory>();
-            var clientHandler = handlerFactory.CreateClientHandler();
-            clientHandler.Proxy = context.WebProxy;
-            return clientHandler;
+            return handlerFactory.CreateClientHandler(context.WebProxy);
         }
     }
 

--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -1,19 +1,18 @@
-﻿using GitHub.Runner.Common.Util;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Diagnostics;
-using System.Net.Http;
-using System.Diagnostics.Tracing;
 using GitHub.DistributedTask.Logging;
-using System.Net.Http.Headers;
 using GitHub.Runner.Sdk;
 
 namespace GitHub.Runner.Common
@@ -614,7 +613,8 @@ namespace GitHub.Runner.Common
     {
         public static HttpClientHandler CreateHttpClientHandler(this IHostContext context)
         {
-            HttpClientHandler clientHandler = new HttpClientHandler();
+            var handlerFactory = context.GetService<IHttpClientHandlerFactory>();
+            var clientHandler = handlerFactory.CreateClientHandler();
             clientHandler.Proxy = context.WebProxy;
             return clientHandler;
         }

--- a/src/Runner.Common/HttpClientHandlerFactory.cs
+++ b/src/Runner.Common/HttpClientHandlerFactory.cs
@@ -1,0 +1,22 @@
+using System.Net.Http;
+
+namespace GitHub.Runner.Common
+{
+    [ServiceLocator(Default = typeof(HttpClientHandlerFactory))]
+    public interface IHttpClientHandlerFactory : IRunnerService
+    {
+        HttpClientHandler CreateClientHandler();
+    }
+
+    public class HttpClientHandlerFactory : IHttpClientHandlerFactory
+    {
+        public HttpClientHandler CreateClientHandler()
+        {
+            return new HttpClientHandler();
+        }
+
+        public void Initialize(IHostContext context)
+        {
+        }
+    }
+}

--- a/src/Runner.Common/HttpClientHandlerFactory.cs
+++ b/src/Runner.Common/HttpClientHandlerFactory.cs
@@ -1,18 +1,19 @@
 using System.Net.Http;
+using GitHub.Runner.Sdk;
 
 namespace GitHub.Runner.Common
 {
     [ServiceLocator(Default = typeof(HttpClientHandlerFactory))]
     public interface IHttpClientHandlerFactory : IRunnerService
     {
-        HttpClientHandler CreateClientHandler();
+        HttpClientHandler CreateClientHandler(RunnerWebProxy webProxy);
     }
 
     public class HttpClientHandlerFactory : IHttpClientHandlerFactory
     {
-        public HttpClientHandler CreateClientHandler()
+        public HttpClientHandler CreateClientHandler(RunnerWebProxy webProxy)
         {
-            return new HttpClientHandler();
+            return new HttpClientHandler() { Proxy = webProxy };
         }
 
         public void Initialize(IHostContext context)

--- a/src/Runner.Common/HttpClientHandlerFactory.cs
+++ b/src/Runner.Common/HttpClientHandlerFactory.cs
@@ -9,15 +9,11 @@ namespace GitHub.Runner.Common
         HttpClientHandler CreateClientHandler(RunnerWebProxy webProxy);
     }
 
-    public class HttpClientHandlerFactory : IHttpClientHandlerFactory
+    public class HttpClientHandlerFactory : RunnerService, IHttpClientHandlerFactory
     {
         public HttpClientHandler CreateClientHandler(RunnerWebProxy webProxy)
         {
             return new HttpClientHandler() { Proxy = webProxy };
-        }
-
-        public void Initialize(IHostContext context)
-        {
         }
     }
 }

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -504,6 +504,7 @@ namespace GitHub.Runner.Worker
                 string archiveLink = BuildLinkToActionArchive(apiUrl, repositoryReference.Name, repositoryReference.Ref);
                 Trace.Info($"Download archive '{archiveLink}' to '{destDirectory}'.");
                 await DownloadRepositoryActionAsync(executionContext, archiveLink, destDirectory);
+                return;
             }
             else
             {

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -522,10 +522,6 @@ namespace GitHub.Runner.Worker
                     BuildLinkToActionArchive(apiUrl, $"actions/community-{repositoryReference.Name.Replace("/", "_")}", repositoryReference.Ref)
                 };
 
-                // // https://api.github.com/repos/{repository}/zipball/{ref}  - An action on DotCom, if fallback is allowed
-                // string dotComApiUrl = GetApiUrl(executionContext, forceDotCom: true);
-                // archiveLinks.Add(BuildLinkToActionArchive(dotComApiUrl), repositoryReference.Name, repositoryReference.Ref);
-
                 foreach (var archiveLink in archiveLinks)
                 {
                     Trace.Info($"Download archive '{archiveLink}' to '{destDirectory}'.");

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -623,7 +623,7 @@ namespace GitHub.Runner.Worker
                                 {
                                     if (response.IsSuccessStatusCode)
                                     {
-                                        using (var result = await httpClient.GetStreamAsync(link))
+                                        using (var result = await response.Content.ReadAsStreamAsync())
                                         {
                                             await result.CopyToAsync(fs, _defaultCopyBufferSize, actionDownloadCancellation.Token);
                                             await fs.FlushAsync(actionDownloadCancellation.Token);

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -528,13 +528,13 @@ namespace GitHub.Runner.Worker
                         await DownloadRepositoryActionAsync(executionContext, archiveLink, destDirectory);
                         return;
                     }
-                    catch (ActionNotFoundException ex)
+                    catch (ActionNotFoundException)
                     {
-                        Trace.Info($"Failed to find the action at {ex.ActionUri}");
+                        Trace.Info($"Failed to find the action '{repositoryReference.Name}' at {archiveLink}");
                         continue;
                     }
                 }
-                throw new NotSupportedException($"Failed to find the action '{repositoryReference.Name}'.  Paths attempted: {string.Join(", ", archiveLinks)}");
+                throw new ActionNotFoundException($"Failed to find the action '{repositoryReference.Name}'.  Paths attempted: {string.Join(", ", archiveLinks)}");
             }
         }
 
@@ -635,7 +635,7 @@ namespace GitHub.Runner.Worker
                                     else if (response.StatusCode == HttpStatusCode.NotFound)
                                     {
                                         // It doesn't make sense to retry in this case, so just stop
-                                        throw new ActionNotFoundException(link);
+                                        throw new ActionNotFoundException(new Uri(link));
                                     }
                                     else
                                     {
@@ -650,9 +650,9 @@ namespace GitHub.Runner.Worker
                             Trace.Info("Action download has been cancelled.");
                             throw;
                         }
-                        catch (ActionNotFoundException ex)
+                        catch (ActionNotFoundException)
                         {
-                            Trace.Info($"The action at '{ex.ActionUri}' does not exist");
+                            Trace.Info($"The action at '{link}' does not exist");
                             throw;
                         }
                         catch (Exception ex) when (retryCount < 2)

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -71,13 +71,7 @@ namespace GitHub.Runner.Worker
             }
 
             // Clear the cache (for self-hosted runners)
-            // Note, temporarily avoid this step for the on-premises product, to avoid rate limiting.
-            var configurationStore = HostContext.GetService<IConfigurationStore>();
-            var isHostedServer = configurationStore.GetSettings().IsHostedServer;
-            if (isHostedServer)
-            {
-                IOUtil.DeleteDirectory(HostContext.GetDirectory(WellKnownDirectory.Actions), executionContext.CancellationToken);
-            }
+            IOUtil.DeleteDirectory(HostContext.GetDirectory(WellKnownDirectory.Actions), executionContext.CancellationToken);
 
             foreach (var action in actions)
             {

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -531,11 +531,11 @@ namespace GitHub.Runner.Worker
                     }
                     catch (ActionNotFoundException)
                     {
-                        Trace.Info($"Failed to find the action '{repositoryReference.Name}' at {archiveLink}");
+                        Trace.Info($"Failed to find the action '{repositoryReference.Name}' at ref '{repositoryReference.Ref}' at {archiveLink}");
                         continue;
                     }
                 }
-                throw new ActionNotFoundException($"Failed to find the action '{repositoryReference.Name}'.  Paths attempted: {string.Join(", ", archiveLinks)}");
+                throw new ActionNotFoundException($"Failed to find the action '{repositoryReference.Name}' at ref '{repositoryReference.Ref}'.  Paths attempted: {string.Join(", ", archiveLinks)}");
             }
         }
 

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -500,7 +500,7 @@ namespace GitHub.Runner.Worker
             var isHostedServer = configurationStore.GetSettings().IsHostedServer;
             if (isHostedServer)
             {
-                string apiUrl = GetApiUrl(executionContext, forceDotCom: true);
+                string apiUrl = GetApiUrl(executionContext);
                 string archiveLink = BuildLinkToActionArchive(apiUrl, repositoryReference.Name, repositoryReference.Ref);
                 Trace.Info($"Download archive '{archiveLink}' to '{destDirectory}'.");
                 await DownloadRepositoryActionAsync(executionContext, archiveLink, destDirectory);
@@ -538,18 +538,15 @@ namespace GitHub.Runner.Worker
             }
         }
 
-        private string GetApiUrl(IExecutionContext executionContext, bool forceDotCom = false)
+        private string GetApiUrl(IExecutionContext executionContext)
         {
-            if (forceDotCom)
-            {
-                return "https://api.github.com";
-            }
             string apiUrl = executionContext.GetGitHubContext("api_url");
-            if (string.IsNullOrEmpty(apiUrl))
+            if (!string.IsNullOrEmpty(apiUrl))
             {
-                throw new InvalidOperationException("Cannot get the link to the action archive: 'api_url' is not defined");
+                return apiUrl;
             }
-            return apiUrl;
+            // Once the api_url is set for hosted, we can remove this fallback (it doesn't make sense for GHES)
+            return "https://api.github.com";
         }
 
         private static string BuildLinkToActionArchive(string apiUrl, string repository, string @ref)

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -517,8 +517,8 @@ namespace GitHub.Runner.Worker
                     BuildLinkToActionArchive(apiUrl, repositoryReference.Name, repositoryReference.Ref),
 
                     // A community action, synced to their GHES instance
-                    // Example:  https://my-ghes/api/v3/repos/actions-community/some-org_some-action/tarball/v1
-                    BuildLinkToActionArchive(apiUrl, $"actions-community/{repositoryReference.Name.Replace("/", "_")}", repositoryReference.Ref)
+                    // Example:  https://my-ghes/api/v3/repos/actions-community/some-org-some-action/tarball/v1
+                    BuildLinkToActionArchive(apiUrl, $"actions-community/{repositoryReference.Name.Replace("/", "-")}", repositoryReference.Ref)
                 };
 
                 foreach (var archiveLink in archiveLinks)

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -511,10 +511,13 @@ namespace GitHub.Runner.Worker
 
                 // URLs to try:
                 var archiveLinks = new List<string> {
-                    // API_URL/repos/{repository}/zipball/{ref}  - A built-in action or an action the user has created, on their GHES instance
+                    // A built-in action or an action the user has created, on their GHES instance
+                    // Example:  https://my-ghes/api/v3/repos/my-org/my-action/tarball/v1
                     BuildLinkToActionArchive(apiUrl, repositoryReference.Name, repositoryReference.Ref),
-                    // API_URL/repos/actions/community-{repository.replace(/,_)}/zipball/{ref}  - A community action, synced to their GHES instance
-                    BuildLinkToActionArchive(apiUrl, $"actions/community-{repositoryReference.Name.Replace("/", "_")}", repositoryReference.Ref)
+
+                    // A community action, synced to their GHES instance
+                    // Example:  https://my-ghes/api/v3/repos/actions-community/some-org_some-action/tarball/v1
+                    BuildLinkToActionArchive(apiUrl, $"actions-community/{repositoryReference.Name.Replace("/", "_")}", repositoryReference.Ref)
                 };
 
                 foreach (var archiveLink in archiveLinks)

--- a/src/Runner.Worker/ActionNotFoundException.cs
+++ b/src/Runner.Worker/ActionNotFoundException.cs
@@ -5,22 +5,19 @@ namespace GitHub.Runner.Worker
 {
     public class ActionNotFoundException : Exception
     {
-        public ActionNotFoundException(string actionUri)
+        public ActionNotFoundException(Uri actionUri)
             : base(FormatMessage(actionUri))
         {
-            ActionUri = actionUri;
         }
 
-        public ActionNotFoundException(string actionUri, string message)
+        public ActionNotFoundException(string message)
             : base(message)
         {
-            ActionUri = actionUri;
         }
 
-        public ActionNotFoundException(string actionUri, string message, System.Exception inner)
+        public ActionNotFoundException(string message, System.Exception inner)
             : base(message, inner)
         {
-            ActionUri = actionUri;
         }
 
         protected ActionNotFoundException(SerializationInfo info, StreamingContext context)
@@ -28,9 +25,7 @@ namespace GitHub.Runner.Worker
         {
         }
 
-        public string ActionUri { get; }
-
-        private static string FormatMessage(string actionUri)
+        private static string FormatMessage(Uri actionUri)
         {
             return $"An action could not be found at the URI '{actionUri}'";
         }

--- a/src/Runner.Worker/ActionNotFoundException.cs
+++ b/src/Runner.Worker/ActionNotFoundException.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace GitHub.Runner.Worker
+{
+    public class ActionNotFoundException : Exception
+    {
+        public ActionNotFoundException(string actionUri)
+            : base(FormatMessage(actionUri))
+        {
+            ActionUri = actionUri;
+        }
+
+        public ActionNotFoundException(string actionUri, string message)
+            : base(message)
+        {
+            ActionUri = actionUri;
+        }
+
+        public ActionNotFoundException(string actionUri, string message, System.Exception inner)
+            : base(message, inner)
+        {
+            ActionUri = actionUri;
+        }
+
+        protected ActionNotFoundException(SerializationInfo info, StreamingContext context)
+                : base(info, context)
+        {
+        }
+
+        public string ActionUri { get; }
+
+        private static string FormatMessage(string actionUri)
+        {
+            return $"An action could not be found at the URI '{actionUri}'";
+        }
+    }
+}

--- a/src/Test/L0/RunnerWebProxyL0.cs
+++ b/src/Test/L0/RunnerWebProxyL0.cs
@@ -16,7 +16,9 @@ namespace GitHub.Runner.Common.Tests
         private static readonly List<string> SkippedFiles = new List<string>()
         {
             "Runner.Common\\HostContext.cs",
-            "Runner.Common/HostContext.cs"
+            "Runner.Common/HostContext.cs",
+            "Runner.Common\\HttpClientHandlerFactory.cs",
+            "Runner.Common/HttpClientHandlerFactory.cs"
         };
 
         [Fact]

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -1891,11 +1891,13 @@ runs:
 ";
             CreateAction(yamlContent: Content, instance: out _, directory: out string directory);
 
-            var archiveFile = Path.Combine(_hc.GetDirectory(WellKnownDirectory.Temp), Path.GetTempFileName());
+            var tempDir = _hc.GetDirectory(WellKnownDirectory.Temp);
+            Directory.CreateDirectory(tempDir);
+            var archiveFile = Path.Combine(tempDir, Path.GetRandomFileName());
             var trace = _hc.GetTrace();
 
 #if OS_WINDOWS
-            ZipFile.CreateFromDirectory(archiveFile, directory);
+            ZipFile.CreateFromDirectory(directory, archiveFile, CompressionLevel.Fastest, includeBaseDirectory: true);
             return Task.FromResult(archiveFile);
 #else
             string tar = WhichUtil.Which("tar", require: true, trace: trace);

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -181,7 +181,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 // Arrange
                 Setup();
                 const string ActionName = "ownerName/sample-action";
-                const string MungedActionName = "actions-community/ownerName_sample-action";
+                const string MungedActionName = "actions-community/ownerName-sample-action";
                 var actions = new List<Pipelines.ActionStep>
                 {
                     new Pipelines.ActionStep()

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -278,7 +278,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Func<Task> action = async () => await _actionManager.PrepareActionsAsync(_ec.Object, actions);
 
                 //Assert
-                await Assert.ThrowsAsync<NotSupportedException>(action);
+                await Assert.ThrowsAsync<ActionNotFoundException>(action);
 
                 var watermarkFile = Path.Combine(_hc.GetDirectory(WellKnownDirectory.Actions), ActionName, "master.completed");
                 Assert.False(File.Exists(watermarkFile));

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -1920,9 +1920,14 @@ runs:
 
         /// <summary>
         /// Creates a sample action in an archive on disk, similar to the archive
-        /// retrieved from GitHub' or GHES' repository API.
+        /// retrieved from GitHub's or GHES' repository API.
         /// </summary>
+        /// <returns>The path on disk to the archive.</returns>
+#if OS_WINDOWS
+        private Task<string> CreateRepoArchive()
+#else
         private async Task<string> CreateRepoArchive()
+#endif
         {
             const string Content = @"
 # Container action
@@ -1942,6 +1947,7 @@ runs:
 
 #if OS_WINDOWS
             ZipFile.CreateFromDirectory(archiveFile, directory);
+            return Task.FromResult(archiveFile);
 #else
             string tar = WhichUtil.Which("tar", require: true, trace: trace);
 
@@ -1973,8 +1979,8 @@ runs:
                     throw new NotSupportedException($"Can't use 'tar -czf' to create archive file: {archiveFile}. return code: {exitCode}.");
                 }
             }
-#endif
             return archiveFile;
+#endif
         }
 
         private static string GetLinkToActionArchive(string apiUrl, string repository, string @ref)

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -181,7 +181,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 // Arrange
                 Setup();
                 const string ActionName = "ownerName/sample-action";
-                const string MungedActionName = "actions/community-ownerName_sample-action";
+                const string MungedActionName = "actions-community/ownerName_sample-action";
                 var actions = new List<Pipelines.ActionStep>
                 {
                     new Pipelines.ActionStep()

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -285,57 +285,6 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 var actionYamlFile = Path.Combine(_hc.GetDirectory(WellKnownDirectory.Actions), ActionName, "master", "action.yml");
                 Assert.False(File.Exists(actionYamlFile));
-            }
-            finally
-            {
-                Teardown();
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Worker")]
-        public async void PrepareActions_SkipDownloadActionFromGraphWhenCached_OnPremises()
-        {
-            try
-            {
-                // Arrange
-                Setup();
-                var actionId = Guid.NewGuid();
-                var actions = new List<Pipelines.ActionStep>
-                {
-                    new Pipelines.ActionStep()
-                    {
-                        Name = "action",
-                        Id = actionId,
-                        Reference = new Pipelines.RepositoryPathReference()
-                        {
-                            Name = "actions/no-such-action",
-                            Ref = "master",
-                            RepositoryType = "GitHub"
-                        }
-                    }
-                };
-                _configurationStore.Object.GetSettings().IsHostedServer = false;
-                var actionDirectory = Path.Combine(_hc.GetDirectory(WellKnownDirectory.Actions), "actions/no-such-action", "master");
-                Directory.CreateDirectory(actionDirectory);
-                var watermarkFile = $"{actionDirectory}.completed";
-                File.WriteAllText(watermarkFile, DateTime.UtcNow.ToString());
-                var actionFile = Path.Combine(actionDirectory, "action.yml");
-                File.WriteAllText(actionFile, @"
-name: ""no-such-action""
-runs:
-  using: node12
-  main: no-such-action.js
-");
-                var testFile = Path.Combine(actionDirectory, "test-file");
-                File.WriteAllText(testFile, "asdf");
-
-                // Act
-                await _actionManager.PrepareActionsAsync(_ec.Object, actions);
-
-                // Assert
-                Assert.True(File.Exists(testFile));
             }
             finally
             {


### PR DESCRIPTION
## Background
The runner downloads actions by creating a URL based on the name and ref specified in the workflow.  For example, for the step `uses: foo/bar@v1` the runner will attempt to download `https://api.github.com/repos/foo/bar/zipball/v1`.  

This has two issues related to GHES:
1. Runners connected to a GHES instance should retrieve all of their actions from GHES and not dotcom.
1. Since we're planning to allow the user to import certain community actions into GHES, we need to munge the URL to point to these imported actions.

## Solution

The API root URL is currently stored in the context as `api_url`, so the runner can use that to point to the GHES instance.  

Munging the URL is simple, but the retry logic needed to change a bit since `uses: foo/bar@v1` could be referencing an org/repo in GHES or an imported action.  In this PR, I changed the action download logic to consider if the runner is connected to GHES or dotcom.  If GHES, first look for the action by name as usual (from the GHES instance).  If that 404s, then munge the URL to look for an imported action.  In both GHES and hosted cases, 404s are detected and no retry is performed.

TODO: Testing with an actual GHES instance