### PR TITLE
docker build using -f instead of implied default 

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -438,7 +438,8 @@ namespace GitHub.Runner.Worker
             var imageName = $"{dockerManger.DockerInstanceLabel}:{Guid.NewGuid().ToString("N")}";
             while (retryCount < 3)
             {
-                buildExitCode = await dockerManger.DockerBuild(executionContext, setupInfo.Container.WorkingDirectory, Directory.GetParent(setupInfo.Container.Dockerfile).FullName, imageName);
+                buildExitCode = await dockerManger.DockerBuild(executionContext, setupInfo.Container.WorkingDirectory, setupInfo.Container.Dockerfile, imageName);
+                // buildExitCode = await dockerManger.DockerBuild(executionContext, setupInfo.Container.WorkingDirectory, Directory.GetParent(setupInfo.Container.Dockerfile).FullName, imageName);
                 if (buildExitCode == 0)
                 {
                     break;
@@ -740,6 +741,10 @@ namespace GitHub.Runner.Worker
 
                         setupInfo.Dockerfile = dockerFileFullPath;
                         setupInfo.WorkingDirectory = destDirectory;
+                        if (File.Exists(dockerFileFullPath))
+                        {
+
+                        }
                         return setupInfo;
                     }
                     else if (containerAction.Image.StartsWith("docker://", StringComparison.OrdinalIgnoreCase))

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -438,7 +438,12 @@ namespace GitHub.Runner.Worker
             var imageName = $"{dockerManger.DockerInstanceLabel}:{Guid.NewGuid().ToString("N")}";
             while (retryCount < 3)
             {
-                buildExitCode = await dockerManger.DockerBuild(executionContext, setupInfo.Container.WorkingDirectory, Directory.GetParent(setupInfo.Container.Dockerfile).FullName, imageName);
+                buildExitCode = await dockerManger.DockerBuild(
+                    executionContext,
+                    setupInfo.Container.WorkingDirectory,
+                    setupInfo.Container.Dockerfile,
+                    Directory.GetParent(setupInfo.Container.Dockerfile).FullName,
+                    imageName);
                 if (buildExitCode == 0)
                 {
                     break;

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -438,8 +438,7 @@ namespace GitHub.Runner.Worker
             var imageName = $"{dockerManger.DockerInstanceLabel}:{Guid.NewGuid().ToString("N")}";
             while (retryCount < 3)
             {
-                buildExitCode = await dockerManger.DockerBuild(executionContext, setupInfo.Container.WorkingDirectory, setupInfo.Container.Dockerfile, imageName);
-                // buildExitCode = await dockerManger.DockerBuild(executionContext, setupInfo.Container.WorkingDirectory, Directory.GetParent(setupInfo.Container.Dockerfile).FullName, imageName);
+                buildExitCode = await dockerManger.DockerBuild(executionContext, setupInfo.Container.WorkingDirectory, Directory.GetParent(setupInfo.Container.Dockerfile).FullName, imageName);
                 if (buildExitCode == 0)
                 {
                     break;
@@ -741,10 +740,7 @@ namespace GitHub.Runner.Worker
 
                         setupInfo.Dockerfile = dockerFileFullPath;
                         setupInfo.WorkingDirectory = destDirectory;
-                        if (File.Exists(dockerFileFullPath))
-                        {
 
-                        }
                         return setupInfo;
                     }
                     else if (containerAction.Image.StartsWith("docker://", StringComparison.OrdinalIgnoreCase))

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -745,7 +745,6 @@ namespace GitHub.Runner.Worker
 
                         setupInfo.Dockerfile = dockerFileFullPath;
                         setupInfo.WorkingDirectory = destDirectory;
-
                         return setupInfo;
                     }
                     else if (containerAction.Image.StartsWith("docker://", StringComparison.OrdinalIgnoreCase))

--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -17,7 +17,7 @@ namespace GitHub.Runner.Worker.Container
         string DockerInstanceLabel { get; }
         Task<DockerVersion> DockerVersion(IExecutionContext context);
         Task<int> DockerPull(IExecutionContext context, string image);
-        Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string tag);
+        Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string dockerContext, string tag);
         Task<string> DockerCreate(IExecutionContext context, ContainerInfo container);
         Task<int> DockerRun(IExecutionContext context, ContainerInfo container, EventHandler<ProcessDataReceivedEventArgs> stdoutDataReceived, EventHandler<ProcessDataReceivedEventArgs> stderrDataReceived);
         Task<int> DockerStart(IExecutionContext context, string containerId);
@@ -87,9 +87,9 @@ namespace GitHub.Runner.Worker.Container
             return await ExecuteDockerCommandAsync(context, "pull", image, context.CancellationToken);
         }
 
-        public async Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string tag)
+        public async Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string dockerContext, string tag)
         {
-            return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} -f \"{dockerFile}\" {workingDirectory}", workingDirectory, context.CancellationToken);
+            return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} -f \"{dockerFile}\" {dockerContext}", workingDirectory, context.CancellationToken);
         }
 
         public async Task<string> DockerCreate(IExecutionContext context, ContainerInfo container)

--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -89,7 +89,7 @@ namespace GitHub.Runner.Worker.Container
 
         public async Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string tag)
         {
-            return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} -f \"{dockerFile}\"", workingDirectory, context.CancellationToken);
+            return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} -f \"{dockerFile}\" {workingDirectory}", workingDirectory, context.CancellationToken);
         }
 
         public async Task<string> DockerCreate(IExecutionContext context, ContainerInfo container)

