### PR TITLE
Composite Actions Support for Multiple Run Steps

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -395,7 +395,7 @@ namespace GitHub.Runner.Worker
                             Trace.Info($"Action cleanup plugin: {plugin.PluginTypeName}.");
                         }
                     }
-                    else if (definition.Data.Execution.ExecutionType == ActionExecutionType.Composite && !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+                    else if (definition.Data.Execution.ExecutionType == ActionExecutionType.Composite && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
                     {
                         var compositeAction = definition.Data.Execution as CompositeActionExecutionData;
                         Trace.Info($"Action steps: {compositeAction.Steps}.");
@@ -1106,7 +1106,7 @@ namespace GitHub.Runner.Worker
                     Trace.Info($"Action plugin: {(actionDefinitionData.Execution as PluginActionExecutionData).Plugin}, no more preparation.");
                     return null;
                 }
-                else if (actionDefinitionData.Execution.ExecutionType == ActionExecutionType.Composite && !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+                else if (actionDefinitionData.Execution.ExecutionType == ActionExecutionType.Composite && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
                 {
                     Trace.Info($"Action composite: {(actionDefinitionData.Execution as CompositeActionExecutionData).Steps}, no more preparation.");
                     return null;

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1221,7 +1221,7 @@ namespace GitHub.Runner.Worker
         NodeJS,
         Plugin,
         Script,
-        Composite
+        Composite,
     }
 
     public sealed class ContainerActionExecutionData : ActionExecutionData

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -397,7 +397,8 @@ namespace GitHub.Runner.Worker
                     }
                     else if (definition.Data.Execution.ExecutionType == ActionExecutionType.Composite && !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
                     {
-                        // Don't do anything for now
+                        var compositeAction = definition.Data.Execution as CompositeActionExecutionData;
+                        Trace.Info($"Action steps: {compositeAction.Steps}.");
                     }
                     else
                     {

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -395,6 +395,10 @@ namespace GitHub.Runner.Worker
                             Trace.Info($"Action cleanup plugin: {plugin.PluginTypeName}.");
                         }
                     }
+                    else if (definition.Data.Execution.ExecutionType == ActionExecutionType.Composite && !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+                    {
+                        // Don't do anything for now
+                    }
                     else
                     {
                         throw new NotSupportedException(definition.Data.Execution.ExecutionType.ToString());
@@ -1101,6 +1105,11 @@ namespace GitHub.Runner.Worker
                     Trace.Info($"Action plugin: {(actionDefinitionData.Execution as PluginActionExecutionData).Plugin}, no more preparation.");
                     return null;
                 }
+                else if (actionDefinitionData.Execution.ExecutionType == ActionExecutionType.Composite && !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+                {
+                    Trace.Info($"Action composite: {(actionDefinitionData.Execution as CompositeActionExecutionData).Steps}, no more preparation.");
+                    return null;
+                }
                 else
                 {
                     throw new NotSupportedException(actionDefinitionData.Execution.ExecutionType.ToString());
@@ -1211,6 +1220,7 @@ namespace GitHub.Runner.Worker
         NodeJS,
         Plugin,
         Script,
+        Composite
     }
 
     public sealed class ContainerActionExecutionData : ActionExecutionData
@@ -1265,6 +1275,14 @@ namespace GitHub.Runner.Worker
         public override ActionExecutionType ExecutionType => ActionExecutionType.Script;
         public override bool HasPre => false;
         public override bool HasPost => false;
+    }
+
+    public sealed class CompositeActionExecutionData : ActionExecutionData
+    {
+        public override ActionExecutionType ExecutionType => ActionExecutionType.Composite;
+        public override bool HasPre => false;
+        public override bool HasPost => false;
+        public List<Pipelines.ActionStep> Steps { get; set; }
     }
 
     public abstract class ActionExecutionData

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -398,7 +398,8 @@ namespace GitHub.Runner.Worker
                     else if (definition.Data.Execution.ExecutionType == ActionExecutionType.Composite && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
                     {
                         var compositeAction = definition.Data.Execution as CompositeActionExecutionData;
-                        Trace.Info($"Action steps: {compositeAction.Steps}.");
+                        Trace.Info($"Load {compositeAction.Steps.Count} action steps.");
+                        Trace.Verbose($"Details: {StringUtil.ConvertToJson(compositeAction.Steps)}");
                     }
                     else
                     {

--- a/src/Runner.Worker/ActionManifestManager.cs
+++ b/src/Runner.Worker/ActionManifestManager.cs
@@ -419,6 +419,7 @@ namespace GitHub.Runner.Worker
                 {
                     if (stepsLoaded == null)
                     {
+                        // TODO: Add a more helpful error message + including file name, etc. to show user that it's because of their yaml file
                         throw new ArgumentNullException($"No steps provided.");
                     }
                     else

--- a/src/Runner.Worker/ActionManifestManager.cs
+++ b/src/Runner.Worker/ActionManifestManager.cs
@@ -360,7 +360,7 @@ namespace GitHub.Runner.Worker
                         preIfToken = run.Value.AssertString("pre-if");
                         break;
                     case "steps":
-                        if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+                        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
                         {
                             var steps = run.Value.AssertSequence("steps");
                             var evaluator = executionContext.ToPipelineTemplateEvaluator();
@@ -415,7 +415,7 @@ namespace GitHub.Runner.Worker
                         };
                     }
                 }
-                else if (string.Equals(usingToken.Value, "composite", StringComparison.OrdinalIgnoreCase) && !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+                else if (string.Equals(usingToken.Value, "composite", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
                 {
                     if (stepsLoaded == null)
                     {

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -291,8 +291,6 @@ namespace GitHub.Runner.Worker
             // placed after the queued composite steps
             // This will take only O(n+m) time which would be just as efficient if we refactored the code of JobSteps to a PriorityQueue
             // This temp Queue is created in the CompositeActionHandler. 
-
-            Trace.Info("Adding Composite Action Step");
             var newGuid = Guid.NewGuid();
             step.ExecutionContext = Root.CreateChild(newGuid, step.DisplayName, newGuid.ToString("N"), null, null);
             step.ExecutionContext.ExpressionValues["inputs"] = inputsData;
@@ -310,7 +308,6 @@ namespace GitHub.Runner.Worker
                 Root.JobSteps.Clear();
                 foreach (var cs in steps)
                 {
-                    Trace.Info($"EnqueueAllCompositeSteps : Adding Composite action step {cs}");
                     Root.JobSteps.Enqueue(cs);
                 }
                 foreach (var s in temp)
@@ -323,7 +320,6 @@ namespace GitHub.Runner.Worker
                 Root.JobSteps = new Queue<IStep>();
                 foreach (var cs in steps)
                 {
-                    Trace.Info($"EnqueueAllCompositeSteps : Adding Composite action step {cs}");
                     Root.JobSteps.Enqueue(cs);
                 }
             }

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -63,7 +63,7 @@ namespace GitHub.Runner.Worker
         JobContext JobContext { get; }
 
         // Only job level ExecutionContext has JobSteps
-        Queue<IStep> JobSteps { get; }
+        List<IStep> JobSteps { get; }
 
         // Only job level ExecutionContext has PostJobSteps
         Stack<IStep> PostJobSteps { get; }
@@ -105,8 +105,7 @@ namespace GitHub.Runner.Worker
         // others
         void ForceTaskComplete();
         void RegisterPostJobStep(IStep step);
-        IStep RegisterCompositeStep(IStep step, DictionaryContextData inputsData);
-        void EnqueueAllCompositeSteps(Queue<IStep> steps);
+        void RegisterNestedStep(IStep step, DictionaryContextData inputsData, int location);
     }
 
     public sealed class ExecutionContext : RunnerService, IExecutionContext
@@ -161,7 +160,7 @@ namespace GitHub.Runner.Worker
         public List<ContainerInfo> ServiceContainers { get; private set; }
 
         // Only job level ExecutionContext has JobSteps
-        public Queue<IStep> JobSteps { get; private set; }
+        public List<IStep> JobSteps { get; private set; }
 
         // Only job level ExecutionContext has PostJobSteps
         public Stack<IStep> PostJobSteps { get; private set; }
@@ -267,62 +266,17 @@ namespace GitHub.Runner.Worker
             Root.PostJobSteps.Push(step);
         }
 
-        /*
-            RegisterCompositeStep is a helper function used in CompositeActionHandler::RunAsync to 
-            add a child node, aka a step, to the current job to the front of the queue for processing. 
-        */
-        public IStep RegisterCompositeStep(IStep step, DictionaryContextData inputsData)
+        /// <summary>
+        /// Helper function used in CompositeActionHandler::RunAsync to
+        /// add a child node, aka a step, to the current job to the Root.JobSteps based on the location. 
+        /// </summary>
+        public void RegisterNestedStep(IStep step, DictionaryContextData inputsData, int location)
         {
-            // ~Brute Force Method~
-            // There is no way to put this current job in front of the queue in < O(n) time where n = # of elements in JobSteps
-            // Everytime we add a new step, you could requeue every item to put those steps from that stack in JobSteps which 
-            // would result in O(n) for each time we add a composite action step where n = number of jobSteps which would compound 
-            // to O(n*m) where m = number of composite steps
-            // var temp = Root.JobSteps.ToArray();
-            // Root.JobSteps.Clear();
-            // Root.JobSteps.Enqueue(step);
-            // foreach(var s in temp)
-            //     Root.JobSteps.Enqueue(s);
-
-            // ~Optimized Method~
-            // Alterative solution: We add to another temp Queue
-            // After we add all the transformed composite steps to this temp queue, we requeue the whole JobSteps accordingly in EnqueueAllCompositeSteps()
-            // where the queued composite steps are at the front of the JobSteps Queue and the rest of the jobs maintain its order and are 
-            // placed after the queued composite steps
-            // This will take only O(n+m) time which would be just as efficient if we refactored the code of JobSteps to a PriorityQueue
-            // This temp Queue is created in the CompositeActionHandler. 
+            // TODO: For UI purposes, look at figuring out how to condense steps in one node => maybe use the same previous GUID
             var newGuid = Guid.NewGuid();
             step.ExecutionContext = Root.CreateChild(newGuid, step.DisplayName, newGuid.ToString("N"), null, null);
             step.ExecutionContext.ExpressionValues["inputs"] = inputsData;
-            return step;
-        }
-
-        // Add Composite Steps first and then requeue the rest of the job steps. 
-        public void EnqueueAllCompositeSteps(Queue<IStep> steps)
-        {
-            // TODO: For UI purposes, look at figuring out how to condense steps in one node
-            //  maybe use "this" instead of "Root"?
-            if (Root.JobSteps != null)
-            {
-                var temp = Root.JobSteps.ToArray();
-                Root.JobSteps.Clear();
-                foreach (var cs in steps)
-                {
-                    Root.JobSteps.Enqueue(cs);
-                }
-                foreach (var s in temp)
-                {
-                    Root.JobSteps.Enqueue(s);
-                }
-            }
-            else
-            {
-                Root.JobSteps = new Queue<IStep>();
-                foreach (var cs in steps)
-                {
-                    Root.JobSteps.Enqueue(cs);
-                }
-            }
+            Root.JobSteps.Insert(0, step);
         }
 
         public IExecutionContext CreateChild(Guid recordId, string displayName, string refName, string scopeName, string contextName, Dictionary<string, string> intraActionState = null, int? recordOrder = null)
@@ -719,7 +673,7 @@ namespace GitHub.Runner.Worker
             PrependPath = new List<string>();
 
             // JobSteps for job ExecutionContext
-            JobSteps = new Queue<IStep>();
+            JobSteps = new List<IStep>();
 
             // PostJobSteps for job ExecutionContext
             PostJobSteps = new Stack<IStep>();

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -277,7 +277,7 @@ namespace GitHub.Runner.Worker
             step.ExecutionContext = Root.CreateChild(newGuid, step.DisplayName, newGuid.ToString("N"), null, null);
             step.ExecutionContext.ExpressionValues["inputs"] = inputsData;
             // TODO: confirm whether not copying message contexts is safe
-            Root.JobSteps.Insert(0, step);
+            Root.JobSteps.Insert(location, step);
         }
 
         public IExecutionContext CreateChild(Guid recordId, string displayName, string refName, string scopeName, string contextName, Dictionary<string, string> intraActionState = null, int? recordOrder = null)

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -276,6 +276,7 @@ namespace GitHub.Runner.Worker
             var newGuid = Guid.NewGuid();
             step.ExecutionContext = Root.CreateChild(newGuid, step.DisplayName, newGuid.ToString("N"), null, null);
             step.ExecutionContext.ExpressionValues["inputs"] = inputsData;
+            // TODO: confirm whether not copying message contexts is safe
             Root.JobSteps.Insert(0, step);
         }
 

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -1,0 +1,105 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using GitHub.Runner.Common;
+using GitHub.Runner.Sdk;
+using GitHub.DistributedTask.WebApi;
+using Pipelines = GitHub.DistributedTask.Pipelines;
+using System;
+using System.Linq;
+using GitHub.DistributedTask.ObjectTemplating.Tokens;
+using System.Collections.Generic;
+using GitHub.DistributedTask.Pipelines.ContextData;
+
+namespace GitHub.Runner.Worker.Handlers
+{
+    [ServiceLocator(Default = typeof(CompositeActionHandler))]
+    public interface ICompositeActionHandler : IHandler
+    {
+        CompositeActionExecutionData Data { get; set; }
+    }
+    public sealed class CompositeActionHandler : Handler, ICompositeActionHandler
+    {
+        public CompositeActionExecutionData Data { get; set; }
+
+        public Task RunAsync(ActionRunStage stage)
+        {
+            // Validate args.
+            Trace.Entering();
+            ArgUtil.NotNull(ExecutionContext, nameof(ExecutionContext));
+            ArgUtil.NotNull(Inputs, nameof(Inputs));
+
+            var githubContext = ExecutionContext.ExpressionValues["github"] as GitHubContext;
+            ArgUtil.NotNull(githubContext, nameof(githubContext));
+
+            var tempDirectory = HostContext.GetDirectory(WellKnownDirectory.Temp);
+
+            // Resolve action steps
+            var actionSteps = Data.Steps;
+            if (actionSteps == null)
+            {
+                Trace.Error("Data.Steps in CompositeActionHandler is null");
+            }
+            else
+            {
+                Trace.Info($"Data Steps Value for Composite Actions is: {actionSteps}.");
+            }
+
+            // Create Context Data to reuse for each composite action step
+            var inputsData = new DictionaryContextData();
+            foreach (var i in Inputs)
+            {
+                inputsData[i.Key] = new StringContextData(i.Value);
+            }
+
+            // Add each composite action step to the front of the queue
+            var compositeActionSteps = new Queue<IStep>();
+            foreach (Pipelines.ActionStep aStep in actionSteps)
+            {
+                // Ex: 
+                // runs:
+                //      using: "composite"
+                //      steps:
+                //          - uses: example/test-composite@v2 (a)
+                //          - run echo hello world (b)
+                //          - run echo hello world 2 (c)
+                // 
+                // ethanchewy/test-composite/action.yaml
+                // runs:
+                //      using: "composite"
+                //      steps: 
+                //          - run echo hello world 3 (d)
+                //          - run echo hello world 4 (e)
+                // 
+                // Stack (LIFO) [Bottom => Middle => Top]:
+                // | a |
+                // | a | => | d |
+                // (Run step d)
+                // | a | 
+                // | a | => | e |
+                // (Run step e)
+                // | a | 
+                // (Run step a)
+                // | b | 
+                // (Run step b)
+                // | c |
+                // (Run step c)
+                // Done.
+
+                var actionRunner = HostContext.CreateService<IActionRunner>();
+                actionRunner.Action = aStep;
+                actionRunner.Stage = stage;
+                actionRunner.Condition = aStep.Condition;
+                actionRunner.DisplayName = aStep.DisplayName;
+                // TODO: Do we need to add any context data from the job message?
+                // (See JobExtension.cs ~line 236)
+
+                compositeActionSteps.Enqueue(ExecutionContext.RegisterCompositeStep(actionRunner, inputsData));
+            }
+            ExecutionContext.EnqueueAllCompositeSteps(compositeActionSteps);
+
+            return Task.CompletedTask;
+        }
+
+    }
+}

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -36,14 +36,6 @@ namespace GitHub.Runner.Worker.Handlers
 
             // Resolve action steps
             var actionSteps = Data.Steps;
-            if (actionSteps == null)
-            {
-                Trace.Error("Data.Steps in CompositeActionHandler is null");
-            }
-            else
-            {
-                Trace.Info($"Data Steps Value for Composite Actions is: {actionSteps}.");
-            }
 
             // Create Context Data to reuse for each composite action step
             var inputsData = new DictionaryContextData();

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -45,7 +45,7 @@ namespace GitHub.Runner.Worker.Handlers
             }
 
             // Add each composite action step to the front of the queue
-            var compositeActionSteps = new Queue<IStep>();
+            int location = 0;
             foreach (Pipelines.ActionStep aStep in actionSteps)
             {
                 // Ex: 
@@ -63,7 +63,7 @@ namespace GitHub.Runner.Worker.Handlers
                 //          - run echo hello world 3 (d)
                 //          - run echo hello world 4 (e)
                 // 
-                // Stack (LIFO) [Bottom => Middle => Top]:
+                // Steps processed as follow:
                 // | a |
                 // | a | => | d |
                 // (Run step d)
@@ -86,9 +86,9 @@ namespace GitHub.Runner.Worker.Handlers
                 // TODO: Do we need to add any context data from the job message?
                 // (See JobExtension.cs ~line 236)
 
-                compositeActionSteps.Enqueue(ExecutionContext.RegisterCompositeStep(actionRunner, inputsData));
+                ExecutionContext.RegisterNestedStep(actionRunner, inputsData, location);
+                location++;
             }
-            ExecutionContext.EnqueueAllCompositeSteps(compositeActionSteps);
 
             return Task.CompletedTask;
         }

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -1,15 +1,16 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GitHub.DistributedTask.ObjectTemplating.Tokens;
+using GitHub.DistributedTask.Pipelines.ContextData;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Common;
 using GitHub.Runner.Sdk;
-using GitHub.DistributedTask.WebApi;
 using Pipelines = GitHub.DistributedTask.Pipelines;
-using System;
-using System.Linq;
-using GitHub.DistributedTask.ObjectTemplating.Tokens;
-using System.Collections.Generic;
-using GitHub.DistributedTask.Pipelines.ContextData;
+
 
 namespace GitHub.Runner.Worker.Handlers
 {

--- a/src/Runner.Worker/Handlers/HandlerFactory.cs
+++ b/src/Runner.Worker/Handlers/HandlerFactory.cs
@@ -66,6 +66,14 @@ namespace GitHub.Runner.Worker.Handlers
                 handler = HostContext.CreateService<IRunnerPluginHandler>();
                 (handler as IRunnerPluginHandler).Data = data as PluginActionExecutionData;
             }
+            else if (data.ExecutionType == ActionExecutionType.Composite)
+            {
+                // TODO
+                // Runner plugin
+                handler = HostContext.CreateService<ICompositeActionHandler>();
+                // handler = CompositeHandler;
+                (handler as ICompositeActionHandler).Data = data as CompositeActionExecutionData;
+            }
             else
             {
                 // This should never happen.

--- a/src/Runner.Worker/Handlers/HandlerFactory.cs
+++ b/src/Runner.Worker/Handlers/HandlerFactory.cs
@@ -68,10 +68,7 @@ namespace GitHub.Runner.Worker.Handlers
             }
             else if (data.ExecutionType == ActionExecutionType.Composite)
             {
-                // TODO
-                // Runner plugin
                 handler = HostContext.CreateService<ICompositeActionHandler>();
-                // handler = CompositeHandler;
                 (handler as ICompositeActionHandler).Data = data as CompositeActionExecutionData;
             }
             else

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -152,7 +152,7 @@ namespace GitHub.Runner.Worker
                 {
                     foreach (var step in jobSteps)
                     {
-                        jobContext.JobSteps.Enqueue(step);
+                        jobContext.JobSteps.Add(step);
                     }
 
                     await stepsRunner.RunAsync(jobContext);

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -68,11 +68,6 @@ namespace GitHub.Runner.Worker
                 var step = jobContext.JobSteps[0];
                 jobContext.JobSteps.RemoveAt(0);
                 var nextStep = jobContext.JobSteps.Count > 0 ? jobContext.JobSteps[0] : null;
-                // TODO: Fix this temporary workaround for Composite Actions
-                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
-                {
-                    nextStep = null;
-                }
 
                 Trace.Info($"Processing step: DisplayName='{step.DisplayName}'");
                 ArgUtil.NotNull(step.ExecutionContext, nameof(step.ExecutionContext));

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -59,14 +59,15 @@ namespace GitHub.Runner.Worker
                     checkPostJobActions = true;
                     while (jobContext.PostJobSteps.TryPop(out var postStep))
                     {
-                        jobContext.JobSteps.Enqueue(postStep);
+                        jobContext.JobSteps.Add(postStep);
                     }
 
                     continue;
                 }
 
-                var step = jobContext.JobSteps.Dequeue();
-                var nextStep = jobContext.JobSteps.Count > 0 ? jobContext.JobSteps.Peek() : null;
+                var step = jobContext.JobSteps[0];
+                jobContext.JobSteps.RemoveAt(0);
+                var nextStep = jobContext.JobSteps.Count > 0 ? jobContext.JobSteps[0] : null;
                 // TODO: Fix this temporary workaround for Composite Actions
                 if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
                 {

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -67,6 +67,11 @@ namespace GitHub.Runner.Worker
 
                 var step = jobContext.JobSteps.Dequeue();
                 var nextStep = jobContext.JobSteps.Count > 0 ? jobContext.JobSteps.Peek() : null;
+                // TODO: Fix this temporary workaround for Composite Actions
+                if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+                {
+                    nextStep = null;
+                }
 
                 Trace.Info($"Processing step: DisplayName='{step.DisplayName}'");
                 ArgUtil.NotNull(step.ExecutionContext, nameof(step.ExecutionContext));
@@ -409,7 +414,11 @@ namespace GitHub.Runner.Worker
                     scope = scopesToInitialize.Pop();
                     executionContext.Debug($"Initializing scope '{scope.Name}'");
                     executionContext.ExpressionValues["steps"] = stepsContext.GetScope(scope.ParentName);
-                    executionContext.ExpressionValues["inputs"] = !String.IsNullOrEmpty(scope.ParentName) ? scopeInputs[scope.ParentName] : null;
+                    // TODO: Fix this temporary workaround for Composite Actions
+                    if (!executionContext.ExpressionValues.ContainsKey("inputs") && !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+                    {
+                        executionContext.ExpressionValues["inputs"] = !String.IsNullOrEmpty(scope.ParentName) ? scopeInputs[scope.ParentName] : null;
+                    }
                     var templateEvaluator = executionContext.ToPipelineTemplateEvaluator();
                     var inputs = default(DictionaryContextData);
                     try
@@ -432,7 +441,11 @@ namespace GitHub.Runner.Worker
             // Setup expression values
             var scopeName = executionContext.ScopeName;
             executionContext.ExpressionValues["steps"] = stepsContext.GetScope(scopeName);
-            executionContext.ExpressionValues["inputs"] = string.IsNullOrEmpty(scopeName) ? null : scopeInputs[scopeName];
+            // TODO: Fix this temporary workaround for Composite Actions
+            if (!executionContext.ExpressionValues.ContainsKey("inputs") && !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+            {
+                executionContext.ExpressionValues["inputs"] = string.IsNullOrEmpty(scopeName) ? null : scopeInputs[scopeName];
+            }
 
             return true;
         }

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -68,7 +68,7 @@ namespace GitHub.Runner.Worker
                 var step = jobContext.JobSteps.Dequeue();
                 var nextStep = jobContext.JobSteps.Count > 0 ? jobContext.JobSteps.Peek() : null;
                 // TODO: Fix this temporary workaround for Composite Actions
-                if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
                 {
                     nextStep = null;
                 }
@@ -415,7 +415,7 @@ namespace GitHub.Runner.Worker
                     executionContext.Debug($"Initializing scope '{scope.Name}'");
                     executionContext.ExpressionValues["steps"] = stepsContext.GetScope(scope.ParentName);
                     // TODO: Fix this temporary workaround for Composite Actions
-                    if (!executionContext.ExpressionValues.ContainsKey("inputs") && !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+                    if (!executionContext.ExpressionValues.ContainsKey("inputs") && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
                     {
                         executionContext.ExpressionValues["inputs"] = !String.IsNullOrEmpty(scope.ParentName) ? scopeInputs[scope.ParentName] : null;
                     }
@@ -442,7 +442,7 @@ namespace GitHub.Runner.Worker
             var scopeName = executionContext.ScopeName;
             executionContext.ExpressionValues["steps"] = stepsContext.GetScope(scopeName);
             // TODO: Fix this temporary workaround for Composite Actions
-            if (!executionContext.ExpressionValues.ContainsKey("inputs") && !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
+            if (!executionContext.ExpressionValues.ContainsKey("inputs") && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TESTING_COMPOSITE_ACTIONS_ALPHA")))
             {
                 executionContext.ExpressionValues["inputs"] = string.IsNullOrEmpty(scopeName) ? null : scopeInputs[scopeName];
             }

--- a/src/Runner.Worker/action_yaml.json
+++ b/src/Runner.Worker/action_yaml.json
@@ -104,6 +104,10 @@
                 "job",
                 "runner",
                 "env",
+                "always(0,0)",
+                "failure(0,0)",
+                "cancelled(0,0)",
+                "success(0,0)",
                 "hashFiles(1,255)"
             ],
             "sequence": {

--- a/src/Runner.Worker/action_yaml.json
+++ b/src/Runner.Worker/action_yaml.json
@@ -32,7 +32,8 @@
             "one-of": [
                 "container-runs",
                 "node12-runs",
-                "plugin-runs"
+                "plugin-runs",
+                "composite-runs"
             ]
         },
         "container-runs": {
@@ -81,6 +82,32 @@
                 "properties": {
                     "plugin": "non-empty-string"
                 }
+            }
+        },
+        "composite-runs": {
+            "mapping": {
+                "properties": {
+                    "using": "non-empty-string",
+                    "steps": "composite-steps"
+                }
+            }
+        },
+        "composite-steps": {
+            "context": [
+                "github",
+                "needs",
+                "strategy",
+                "matrix",
+                "secrets",
+                "steps",
+                "inputs",
+                "job",
+                "runner",
+                "env",
+                "hashFiles(1,255)"
+            ],
+            "sequence": {
+                "item-type": "any"
             }
         },
         "container-runs-context": {

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
@@ -65,6 +65,8 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
         public const String StepEnv = "step-env";
         public const String StepIfResult = "step-if-result";
         public const String Steps = "steps";
+
+        public const String StepsInTemplate = "steps-in-template";
         public const String StepsScopeInputs = "steps-scope-inputs";
         public const String StepsScopeOutputs = "steps-scope-outputs";
         public const String StepsTemplateRoot = "steps-template-root";

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
@@ -65,7 +65,6 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
         public const String StepEnv = "step-env";
         public const String StepIfResult = "step-if-result";
         public const String Steps = "steps";
-
         public const String StepsInTemplate = "steps-in-template";
         public const String StepsScopeInputs = "steps-scope-inputs";
         public const String StepsScopeOutputs = "steps-scope-outputs";

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -29,7 +29,6 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             var evaluationResult = EvaluationResult.CreateIntermediateResult(null, ifResult);
             return evaluationResult.IsTruthy;
         }
-
         internal static Boolean? ConvertToStepContinueOnError(
             TemplateContext context,
             TemplateToken token,
@@ -264,5 +263,351 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
 
             return result;
         }
+
+        //Note: originally was List<Step> but we need to change to List<ActionStep> to use the "Inputs" attribute
+        internal static List<ActionStep> ConvertToSteps(
+            TemplateContext context,
+            TemplateToken steps)
+        {
+            var stepsSequence = steps.AssertSequence($"job {PipelineTemplateConstants.Steps}");
+
+            var result = new List<ActionStep>();
+            foreach (var stepsItem in stepsSequence)
+            {
+                var step = ConvertToStep(context, stepsItem);
+                if (step != null) // step = null means we are hitting error during step conversion, there should be an error in context.errors
+                {
+                    if (step.Enabled)
+                    {
+                        result.Add(step);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static ActionStep ConvertToStep(
+            TemplateContext context,
+            TemplateToken stepsItem)
+        {
+            var step = stepsItem.AssertMapping($"{PipelineTemplateConstants.Steps} item");
+            var continueOnError = default(ScalarToken);
+            var env = default(TemplateToken);
+            var id = default(StringToken);
+            var ifCondition = default(String);
+            var ifToken = default(ScalarToken);
+            var name = default(ScalarToken);
+            var run = default(ScalarToken);
+            var scope = default(StringToken);
+            var timeoutMinutes = default(ScalarToken);
+            var uses = default(StringToken);
+            var with = default(TemplateToken);
+            var workingDir = default(ScalarToken);
+            var path = default(ScalarToken);
+            var clean = default(ScalarToken);
+            var fetchDepth = default(ScalarToken);
+            var lfs = default(ScalarToken);
+            var submodules = default(ScalarToken);
+            var shell = default(ScalarToken);
+
+            foreach (var stepProperty in step)
+            {
+                var propertyName = stepProperty.Key.AssertString($"{PipelineTemplateConstants.Steps} item key");
+
+                switch (propertyName.Value)
+                {
+                    case PipelineTemplateConstants.Clean:
+                        clean = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.Clean}");
+                        break;
+
+                    case PipelineTemplateConstants.ContinueOnError:
+                        ConvertToStepContinueOnError(context, stepProperty.Value, allowExpressions: true); // Validate early if possible
+                        continueOnError = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} {PipelineTemplateConstants.ContinueOnError}");
+                        break;
+
+                    case PipelineTemplateConstants.Env:
+                        ConvertToStepEnvironment(context, stepProperty.Value, StringComparer.Ordinal, allowExpressions: true); // Validate early if possible
+                        env = stepProperty.Value;
+                        break;
+
+                    case PipelineTemplateConstants.FetchDepth:
+                        fetchDepth = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.FetchDepth}");
+                        break;
+
+                    case PipelineTemplateConstants.Id:
+                        id = stepProperty.Value.AssertString($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.Id}");
+                        if (!NameValidation.IsValid(id.Value, true))
+                        {
+                            context.Error(id, $"Step id {id.Value} is invalid. Ids must start with a letter or '_' and contain only alphanumeric characters, '-', or '_'");
+                        }
+                        break;
+
+                    case PipelineTemplateConstants.If:
+                        ifToken = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.If}");
+                        break;
+
+                    case PipelineTemplateConstants.Lfs:
+                        lfs = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.Lfs}");
+                        break;
+
+                    case PipelineTemplateConstants.Name:
+                        name = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.Name}");
+                        break;
+
+                    case PipelineTemplateConstants.Path:
+                        path = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.Path}");
+                        break;
+
+                    case PipelineTemplateConstants.Run:
+                        run = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.Run}");
+                        break;
+
+                    case PipelineTemplateConstants.Shell:
+                        shell = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.Shell}");
+                        break;
+
+                    case PipelineTemplateConstants.Scope:
+                        scope = stepProperty.Value.AssertString($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.Scope}");
+                        break;
+
+                    case PipelineTemplateConstants.Submodules:
+                        submodules = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.Submodules}");
+                        break;
+
+                    case PipelineTemplateConstants.TimeoutMinutes:
+                        ConvertToStepTimeout(context, stepProperty.Value, allowExpressions: true); // Validate early if possible
+                        timeoutMinutes = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.TimeoutMinutes}");
+                        break;
+
+                    case PipelineTemplateConstants.Uses:
+                        uses = stepProperty.Value.AssertString($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.Uses}");
+                        break;
+
+                    case PipelineTemplateConstants.With:
+                        ConvertToStepInputs(context, stepProperty.Value, allowExpressions: true); // Validate early if possible
+                        with = stepProperty.Value;
+                        break;
+
+                    case PipelineTemplateConstants.WorkingDirectory:
+                        workingDir = stepProperty.Value.AssertScalar($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.WorkingDirectory}");
+                        break;
+
+                    default:
+                        propertyName.AssertUnexpectedValue($"{PipelineTemplateConstants.Steps} item key"); // throws
+                        break;
+                }
+            }
+
+            // Fixup the if-condition
+            var isDefaultScope = String.IsNullOrEmpty(scope?.Value);
+            ifCondition = ConvertToIfCondition(context, ifToken, false, isDefaultScope);
+
+            if (run != null)
+            {
+                var result = new ActionStep
+                {
+                    ScopeName = scope?.Value,
+                    ContextName = id?.Value,
+                    ContinueOnError = continueOnError,
+                    DisplayNameToken = name,
+                    Condition = ifCondition,
+                    TimeoutInMinutes = timeoutMinutes,
+                    Environment = env,
+                    Reference = new ScriptReference(),
+                };
+
+                var inputs = new MappingToken(null, null, null);
+                inputs.Add(new StringToken(null, null, null, PipelineConstants.ScriptStepInputs.Script), run);
+
+                if (workingDir != null)
+                {
+                    inputs.Add(new StringToken(null, null, null, PipelineConstants.ScriptStepInputs.WorkingDirectory), workingDir);
+                }
+
+                if (shell != null)
+                {
+                    inputs.Add(new StringToken(null, null, null, PipelineConstants.ScriptStepInputs.Shell), shell);
+                }
+
+                result.Inputs = inputs;
+
+                return result;
+            }
+            else
+            {
+                uses.AssertString($"{PipelineTemplateConstants.Steps} item {PipelineTemplateConstants.Uses}");
+                var result = new ActionStep
+                {
+                    ScopeName = scope?.Value,
+                    ContextName = id?.Value,
+                    ContinueOnError = continueOnError,
+                    DisplayNameToken = name,
+                    Condition = ifCondition,
+                    TimeoutInMinutes = timeoutMinutes,
+                    Inputs = with,
+                    Environment = env,
+                };
+
+                if (uses.Value.StartsWith("docker://", StringComparison.Ordinal))
+                {
+                    var image = uses.Value.Substring("docker://".Length);
+                    result.Reference = new ContainerRegistryReference { Image = image };
+                }
+                else if (uses.Value.StartsWith("./") || uses.Value.StartsWith(".\\"))
+                {
+                    result.Reference = new RepositoryPathReference
+                    {
+                        RepositoryType = PipelineConstants.SelfAlias,
+                        Path = uses.Value
+                    };
+                }
+                else
+                {
+                    var usesSegments = uses.Value.Split('@');
+                    var pathSegments = usesSegments[0].Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+                    var gitRef = usesSegments.Length == 2 ? usesSegments[1] : String.Empty;
+
+                    if (usesSegments.Length != 2 ||
+                        pathSegments.Length < 2 ||
+                        String.IsNullOrEmpty(pathSegments[0]) ||
+                        String.IsNullOrEmpty(pathSegments[1]) ||
+                        String.IsNullOrEmpty(gitRef))
+                    {
+                        // todo: loc
+                        context.Error(uses, $"Expected format {{org}}/{{repo}}[/path]@ref. Actual '{uses.Value}'");
+                    }
+                    else
+                    {
+                        var repositoryName = $"{pathSegments[0]}/{pathSegments[1]}";
+                        var directoryPath = pathSegments.Length > 2 ? String.Join("/", pathSegments.Skip(2)) : String.Empty;
+
+                        result.Reference = new RepositoryPathReference
+                        {
+                            RepositoryType = RepositoryTypes.GitHub,
+                            Name = repositoryName,
+                            Ref = gitRef,
+                            Path = directoryPath,
+                        };
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// When empty, default to "success()".
+        /// When a status function is not referenced, format as "success() &amp;&amp; &lt;CONDITION&gt;".
+        /// </summary>
+        private static String ConvertToIfCondition(
+            TemplateContext context,
+            TemplateToken token,
+            Boolean isJob,
+            Boolean isDefaultScope)
+        {
+            String condition;
+            if (token is null)
+            {
+                condition = null;
+            }
+            else if (token is BasicExpressionToken expressionToken)
+            {
+                condition = expressionToken.Expression;
+            }
+            else
+            {
+                var stringToken = token.AssertString($"{(isJob ? "job" : "step")} {PipelineTemplateConstants.If}");
+                condition = stringToken.Value;
+            }
+
+            if (String.IsNullOrWhiteSpace(condition))
+            {
+                return $"{PipelineTemplateConstants.Success}()";
+            }
+
+            var expressionParser = new ExpressionParser();
+            var functions = default(IFunctionInfo[]);
+            var namedValues = default(INamedValueInfo[]);
+            if (isJob)
+            {
+                namedValues = s_jobIfNamedValues;
+                // TODO: refactor into seperate functions
+                // functions = PhaseCondition.FunctionInfo;
+            }
+            else
+            {
+                namedValues = isDefaultScope ? s_stepNamedValues : s_stepInTemplateNamedValues;
+                functions = s_stepConditionFunctions;
+            }
+
+            var node = default(ExpressionNode);
+            try
+            {
+                node = expressionParser.CreateTree(condition, null, namedValues, functions) as ExpressionNode;
+            }
+            catch (Exception ex)
+            {
+                context.Error(token, ex);
+                return null;
+            }
+
+            if (node == null)
+            {
+                return $"{PipelineTemplateConstants.Success}()";
+            }
+
+            var hasStatusFunction = node.Traverse().Any(x =>
+            {
+                if (x is Function function)
+                {
+                    return String.Equals(function.Name, PipelineTemplateConstants.Always, StringComparison.OrdinalIgnoreCase) ||
+                        String.Equals(function.Name, PipelineTemplateConstants.Cancelled, StringComparison.OrdinalIgnoreCase) ||
+                        String.Equals(function.Name, PipelineTemplateConstants.Failure, StringComparison.OrdinalIgnoreCase) ||
+                        String.Equals(function.Name, PipelineTemplateConstants.Success, StringComparison.OrdinalIgnoreCase);
+                }
+
+                return false;
+            });
+
+            return hasStatusFunction ? condition : $"{PipelineTemplateConstants.Success}() && ({condition})";
+        }
+
+        private static readonly INamedValueInfo[] s_jobIfNamedValues = new INamedValueInfo[]
+        {
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.GitHub),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Needs),
+        };
+        private static readonly INamedValueInfo[] s_stepNamedValues = new INamedValueInfo[]
+        {
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Strategy),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Matrix),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Steps),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.GitHub),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Job),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Runner),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Env),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Needs),
+        };
+        private static readonly INamedValueInfo[] s_stepInTemplateNamedValues = new INamedValueInfo[]
+        {
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Strategy),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Matrix),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Steps),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Inputs),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.GitHub),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Job),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Runner),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Env),
+            new NamedValueInfo<NoOperationNamedValue>(PipelineTemplateConstants.Needs),
+        };
+        private static readonly IFunctionInfo[] s_stepConditionFunctions = new IFunctionInfo[]
+        {
+            new FunctionInfo<NoOperation>(PipelineTemplateConstants.Always, 0, 0),
+            new FunctionInfo<NoOperation>(PipelineTemplateConstants.Cancelled, 0, 0),
+            new FunctionInfo<NoOperation>(PipelineTemplateConstants.Failure, 0, 0),
+            new FunctionInfo<NoOperation>(PipelineTemplateConstants.Success, 0, 0),
+            new FunctionInfo<NoOperation>(PipelineTemplateConstants.HashFiles, 1, Byte.MaxValue),
+        };
     }
 }

