### PR TITLE
jq returns "null" if the field does not exist

### DIFF
--- a/scripts/create-latest-svc.sh
+++ b/scripts/create-latest-svc.sh
@@ -81,7 +81,7 @@ fi
 
 export RUNNER_TOKEN=$(curl -s -X POST ${base_api_url}/${orgs_or_repos}/${runner_scope}/actions/runners/registration-token -H "accept: application/vnd.github.everest-preview+json" -H "authorization: token ${RUNNER_CFG_PAT}" | jq -r '.token')
 
-if [ -z "$RUNNER_TOKEN" ]; then fatal "Failed to get a token"; fi
+if [ "null" == "$RUNNER_TOKEN" -o -z "$RUNNER_TOKEN" ]; then fatal "Failed to get a token"; fi
 
 #---------------------------------------
 # Download latest released and extract


### PR DESCRIPTION
When the response is a JSON-valid and does not contain the token field, null is returned, this lets to the failure of the control of valid runner token.