--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -89,7 +89,8 @@ namespace GitHub.Runner.Worker.Container
 
         public async Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string tag)
         {
-            return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} \"{dockerFile}\"", workingDirectory, context.CancellationToken);
+            return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} -f \"{dockerFile}\"", workingDirectory, context.CancellationToken);
+            // return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} \"{dockerFile}\"", workingDirectory, context.CancellationToken);
         }
 
         public async Task<string> DockerCreate(IExecutionContext context, ContainerInfo container)

--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -89,7 +89,7 @@ namespace GitHub.Runner.Worker.Container
 
         public async Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string dockerContext, string tag)
         {
-            return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} -f \"{dockerFile}\" {dockerContext}", workingDirectory, context.CancellationToken);
+            return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} -f \"{dockerFile}\" \"{dockerContext}\"", workingDirectory, context.CancellationToken);
         }
 
         public async Task<string> DockerCreate(IExecutionContext context, ContainerInfo container)

--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -90,7 +90,6 @@ namespace GitHub.Runner.Worker.Container
         public async Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string tag)
         {
             return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} -f \"{dockerFile}\"", workingDirectory, context.CancellationToken);
-            // return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} \"{dockerFile}\"", workingDirectory, context.CancellationToken);
         }
 
         public async Task<string> DockerCreate(IExecutionContext context, ContainerInfo container)

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -56,8 +56,7 @@ namespace GitHub.Runner.Worker.Handlers
                     ExecutionContext,
                     ExecutionContext.GetGitHubContext("workspace"),
                     dockerFile,
-                    Directory.GetParent(dockerFile).FullName, imageName
-                );
+                    Directory.GetParent(dockerFile).FullName, imageName);
                 if (buildExitCode != 0)
                 {
                     throw new InvalidOperationException($"Docker build failed with exit code {buildExitCode}");

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -52,7 +52,7 @@ namespace GitHub.Runner.Worker.Handlers
                 ExecutionContext.Output($"Dockerfile for action: '{dockerFile}'.");
 
                 var imageName = $"{dockerManger.DockerInstanceLabel}:{ExecutionContext.Id.ToString("N")}";
-                var buildExitCode = await dockerManger.DockerBuild(ExecutionContext, ExecutionContext.GetGitHubContext("workspace"), Directory.GetParent(dockerFile).FullName, imageName);
+                var buildExitCode = await dockerManger.DockerBuild(ExecutionContext, ExecutionContext.GetGitHubContext("workspace"), dockerFile, imageName);
                 if (buildExitCode != 0)
                 {
                     throw new InvalidOperationException($"Docker build failed with exit code {buildExitCode}");

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -52,7 +52,12 @@ namespace GitHub.Runner.Worker.Handlers
                 ExecutionContext.Output($"Dockerfile for action: '{dockerFile}'.");
 
                 var imageName = $"{dockerManger.DockerInstanceLabel}:{ExecutionContext.Id.ToString("N")}";
-                var buildExitCode = await dockerManger.DockerBuild(ExecutionContext, ExecutionContext.GetGitHubContext("workspace"), dockerFile, imageName);
+                var buildExitCode = await dockerManger.DockerBuild(
+                    ExecutionContext,
+                    ExecutionContext.GetGitHubContext("workspace"),
+                    dockerFile,
+                    Directory.GetParent(dockerFile).FullName, imageName
+                );
                 if (buildExitCode != 0)
                 {
                     throw new InvalidOperationException($"Docker build failed with exit code {buildExitCode}");

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -56,7 +56,8 @@ namespace GitHub.Runner.Worker.Handlers
                     ExecutionContext,
                     ExecutionContext.GetGitHubContext("workspace"),
                     dockerFile,
-                    Directory.GetParent(dockerFile).FullName, imageName);
+                    Directory.GetParent(dockerFile).FullName,
+                    imageName);
                 if (buildExitCode != 0)
                 {
                     throw new InvalidOperationException($"Docker build failed with exit code {buildExitCode}");

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -1761,7 +1761,7 @@ runs:
             _dockerManager.Setup(x => x.DockerPull(_ec.Object, "ubuntu:16.04")).Returns(Task.FromResult(0));
             _dockerManager.Setup(x => x.DockerPull(_ec.Object, "ubuntu:100.04")).Returns(Task.FromResult(1));
 
-            _dockerManager.Setup(x => x.DockerBuild(_ec.Object, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(0));
+            _dockerManager.Setup(x => x.DockerBuild(_ec.Object, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(0));
 
             _pluginManager = new Mock<IRunnerPluginManager>();
             _pluginManager.Setup(x => x.GetPluginAction(It.IsAny<string>())).Returns(new RunnerPluginActionInfo() { PluginTypeName = "plugin.class, plugin", PostPluginTypeName = "plugin.cleanup, plugin" });


### PR DESCRIPTION
This lets you specify `image: './path/to/dockerfile.Dockerfile` instead of requiring the filename to be just `Dockerfile`.

Passes the existing filename to `build` explicitly with `-f` but continues passing the directory containing the dockerfile to indicate the docker context, rather than assuming it will contain "Dockerfile" by default.

e.g. in an action you can now have (under image):

```yaml
# action.yml
name: 'Hello World'
runs:
  using: 'docker'
  image: './anyNameIWant.Dockerfile'
...
```