--- a/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
@@ -94,5 +94,12 @@ namespace GitHub.DistributedTask.Pipelines
             public static readonly String Resources = "resources";
             public static readonly String All = "all";
         }
+
+        public static class ScriptStepInputs
+        {
+            public static readonly String Script = "script";
+            public static readonly String WorkingDirectory = "workingDirectory";
+            public static readonly String Shell = "shell";
+        }
     }
 }

--- a/src/Test/L0/Worker/StepsRunnerL0.cs
+++ b/src/Test/L0/Worker/StepsRunnerL0.cs
@@ -80,7 +80,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _ec.Object.Result = null;
 
-                    _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(variableSet.Select(x => x.Object).ToList()));
+                    _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(variableSet.Select(x => x.Object).ToList()));
 
                     // Act.
                     await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -115,7 +115,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _ec.Object.Result = null;
 
-                    _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(variableSet.Select(x => x.Object).ToList()));
+                    _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(variableSet.Select(x => x.Object).ToList()));
 
                     // Act.
                     await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -154,7 +154,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _ec.Object.Result = null;
 
-                    _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(variableSet.Steps.Select(x => x.Object).ToList()));
+                    _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(variableSet.Steps.Select(x => x.Object).ToList()));
 
                     // Act.
                     await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -208,7 +208,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _ec.Object.Result = null;
 
