### PR TITLE
Adapt create-latest-svc.sh to work with GHES

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,4 @@
+# Sample scripts for self-hosted runners
+
+Here are some examples to work from if you'd like to automate your use of self-hosted runners.
+See the docs [here](../docs/automate.md).

--- a/scripts/create-latest-svc.sh
+++ b/scripts/create-latest-svc.sh
@@ -68,9 +68,9 @@ sudo -u ${svc_user} mkdir runner
 echo
 echo "Generating a registration token..."
 
-base_api_url="https://api.github.com/"
-if [ -z "${ghe_hostname}" ]; then
-    base_api_url="https://${ghe_hostname}/api/v3/"
+base_api_url="https://api.github.com"
+if [ -n "${ghe_hostname}" ]; then
+    base_api_url="https://${ghe_hostname}/api/v3"
 fi
 
 # if the scope has a slash, it's a repo runner
@@ -124,7 +124,7 @@ pushd ./runner
 # Unattend config
 #---------------------------------------
 runner_url="https://github.com/${runner_scope}"
-if [ -z "${ghe_hostname}" ]; then
+if [ -n "${ghe_hostname}" ]; then
     runner_url="https://${ghe_hostname}/${runner_scope}"
 fi
 
@@ -140,7 +140,7 @@ echo
 echo "Configuring as a service ..."
 prefix=""
 if [ "${runner_plat}" == "linux" ]; then
-    prefix="sudo "
+prefix="sudo "
 fi
 
 ${prefix}./svc.sh install ${svc_user}

--- a/scripts/create-latest-svc.sh
+++ b/scripts/create-latest-svc.sh
@@ -7,27 +7,29 @@ set -e
 # Configures as a service
 #
 # Examples:
-# RUNNER_CFG_PAT=<yourPAT> ./create-latest-svc.sh myuser/myrepo
-# RUNNER_CFG_PAT=<yourPAT> ./create-latest-svc.sh myorg
+# RUNNER_CFG_PAT=<yourPAT> ./create-latest-svc.sh myuser/myrepo my.ghe.deployment.net
+# RUNNER_CFG_PAT=<yourPAT> ./create-latest-svc.sh myorg my.ghe.deployment.net
 #
 # Usage:
 #     export RUNNER_CFG_PAT=<yourPAT>
-#     ./create-latest-svc scope [name] [user]
+#     ./create-latest-svc scope [ghe_domain] [name] [user]
 #
-#      scope required  repo (:owner/:repo) or org (:organization)
-#      name  optional  defaults to hostname
-#      user  optional  user svc will run as. defaults to current
-# 
+#      scope       required  repo (:owner/:repo) or org (:organization)
+#      ghe_domain  optional  the fully qualified domain name of your GitHub Enterprise Server deployment
+#      name        optional  defaults to hostname
+#      user        optional  user svc will run as. defaults to current
+#
 # Notes:
 # PATS over envvars are more secure
 # Should be used on VMs and not containers
-# Works on OSX and Linux 
+# Works on OSX and Linux
 # Assumes x64 arch
 #
 
 runner_scope=${1}
-runner_name=${2:-$(hostname)}
-svc_user=${3:-$USER}
+ghe_hostname=${2}
+runner_name=${3:-$(hostname)}
+svc_user=${4:-$USER}
 
 echo "Configuring runner @ ${runner_scope}"
 sudo echo
@@ -51,9 +53,9 @@ which curl || fatal "curl required.  Please install in PATH with apt-get, brew, 
 which jq || fatal "jq required.  Please install in PATH with apt-get, brew, etc"
 
 # bail early if there's already a runner there. also sudo early
-if [ -d ./runner ]; then 
+if [ -d ./runner ]; then
     fatal "Runner already exists.  Use a different directory or delete ./runner"
-fi 
+fi
 
 sudo -u ${svc_user} mkdir runner
 
@@ -66,15 +68,20 @@ sudo -u ${svc_user} mkdir runner
 echo
 echo "Generating a registration token..."
 
-# if the scope has a slash, it's an repo runner
-base_api_url="https://api.github.com/orgs"
-if [[ "$runner_scope" == *\/* ]]; then
-    base_api_url="https://api.github.com/repos"
+base_api_url="https://api.github.com/"
+if [ -z "${ghe_hostname}" ]; then
+    base_api_url="https://${ghe_hostname}/api/v3/"
 fi
 
-export RUNNER_TOKEN=$(curl -s -X POST ${base_api_url}/${runner_scope}/actions/runners/registration-token -H "accept: application/vnd.github.everest-preview+json" -H "authorization: token ${RUNNER_CFG_PAT}" | jq -r '.token')
+# if the scope has a slash, it's a repo runner
+orgs_or_repos="orgs"
+if [[ "$runner_scope" == *\/* ]]; then
+    orgs_or_repos="repos"
+fi
 
-if [ -z "$RUNNER_TOKEN" ]; then fatal "Failed to get a token"; fi 
+export RUNNER_TOKEN=$(curl -s -X POST ${base_api_url}/${orgs_or_repos}/${runner_scope}/actions/runners/registration-token -H "accept: application/vnd.github.everest-preview+json" -H "authorization: token ${RUNNER_CFG_PAT}" | jq -r '.token')
+
+if [ -z "$RUNNER_TOKEN" ]; then fatal "Failed to get a token"; fi
 
 #---------------------------------------
 # Download latest released and extract
@@ -82,6 +89,7 @@ if [ -z "$RUNNER_TOKEN" ]; then fatal "Failed to get a token"; fi
 echo
 echo "Downloading latest runner ..."
 
+# For the GHES Alpha, download the runner from github.com
 latest_version_label=$(curl -s -X GET 'https://api.github.com/repos/actions/runner/releases/latest' | jq -r '.tag_name')
 latest_version=$(echo ${latest_version_label:1})
 runner_file="actions-runner-${runner_plat}-x64-${latest_version}.tar.gz"
@@ -116,6 +124,10 @@ pushd ./runner
 # Unattend config
 #---------------------------------------
 runner_url="https://github.com/${runner_scope}"
+if [ -z "${ghe_hostname}" ]; then
+    runner_url="https://${ghe_hostname}/${runner_scope}"
+fi
+
 echo
 echo "Configuring ${runner_name} @ $runner_url"
 echo "./config.sh --unattended --url $runner_url --token *** --name $runner_name"
@@ -127,9 +139,9 @@ sudo -E -u ${svc_user} ./config.sh --unattended --url $runner_url --token $RUNNE
 echo
 echo "Configuring as a service ..."
 prefix=""
-if [ "${runner_plat}" == "linux" ]; then 
+if [ "${runner_plat}" == "linux" ]; then
     prefix="sudo "
-fi 
+fi
 
 ${prefix}./svc.sh install ${svc_user}
 ${prefix}./svc.sh start


### PR DESCRIPTION
With Actions on GHES under development, we'd like to be able to automate setting up runners while testing.

I've adapted this script to take an optional `ghe_domain` parameter.  If this is set, the script will use the given domain name for the GHES deployment.

**Testing**
* Configured a runner on a github.com repo
* Configured a runner on a GHES repo