### PR TITLE
Help trace worker crash in Kusto.

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -137,6 +137,8 @@ namespace GitHub.Runner.Common
                 public const int RunnerUpdating = 3;
                 public const int RunOnceRunnerUpdating = 4;
             }
+
+            public static readonly string WorkerCrashIssueDataKey = "_worker_crash_unhandled_exception";
         }
 
         public static class RunnerEvent

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -138,7 +138,8 @@ namespace GitHub.Runner.Common
                 public const int RunOnceRunnerUpdating = 4;
             }
 
-            public static readonly string WorkerCrashIssueDataKey = "_worker_crash_unhandled_exception";
+            public static readonly string InternalTelemetryIssueDataKey = "_internal_telemetry";
+            public static readonly string WorkerCrash = "WORKER_CRASH";
         }
 
         public static class RunnerEvent

--- a/src/Runner.Listener/JobDispatcher.cs
+++ b/src/Runner.Listener/JobDispatcher.cs
@@ -952,7 +952,7 @@ namespace GitHub.Runner.Listener
                 TimelineRecord jobRecord = timeline.Records.FirstOrDefault(x => x.Id == message.JobId && x.RecordType == "Job");
                 ArgUtil.NotNull(jobRecord, nameof(jobRecord));
                 var unhandledExceptionIssue = new Issue() { Type = IssueType.Error, Message = errorMessage };
-                unhandledExceptionIssue.Data[Constants.Runner.WorkerCrashIssueDataKey] = string.Empty;
+                unhandledExceptionIssue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.WorkerCrash;
                 jobRecord.ErrorCount++;
                 jobRecord.Issues.Add(unhandledExceptionIssue);
                 await jobServer.UpdateTimelineRecordsAsync(message.Plan.ScopeIdentifier, message.Plan.PlanType, message.Plan.PlanId, message.Timeline.Id, new TimelineRecord[] { jobRecord }, CancellationToken.None);

--- a/src/Runner.Listener/JobDispatcher.cs
+++ b/src/Runner.Listener/JobDispatcher.cs
@@ -858,7 +858,6 @@ namespace GitHub.Runner.Listener
             }
         }
 
-        // TODO: We need send detailInfo back to DT in order to add an issue for the job
         private async Task CompleteJobRequestAsync(int poolId, Pipelines.AgentJobRequestMessage message, Guid lockToken, TaskResult result, string detailInfo = null)
         {
             Trace.Entering();
@@ -952,8 +951,10 @@ namespace GitHub.Runner.Listener
                 ArgUtil.NotNull(timeline, nameof(timeline));
                 TimelineRecord jobRecord = timeline.Records.FirstOrDefault(x => x.Id == message.JobId && x.RecordType == "Job");
                 ArgUtil.NotNull(jobRecord, nameof(jobRecord));
+                var unhandledExceptionIssue = new Issue() { Type = IssueType.Error, Message = errorMessage };
+                unhandledExceptionIssue.Data["_worker_crash_unhandled_exception"] = string.Empty;
                 jobRecord.ErrorCount++;
-                jobRecord.Issues.Add(new Issue() { Type = IssueType.Error, Message = errorMessage });
+                jobRecord.Issues.Add(unhandledExceptionIssue);
                 await jobServer.UpdateTimelineRecordsAsync(message.Plan.ScopeIdentifier, message.Plan.PlanType, message.Plan.PlanId, message.Timeline.Id, new TimelineRecord[] { jobRecord }, CancellationToken.None);
             }
             catch (Exception ex)

--- a/src/Runner.Listener/JobDispatcher.cs
+++ b/src/Runner.Listener/JobDispatcher.cs
@@ -952,7 +952,7 @@ namespace GitHub.Runner.Listener
                 TimelineRecord jobRecord = timeline.Records.FirstOrDefault(x => x.Id == message.JobId && x.RecordType == "Job");
                 ArgUtil.NotNull(jobRecord, nameof(jobRecord));
                 var unhandledExceptionIssue = new Issue() { Type = IssueType.Error, Message = errorMessage };
-                unhandledExceptionIssue.Data["_worker_crash_unhandled_exception"] = string.Empty;
+                unhandledExceptionIssue.Data[Constants.Runner.WorkerCrashIssueDataKey] = string.Empty;
                 jobRecord.ErrorCount++;
                 jobRecord.Issues.Add(unhandledExceptionIssue);
                 await jobServer.UpdateTimelineRecordsAsync(message.Plan.ScopeIdentifier, message.Plan.PlanType, message.Plan.PlanId, message.Timeline.Id, new TimelineRecord[] { jobRecord }, CancellationToken.None);

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -486,7 +486,10 @@ namespace GitHub.Runner.Worker
 
             foreach (var property in command.Properties)
             {
-                issue.Data[property.Key] = property.Value;
+                if (!string.Equals(property.Key, Constants.Runner.WorkerCrashIssueDataKey, StringComparison.OrdinalIgnoreCase))
+                {
+                    issue.Data[property.Key] = property.Value;
+                }
             }
 
             context.AddIssue(issue);

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -486,7 +486,7 @@ namespace GitHub.Runner.Worker
 
             foreach (var property in command.Properties)
             {
-                if (!string.Equals(property.Key, Constants.Runner.WorkerCrashIssueDataKey, StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(property.Key, Constants.Runner.InternalTelemetryIssueDataKey, StringComparison.OrdinalIgnoreCase))
                 {
                     issue.Data[property.Key] = property.Value;
                 }


### PR DESCRIPTION
There was a bug in the Actions hosted runner virtual environment that causes the available disk space reduced. http://github.com/actions/virtual-environments/issues/709

Some customer's workflow used all disk space and cause the runner crash as well.

We want to get alert when the number of worker crash increase, so we can proactively investigate these issue instead of waiting for customer report.

Each worker crash means there is a failed workflow run and the customer is not happy with it.