-                    _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(variableSet.Steps.Select(x => x.Object).ToList()));
+                    _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(variableSet.Steps.Select(x => x.Object).ToList()));
 
                     // Act.
                     await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -287,7 +287,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _ec.Object.Result = null;
 
-                    _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(variableSet.Steps.Select(x => x.Object).ToList()));
+                    _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(variableSet.Steps.Select(x => x.Object).ToList()));
 
                     // Act.
                     await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -330,7 +330,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _ec.Object.Result = null;
 
-                    _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(variableSet.Step.Select(x => x.Object).ToList()));
+                    _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(variableSet.Step.Select(x => x.Object).ToList()));
 
                     // Act.
                     await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -361,7 +361,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _ec.Object.Result = null;
 
-                    _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(variableSet.Select(x => x.Object).ToList()));
+                    _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(variableSet.Select(x => x.Object).ToList()));
 
                     // Act.
                     await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -391,7 +391,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _ec.Object.Result = null;
 
-                    _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(variableSet.Select(x => x.Object).ToList()));
+                    _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(variableSet.Select(x => x.Object).ToList()));
 
                     // Act.
                     await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -417,7 +417,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 _ec.Object.Result = null;
 
-                _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(new[] { step1.Object }));
+                _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(new[] { step1.Object }));
 
                 // Act.
                 await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -455,7 +455,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 _ec.Object.Result = null;
 
