### PR TITLE
Remove community actions munging and add dotcom fallback for downloading actions

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -503,7 +503,7 @@ namespace GitHub.Runner.Worker
                 string apiUrl = GetApiUrl(executionContext);
                 string archiveLink = BuildLinkToActionArchive(apiUrl, repositoryReference.Name, repositoryReference.Ref);
                 Trace.Info($"Download archive '{archiveLink}' to '{destDirectory}'.");
-                var downloadDetails = new ActionDownloadDetails(archiveLink, ConfigureAuthorization);
+                var downloadDetails = new ActionDownloadDetails(archiveLink, ConfigureAuthorizationFromContext);
                 await DownloadRepositoryActionAsync(executionContext, downloadDetails, destDirectory);
                 return;
             }
@@ -517,7 +517,7 @@ namespace GitHub.Runner.Worker
                     // Example:  https://my-ghes/api/v3/repos/my-org/my-action/tarball/v1
                     new ActionDownloadDetails(
                         BuildLinkToActionArchive(apiUrl, repositoryReference.Name, repositoryReference.Ref),
-                        ConfigureAuthorization),
+                        ConfigureAuthorizationFromContext),
 
                     // The same action, on GitHub.com
                     // Example:  https://api.github.com/repos/my-org/my-action/tarball/v1
@@ -736,7 +736,7 @@ namespace GitHub.Runner.Worker
             }
         }
 
-        private void ConfigureAuthorization(IExecutionContext executionContext, HttpClient httpClient)
+        private void ConfigureAuthorizationFromContext(IExecutionContext executionContext, HttpClient httpClient)
         {
             var authToken = Environment.GetEnvironmentVariable("_GITHUB_ACTION_TOKEN");
             if (string.IsNullOrEmpty(authToken))

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -174,14 +174,13 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_DownloadCommunityActionFromGraph_OnPremises()
+        public async void PrepareActions_DownloadActionFromDotCom_OnPremises()
         {
             try
             {
                 // Arrange
                 Setup();
                 const string ActionName = "ownerName/sample-action";
-                const string MungedActionName = "actions-community/ownerName-sample-action";
                 var actions = new List<Pipelines.ActionStep>
                 {
                     new Pipelines.ActionStep()
@@ -200,13 +199,13 @@ namespace GitHub.Runner.Common.Tests.Worker
                 // Return a valid action from GHES via mock
                 const string ApiUrl = "https://ghes.example.com/api/v3";
                 string builtInArchiveLink = GetLinkToActionArchive(ApiUrl, ActionName, "master");
-                string mungedArchiveLink = GetLinkToActionArchive(ApiUrl, MungedActionName, "master");
+                string dotcomArchiveLink = GetLinkToActionArchive("https://api.github.com", ActionName, "master");
                 string archiveFile = await CreateRepoArchive();
                 using var stream = File.OpenRead(archiveFile);
                 var mockClientHandler = new Mock<HttpClientHandler>();
                 mockClientHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(m => m.RequestUri == new Uri(builtInArchiveLink)), ItExpr.IsAny<CancellationToken>())
                     .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
-                mockClientHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(m => m.RequestUri == new Uri(mungedArchiveLink)), ItExpr.IsAny<CancellationToken>())
+                mockClientHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(m => m.RequestUri == new Uri(dotcomArchiveLink)), ItExpr.IsAny<CancellationToken>())
                     .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream) });
 
                 var mockHandlerFactory = new Mock<IHttpClientHandlerFactory>();


### PR DESCRIPTION
### Background
In #437 we added functionality to attempt to find an action in the `actions-community` org (on the GHES instance) if it was not found with its listed name-with-owner in the workflow. We're cutting that functionality for the current epic and instead will fallback to `github.com/org/action` in case the action cannot be found on `ghes-instance/org/action`.  This simplifies the workflow and lets us refine the scenario for importing actions into the GHES instance.

### In this PR
I replaced the munged community-actions URL with an equivalent URL for `github.com`.  The call to `github.com` is unauthenticated, which is a known limitation, but this is temporary until we can decide on the best way forward.  Some of this will likely be solved in https://github.com/github/c2c-actions-experience/issues/2727.

### Testing
- Updated unit tests
- Manually tested with actions that are and are not on the instance.  Logs show it's falling back correctly:
```
[2020-05-06 19:13:37Z INFO ActionManager] Download archive 'https://pjquirk-15887885337.service.bpdev-us-east-1.github.net/api/v3/repos/actions/checkout/tarball/v2' to '/Users/pjquirk/Source/GitHub/runner/_layout/_work/_actions/actions/checkout/v2'.
[2020-05-06 19:13:37Z INFO ActionManager] Save archive 'https://pjquirk-15887885337.service.bpdev-us-east-1.github.net/api/v3/repos/actions/checkout/tarball/v2' into /Users/pjquirk/Source/GitHub/runner/_layout/_work/_actions/_temp_cd622e14-018e-4892-b691-9d779d9b5fc8/b4306b3e-f345-418f-bf6c-36f00d236774.tar.gz.
[2020-05-06 19:13:37Z INFO ActionManager] The action at 'https://pjquirk-15887885337.service.bpdev-us-east-1.github.net/api/v3/repos/actions/checkout/tarball/v2' does not exist
[2020-05-06 19:13:37Z INFO ActionManager] Failed to find the action 'actions/checkout' at ref 'v2' at https://pjquirk-15887885337.service.bpdev-us-east-1.github.net/api/v3/repos/actions/checkout/tarball/v2
[2020-05-06 19:13:37Z INFO ActionManager] Download archive 'https://api.github.com/repos/actions/checkout/tarball/v2' to '/Users/pjquirk/Source/GitHub/runner/_layout/_work/_actions/actions/checkout/v2'.
[2020-05-06 19:13:37Z INFO ActionManager] Save archive 'https://api.github.com/repos/actions/checkout/tarball/v2' into /Users/pjquirk/Source/GitHub/runner/_layout/_work/_actions/_temp_c094527b-08cd-499b-ade3-75ccf81a423b/cd1a7f94-f1dc-4471-8497-f63e12ea787e.tar.gz.
[2020-05-06 19:13:37Z INFO ActionManager] Which: 'tar'
[2020-05-06 19:13:38Z INFO ActionManager] Location: '/usr/bin/tar'
[2020-05-06 19:13:38Z VERB ActionManager] Create watermark file indicate action download succeed.
[2020-05-06 19:13:38Z INFO ActionManager] Finished getting action repository.
```