### PR TITLE
Reduce input validation warnings

### DIFF
--- a/src/Runner.Worker/ActionRunner.cs
+++ b/src/Runner.Worker/ActionRunner.cs
@@ -187,12 +187,18 @@ namespace GitHub.Runner.Worker
             // Validate inputs only for actions with action.yml
             if (Action.Reference.Type == Pipelines.ActionSourceType.Repository)
             {
+                var unexpectedInputs = new List<string>();
                 foreach (var input in userInputs)
                 {
                     if (!validInputs.Contains(input))
                     {
-                        ExecutionContext.Warning($"Unexpected input '{input}', valid inputs are ['{string.Join("', '", validInputs)}']");
+                        unexpectedInputs.Add(input);
                     }
+                }
+
+                if (unexpectedInputs.Count > 0)
+                {
+                    ExecutionContext.Warning($"Unexpected input(s) '{string.Join("', '", unexpectedInputs)}', valid inputs are ['{string.Join("', '", validInputs)}']");
                 }
             }
 

--- a/src/Test/L0/Worker/ActionRunnerL0.cs
+++ b/src/Test/L0/Worker/ActionRunnerL0.cs
@@ -328,8 +328,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             Assert.Equal("invalid1", finialInputs["invalid1"]);
             Assert.Equal("invalid2", finialInputs["invalid2"]);
 
-            _ec.Verify(x => x.AddIssue(It.Is<Issue>(s => s.Message.Contains("Unexpected input 'invalid1'")), It.IsAny<string>()), Times.Once);
-            _ec.Verify(x => x.AddIssue(It.Is<Issue>(s => s.Message.Contains("Unexpected input 'invalid2'")), It.IsAny<string>()), Times.Once);
+            _ec.Verify(x => x.AddIssue(It.Is<Issue>(s => s.Message.Contains("Unexpected input(s) 'invalid1', 'invalid2'")), It.IsAny<string>()), Times.Once);
         }
 
         private void Setup([CallerMemberName] string name = "")


### PR DESCRIPTION
A recent change to input validation is causing certain Actions to now throw many input validation warnings.  In certain use cases, this warning is incorrect and incredibly noisy.  This PR will at least summarize and reduce the number of warnings to one per action rather than one per input per action.

# Use Cases
In our organization, we have a single private repository for our Actions.  We use the [private-action-loader](https://github.com/marketplace/actions/private-action-loader) action to load this private repo and pass inputs down into the private action.  As a result, every time private-action-loader is used, we get a warning for each additional input that is passed into the private actions.  Some repos with matrix workflows call private actions multiple times with many inputs and result in hundreds of warnings being generated and added to the Workflow run.