-                _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(new[] { step1.Object, step2.Object }));
+                _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(new[] { step1.Object, step2.Object }));
 
                 // Act.
                 await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -493,7 +493,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 _ec.Object.Result = null;
 
-                _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(new[] { step1.Object, step2.Object }));
+                _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(new[] { step1.Object, step2.Object }));
 
                 // Act.
                 await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -524,7 +524,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 _ec.Object.Result = null;
 
-                _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(new[] { step1.Object, step2.Object, step3.Object }));
+                _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(new[] { step1.Object, step2.Object, step3.Object }));
 
                 // Act.
                 await _stepsRunner.RunAsync(jobContext: _ec.Object);
@@ -560,7 +560,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 _ec.Object.Result = null;
 
-                _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(new[] { step1.Object, step2.Object, step3.Object }));
+                _ec.Setup(x => x.JobSteps).Returns(new List<IStep>(new[] { step1.Object, step2.Object, step3.Object }));
 
                 // Act.
                 await _stepsRunner.RunAsync(jobContext: _ec.Object);


### PR DESCRIPTION
In this PR, we support executing multiple run steps with custom inputs in a composite action. You can use this feature by writing `using: "composite"` in the action.yml file. Our goal for our first version is to be able to run simple, multiple steps in an action.yml file. This first step allows for users to run a list of steps in the `action.yml` file rather than invoking a javascript entry point. This will eventually allow us to support nesting of actions within an action, etc. 

