### PR TITLE
Validate inputs only for repo action, no warning for small delay.

### DIFF
--- a/src/Runner.Worker/ActionRunner.cs
+++ b/src/Runner.Worker/ActionRunner.cs
@@ -170,11 +170,15 @@ namespace GitHub.Runner.Worker
                 }
             }
 
-            foreach (var input in userInputs)
+            // Validate inputs only for actions with action.yml
+            if (Action.Reference.Type == Pipelines.ActionSourceType.Repository)
             {
-                if (!validInputs.Contains(input))
+                foreach (var input in userInputs)
                 {
-                    ExecutionContext.Warning($"Unexpected input '{input}', valid inputs are ['{string.Join("', '", validInputs)}']");
+                    if (!validInputs.Contains(input))
+                    {
+                        ExecutionContext.Warning($"Unexpected input '{input}', valid inputs are ['{string.Join("', '", validInputs)}']");
+                    }
                 }
             }
 

--- a/src/Test/L0/Worker/ActionRunnerL0.cs
+++ b/src/Test/L0/Worker/ActionRunnerL0.cs
@@ -295,9 +295,10 @@ namespace GitHub.Runner.Common.Tests.Worker
             {
                 Name = "action",
                 Id = actionId,
-                Reference = new Pipelines.ContainerRegistryReference()
+                Reference = new Pipelines.RepositoryPathReference()
                 {
-                    Image = "ubuntu:16.04"
+                    Name = "actions/runner",
+                    Ref = "v1"
                 },
                 Inputs = actionInputs
             };


### PR DESCRIPTION
https://github.com/github/c2c-actions-service/issues/1051