### PR TITLE
add debug option to disable SSL verification

### DIFF
--- a/src/Misc/layoutbin/runsvc.sh
+++ b/src/Misc/layoutbin/runsvc.sh
@@ -10,6 +10,13 @@ if [ -f ".path" ]; then
     echo ".path=${PATH}"
 fi
 
+if [ -f ".debug-runner-disable-ssl-verify" ]; then
+    export GIT_SSL_NO_VERIFY=true
+    export NODE_TLS_REJECT_UNAUTHORIZED=0
+    echo "SSL verification for Git and Node disabled"
+    echo "   *** DO NOT RUN THIS IN PRODUCTION ***"
+fi
+
 # insert anything to setup env when running as a service
 
 # run the host process which keep the listener alive


### PR DESCRIPTION
Customers playing with the hosted Actions runner preview might not have
a proper SSL certificate setup. Give them an option to disable SSL
verification for Node and Git commands in their actions (e.g. for the
checkout action).

This debug mode is enabled by creating a file `.debug-runner-disable-ssl-verify`
in the directory of the `runsvc.sh` file.

---

I know this is an ugly hack but it might help in a dev setup 😄 