### PR TITLE
update checkout@v1 for GHES

### DIFF
--- a/src/Runner.Plugins/Repository/v1.0/GitSourceProvider.cs
+++ b/src/Runner.Plugins/Repository/v1.0/GitSourceProvider.cs
@@ -80,7 +80,12 @@ namespace GitHub.Runner.Plugins.Repository.v1_0
             // Validate args.
             ArgUtil.NotNull(executionContext, nameof(executionContext));
             executionContext.Output($"Syncing repository: {repoFullName}");
-            Uri repositoryUrl = new Uri($"https://github.com/{repoFullName}");
+
+            // Repository URL
+            var githubUrl = executionContext.GetGitHubContext("url");
+            var githubUri = new Uri(!string.IsNullOrEmpty(githubUrl) ? githubUrl : "https://github.com");
+            var portInfo = githubUri.IsDefaultPort ? string.Empty : $":{githubUri.Port}";
+            Uri repositoryUrl = new Uri($"{githubUri.Scheme}://{githubUri.Host}{portInfo}/{repoFullName}");
             if (!repositoryUrl.IsAbsoluteUri)
             {
                 throw new InvalidOperationException("Repository url need to be an absolute uri.");


### PR DESCRIPTION
Update checkout@v1 to use the `github.url` when constructing the remote URL