### PR TITLE
Skip search $PATH on command with fully qualified path

### DIFF
--- a/src/Runner.Sdk/Util/WhichUtil.cs
+++ b/src/Runner.Sdk/Util/WhichUtil.cs
@@ -11,6 +11,11 @@ namespace GitHub.Runner.Sdk
         {
             ArgUtil.NotNullOrEmpty(command, nameof(command));
             trace?.Info($"Which: '{command}'");
+            if (Path.IsPathFullyQualified(command) && File.Exists(command))
+            {
+                trace?.Info($"Fully qualified path: '{command}'");
+                return command;
+            }
             string path = Environment.GetEnvironmentVariable(PathUtil.PathVariable);
             if (string.IsNullOrEmpty(path))
             {

--- a/src/Test/L0/Util/WhichUtilL0.cs
+++ b/src/Test/L0/Util/WhichUtilL0.cs
@@ -70,5 +70,24 @@ namespace GitHub.Runner.Common.Tests.Util
                 }
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void WhichHandleFullyQualifiedPath()
+        {
+            using (TestHostContext hc = new TestHostContext(this))
+            {
+                //Arrange
+                Tracing trace = hc.GetTrace();
+
+                // Act.
+                var gitPath = WhichUtil.Which("git", require: true, trace: trace);
+                var gitPath2 = WhichUtil.Which(gitPath, require: true, trace: trace);
+
+                // Assert.
+                Assert.Equal(gitPath, gitPath2);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix limitation found in https://github.com/actions/runner/issues/497 


Customer tried:
```
- run: |
    echo foo
  shell: C:\msys64\usr\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
```

runner error with `Second path fragment must not be a drive or UNC name` from `WhichUtil`