### PR TITLE
post-alpha fixes for github.url github.api_url and github.graphql_url

### DIFF
--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -10,10 +10,11 @@ namespace GitHub.Runner.Worker
         {
             "action",
             "actor",
-            "api_url", // temp for GHES alpha release
+            "api_url",
             "base_ref",
             "event_name",
             "event_path",
+            "graphql_url",
             "head_ref",
             "job",
             "ref",
@@ -22,7 +23,7 @@ namespace GitHub.Runner.Worker
             "run_id",
             "run_number",
             "sha",
-            "url", // temp for GHES alpha release
+            "url",
             "workflow",
             "workspace",
         };

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -131,7 +131,7 @@ namespace GitHub.Runner.Worker
                     // Temporary hack for GHES alpha
                     var configurationStore = HostContext.GetService<IConfigurationStore>();
                     var runnerSettings = configurationStore.GetSettings();
-                    if (!runnerSettings.IsHostedServer && !string.IsNullOrEmpty(runnerSettings.GitHubUrl))
+                    if (string.IsNullOrEmpty(context.GetGitHubContext("url")) && !runnerSettings.IsHostedServer && !string.IsNullOrEmpty(runnerSettings.GitHubUrl))
                     {
                         var url = new Uri(runnerSettings.GitHubUrl);
                         var portInfo = url.IsDefaultPort ? string.Empty : $":{url.Port.ToString(CultureInfo.InvariantCulture)}";


### PR DESCRIPTION
Post-alpha updates for handling github.url, github.api_url, and github.graphql_url:
- Propagate github.graphql_url to env vars
- Temporary back compat, check whether github.url is defined before adding value when not hosted