### PR TITLE
Add Replace to WellKnownFunctions 

### DIFF
--- a/src/Sdk/DTExpressions2/Expressions2/ExpressionConstants.cs
+++ b/src/Sdk/DTExpressions2/Expressions2/ExpressionConstants.cs
@@ -16,6 +16,7 @@ namespace GitHub.DistributedTask.Expressions2
             AddFunction<StartsWith>("startsWith", 2, 2);
             AddFunction<ToJson>("toJson", 1, 1);
             AddFunction<FromJson>("fromJson", 1, 1);
+            AddFunction<Replace>("replace", 3, 3);
         }
 
         private static void AddFunction<T>(String name, Int32 minParameters, Int32 maxParameters)

--- a/src/Sdk/DTExpressions2/Expressions2/Sdk/Functions/Replace.cs
+++ b/src/Sdk/DTExpressions2/Expressions2/Sdk/Functions/Replace.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace GitHub.DistributedTask.Expressions2.Sdk.Functions
+{
+    internal sealed class Replace : Function
+    {
+        protected sealed override Boolean TraceFullyRealized => false;
+
+        protected sealed override Object EvaluateCore(
+            EvaluationContext context,
+            out ResultMemory resultMemory)
+        {
+            resultMemory = null;
+            var value = Parameters[0].Evaluate(context);
+            var characterToReplace = Parameters[1].Evaluate(context);
+            var characterToReplaceWith = Parameters[2].Evaluate(context);
+
+            if (value.IsPrimitive)
+            {
+                value = value.ConvertToString();
+            }
+            if (characterToReplace.IsPrimitive)
+            {
+                characterToReplace = characterToReplace.ConvertToString();
+            }
+            if (characterToReplaceWith.IsPrimitive)
+            {
+                characterToReplaceWith = characterToReplaceWith.ConvertToString();
+            }
+
+            return String.IsNullOrEmpty(value) ? String.Empty : value.Replace(characterToReplace, characterToReplaceWith);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds Function that allows replacing characters in string.

It is common practice to build and then run Docker Images using branch name in Docker Tag. The problem is that branch name can contain characters (for example: "/") that are not allowed in Docker Tags. 

Other CI providers provide ENV variable that contains normalized branch name (example: `BRANCH=feat/ch-1234/some-feature` is transformed to `BRANCH_SLUG=feat-ch-1234-some-feature`). And this normalized branch is later used in container name:

```
some-job:
  container: some-registry.com/rails:${{ env.BRANCH_SLUG }}-${{ github.sha }}
```