Here is an in-depth example:

`ethanchewy/test-composite/action.yml`:
```
name: "Composite Action Test v2"
description: "Run a simple composite action"
inputs:
  your_name:
    description: 'lol'
    default: 'Ethan'
runs:
    using: "composite"
    steps: 
        - run: echo hello ${{inputs.your_name}}
        - run: echo sha ${{github.sha}}
        - run: echo os ${{runner.os}}
        - run: |
            echo job index ${{ strategy.job-index }}
```
`workflow.yml`

```
name: Composite Action
on:
  push:
    branches: [ master ]
  pull_request:
    branches: [ master ]
jobs:
  build:
    runs-on: self-hosted
    - uses: actions/checkout@v2
    - uses: ethanchewy/test-composite@v5
      with:
        your_name: "Octocat"
    - name: step 1
      run: echo Workflow step 1
    - name: step 2
      run: echo Workflow step 2
```
Github UI Action View: https://github.com/ethanchewy/testing-actions/runs/778225962?check_suite_focus=true


What this doesn't support yet (for future PRs):

- Input, Output, Env flow (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables)
- Nesting other actions in composite actions (supporting in a step the terminology "using: __")
- etc.

**How this was implemented at a high level:**
We have one queue that keeps track of the composite actions transformed into a job step (in the process, it’s added to the Root node) => then we requeue in a way where these composite actions are executed first. 
None of the steps are actually evaluated by the CompositeActionsHandler but they are pushed to the front of the job step queue and handled by other handlers depending on its type (ex: Script handler).




**This is an experimental feature that can only be turned on via turning the feature flag on:**
`export TESTING_COMPOSITE_ACTIONS_ALPHA=1`
`./run.sh`