### PR TITLE
Use an env var to point to an Actions Service dev instance

### DIFF
--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -92,9 +92,11 @@ namespace GitHub.Runner.Listener.Configuration
             _term.WriteSection("Authentication");
             while (true)
             {
-                // Get the URL
-                var inputUrl = command.GetUrl();
-                if (inputUrl.Contains("codedev.ms", StringComparison.OrdinalIgnoreCase))
+                // For testing against a dev deployment of Actions Service, set this environment variable to the deployment URL
+                var actionsServiceTestUrl = Environment.GetEnvironmentVariable("DEV_ACTIONS_SERVICE_TEST_URL");
+                var inputUrl = actionsServiceTestUrl ?? command.GetUrl();
+                if (inputUrl.Contains("codedev.ms", StringComparison.OrdinalIgnoreCase)
+                    || actionsServiceTestUrl != null)
                 {
                     runnerSettings.ServerUrl = inputUrl;
                     // Get the credentials

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -92,11 +92,11 @@ namespace GitHub.Runner.Listener.Configuration
             _term.WriteSection("Authentication");
             while (true)
             {
-                // For testing against a dev deployment of Actions Service, set this environment variable to the deployment URL
-                var actionsServiceTestUrl = Environment.GetEnvironmentVariable("DEV_ACTIONS_SERVICE_TEST_URL");
-                var inputUrl = actionsServiceTestUrl ?? command.GetUrl();
+                // When testing against a dev deployment of Actions Service, set this environment variable
+                var useDevActionsServiceUrl = Environment.GetEnvironmentVariable("USE_DEV_ACTIONS_SERVICE_URL");
+                var inputUrl = command.GetUrl();
                 if (inputUrl.Contains("codedev.ms", StringComparison.OrdinalIgnoreCase)
-                    || actionsServiceTestUrl != null)
+                    || useDevActionsServiceUrl != null)
                 {
                     runnerSettings.ServerUrl = inputUrl;
                     // Get the credentials


### PR DESCRIPTION
When running Actions Service L2 tests against GHES, the instance won't have a `codedev.ms` URL.   This adds the ability to specify the URL through the `USE_DEV_ACTIONS_SERVICE_URL` environment variable.

Unless someone wants to name their GHES instance `codedev.ms`, let's leave the old backdoor there for compat.

**Testing**
- We've been using this while hacking on L2s through a [special release](https://github.com/brcrista/runner/releases/tag/v2.169.0-l2.1).