### PR TITLE
Composite Run Steps ADR

### DIFF
--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -46,8 +46,7 @@ echo hello world 2
 echo hello world 3
 echo hello world 4
 ```
-We add a token called "composite" which allows our Runner code to process composite actions. By invoking "using: composite", our Runner code then processes the "steps" attribute, converts this template code to a list of steps, and finally runs each run step 
-sequentially. 
+We add a token called "composite" which allows our Runner code to process composite actions. By invoking "using: composite", our Runner code then processes the "steps" attribute, converts this template code to a list of steps, and finally runs each run step sequentially. If any step fails and there are no `if` conditions defined, the whole composite action job fails. 
 
 ### Inputs
 Example `user/test/composite-action.yml`:
@@ -221,13 +220,15 @@ If the time taken for any of the steps in combination or individually exceed the
 
 For reference, in the example above, if the composite step `foo1` takes 11 minutes to run, that step will fail but the rest of the steps, `foo1` and `foo2`, will proceed as long as their total runtime with the previous failed `foo1` action is less than the composite action's `timeout-minutes` (50 minutes). If the composite step `foo2` takes 51 minutes to run, it will cause the whole composite action job to fail. I
 
-The rationale behind this is that users can configure their steps with the `needs` attribute or `if` condition to conditionally set how steps rely on each other. Due to the additional capabilities that are offered with combining '=`timeout-minutes`, `needs`, and/or `if`, we wanted the `timeout-minutes` condition to be as dumb as possible and not effect other steps. 
+The rationale behind this is that users can configure their steps with the `if` condition to conditionally set how steps rely on each other. Due to the additional capabilities that are offered with combining `timeout-minutes` and/or `if`, we wanted the `timeout-minutes` condition to be as dumb as possible and not effect other steps. 
 
-### Needs
+[Usage limits still apply](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions?query=if%28%29#usage-limits)
+
 
 ### Continue-on-error
 
 **TODO: This continue-on-error condition implementation is up to discussion.** 
+For now, if `continue-on-error` is set to `true` for any of the composite action steps, the composite action job proceeds with the next step and ignores that failure. 
 
 ### Visualizing Composite Action in the GitHub Actions UI
 We want all the composite action's steps to be condensed into the original composite action node. 
@@ -244,3 +245,4 @@ Here is a visual represenation of the [first example](#Steps)
 
 
 ## Conclusion
+This ADR lays the framework for eventually supporting nested Composite Actions within Composite Actions. This ADR allows for users to run multiple run steps within a GitHub Composite Action with the support of inputs, outputs, environment, and context for use in any steps as well as the if, timeout-minutes, and the continue-on-error attributes for each Composite Action step. 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -18,6 +18,8 @@ An important step towards meeting this goal is to build in functionality for act
 
 We don't want the workflow author to need to know how the internal workings of the action work. Users shouldn't know the internal workings of the composite action (for example, `default.shell` and `default.workingDir` should not be inherited from the workflow file to the action file). When deciding how to design certain parts of composite run steps, we want to think one logical step from the consumer.
 
+A composite action is treated as **one** individual job step. 
+
 
 ## Decision
 
@@ -114,12 +116,12 @@ Example `user/composite/action.yml`:
 
 ```yaml
 outputs:
-  random-number: 
-    description: "random number"
+  random-number: ${{ steps.random-number-generator.outputs.random-id }}
 runs:
   using: "composite"
   steps: 
-    - run: echo "::set-output name=random-number::$(echo $RANDOM)"
+    - id: random-number-generator
+      run: echo "::set-output name=random-id::$(echo $RANDOM)"
 ```
 
 Example Output:
@@ -129,9 +131,9 @@ Example Output:
 random-number 43243
 ```
 
-Each of the output variables from the composite action is viewable from the workflow file that uses the composite action. In other words, every child action output(s) is viewable only by its parent using dot notation (ex `steps.foo.outputs.bar`).
+Each of the output variables from the composite action is viewable from the workflow file that uses the composite action. In other words, every child action output(s) is viewable only by its parent using dot notation (ex `steps.foo.outputs.random-number`).
 
-Moreover, the output ids are only accessible within the scope where it was defined. Note that in the example above, in our `workflow.yml` file, it should not have access to output id (i.e. `my-output`). For example, in the `workflow.yml` file, you can't run `foo.steps.my-step.my-output`.
+Moreover, the output ids are only accessible within the scope where it was defined. Note that in the example above, in our `workflow.yml` file, it should not have access to output id (i.e. `random-id`). The reason why we are doing this is because we don't want to require the workflow author to know the internal workings of the composite action.
 
 ## Context
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -121,6 +121,8 @@ Each of the output variables from the composite action is viewable from the work
 
 Moreover, the output ids are only accessible within the scope where it was defined. Note that in the example above, in our `workflow.yml` file, it should not have access to output id (i.e. `my-output`). For example, in the `workflow.yml` file, you can't run `foo.steps.my-step.my-output`.
 
+Our philosophy is we don't want the workflow author to need to know how the internal workings of the action work.
+
 ### Context
 Similar to the workflow file, the composite action has access to the [same context objects](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts) (ex: `github`, `env`, `strategy`). 
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -14,7 +14,7 @@ Customers want to be able to compose actions from actions (ex: https://github.co
 An important step towards meeting this goal is to build in functionality for actions where users can simply execute any number of steps. 
 
 ## Decision
-In this ADR, we support running multiple steps in an Action. In doing so, we build in support for mapping and flowing the inputs, outputs, and env variables (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables).
+**In this ADR, we only support running multiple steps in an Action.** In doing so, we build in support for mapping and flowing the inputs, outputs, and env variables (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables).
 
 ### Steps
 Example `user/composite/action.yml`

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -111,7 +111,7 @@ Example Output:
 hello Octocat
 oh hello Octocat
 ```
-Each of the output variables from the composite action is viewable from the workflow file that uses the composite action. In other words, every child action output(s) is viewable only by its immediete parent.
+Each of the output variables from the composite action is viewable from the workflow file that uses the composite action. In other words, every child action output(s) is viewable only by its parent using dot notation (ex `steps.foo.outputs.bar`).
 
 Moreover, the output ids are only accessible within the scope where it was defined. Note that in the example above, in our `workflow.yml` file, it should not have access to output id (i.e. `my-output`). For example, in the `workflow.yml` file, you can't run `foo.steps.my-step.my-output`.
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -291,6 +291,13 @@ For now, if `continue-on-error` is set to `true` for any of the composite action
 
 Note, that since the composite action is not a workflow, it does not have jobs and thus it is not within scope at the moment to support something like `strategy` with `continue-on-error` as seen in this [example](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error).
 
+## Defaults
+TODO
+
+Shell & WorkingDir
+
+Initial thoughts: the composite action takes the workingDir from the workflow file and the shell for the composite action is set by default only by the composite action itself. 
+
 ## Visualizing Composite Action in the GitHub Actions UI
 We want all the composite action's steps to be condensed into the original composite action node. 
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -14,7 +14,7 @@ Customers want to be able to compose actions from actions (ex: https://github.co
 An important step towards meeting this goal is to build in functionality for actions where users can simply execute any number of steps. 
 
 ## Decision
-**In this ADR, we only support running multiple steps in an Action.** In doing so, we build in support for mapping and flowing the inputs, outputs, and env variables (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables).
+**In this ADR, we only support running multiple run steps in an Action.** In doing so, we build in support for mapping and flowing the inputs, outputs, and env variables (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables).
 
 ### Steps
 Example `user/composite/action.yml`

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -114,7 +114,9 @@ Example `user/composite/action.yml`:
 
 ```yaml
 outputs:
-  random-number: ${{ steps.random-number-generator.outputs.random-id }}
+  random-number: 
+    description: "Random number"
+    value: ${{ steps.random-number-generator.outputs.random-id }}
 runs:
   using: "composite"
   steps: 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -32,9 +32,9 @@ jobs:
   build:
     runs-on: self-hosted
     steps:
-    - id: job1
+    - id: step1
       uses: actions/setup-python@v1
-    - id: job2
+    - id: step2
       uses: actions/setup-node@v2
     - uses: actions/checkout@v2
       needs: [job1, job2]

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -15,8 +15,6 @@ An important step towards meeting this goal is to build in functionality for act
 In this ADR, we support running multiple steps in an Action. In doing so, we build in support for mapping and flowing the inputs, outputs, and env variables (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables).
 
 ### Steps
-We add a token called "composite" which allows our Runner code to process composite actions. By invoking "using: composite", our Runner code then processes the "steps" attribute, converts this template code to a list of steps, and finally runs each run step 
-sequentially. 
 Example `user/test/composite-action.yml`
 ```
 ...
@@ -46,6 +44,9 @@ echo hello world 2
 echo hello world 3
 echo hello world 4
 ```
+We add a token called "composite" which allows our Runner code to process composite actions. By invoking "using: composite", our Runner code then processes the "steps" attribute, converts this template code to a list of steps, and finally runs each run step 
+sequentially. 
+
 ### Inputs
 Example `user/test/composite-action.yml`:
 ```
@@ -74,9 +75,8 @@ Example Output:
 hello Octocat
 Error
 ```
-We plan to use inputs for Composite Actions similar to how parameters are used in programming languages like Python in terms of [lexical scoping](https://inst.eecs.berkeley.edu/~cs61a/fa19/assets/slides/29-Tail_Calls_full.pdf). In Python, let's say you have "Function A", parameters in this function are stored as local variables in this function frame. Let's say we have a "Function B" that a parent frame "Function A" (aka "Function B" is called in "Function A") will have access to those input variables unless its overwritten locally in the body of this child function.
 
-Similar to how Python treats its parameters, for our case, each input variable in the composite action is viewable in its own scope as well as its descendants' scope (when we have nested composite functions). On the flip side, a child action cannot view its ancestors' inputs. Similarly, as seen in the last line in the example output, in the workflow file, it will not have access to the action's `inputs` attribute.
+Each input variable in the composite action is only viewable in its own scope (unlike environment variables). As seen in the last line in the example output, in the workflow file, it will not have access to the action's `inputs` attribute.
 
 ### Outputs
 Example `user/test/composite-action.yml`:
@@ -103,13 +103,13 @@ steps:
     uses: user/test@v1
     with:
       your_name: "Octocat"
-  - run: echo woahhhhhh ${{ steps.foo.outputs.bar }} 
+  - run: echo oh ${{ steps.foo.outputs.bar }} 
 ```
 
 Example Output:
 ```
 hello Octocat
-woahhhhhh hello Octocat
+oh hello Octocat
 ```
 Each of the output variables from the composite action is viewable from the workflow file that uses the composite action. In other words, every child action output(s) is viewable only by its immediete parent.
 
@@ -119,8 +119,42 @@ Moreover, the output ids are only accessible within the scope where it was defin
 Similar to the workflow file, the composite action has access to the [same context objects](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts) (ex: `github`, `env`, `strategy`). 
 
 ### Environment
-The environment variables will flow from the parent node to its children node. More concretely, whatever workflow/action calls a composite action, that composite action has access to whatever environment variables its caller workflow/action has. Nevertheless, the composite action can append its own environment variables or overwrite its parent's environment variables. 
+Example `user/test/composite-action.yml`:
+```
+using: 'composite' 
+env:
+  NAME2: test2
+  SERVER: development
+steps: 
+  - id: my-step
+    run: |
+      echo NAME1: ${{ env.NAME1 }} 
+      echo NAME2: ${{ env.NAME2 }} 
+      echo Server: ${{ env.SERVER }} 
+```
 
+Example `workflow.yml`:
+```
+env:
+  NAME1: test1
+  SERVER: production
+steps: 
+  - id: foo
+    uses: user/test@v1
+  - run: Server: ${{ env.SERVER }} 
+```
+
+Example Output:
+```
+NAME1: test1
+NAME2: test2
+Server: development
+server: production
+```
+
+We plan to use environment variables for Composite Actions similar to the parent/child relationship between nested function calls in programming languages like Python in terms of [lexical scoping](https://inst.eecs.berkeley.edu/~cs61a/fa19/assets/slides/29-Tail_Calls_full.pdf). In Python, let's say you have `functionA` that has local variables called `a` and `b` in this function frame. Let's say we have a `functionB` whose parent frame is `functionA` and has local variable `a` (aka `functionB` is called and defined in `functionA`). `functionB` will have access to its parent input variables that are not overwritten in the local scope (`a`) as well as its own local variable `b`. [Visual Example](http://www.pythontutor.com/visualize.html#code=def%20functionA%28%29%3A%0A%20%20%20%20a%20%3D%201%0A%20%20%20%20b%20%3D%202%0A%20%20%20%20def%20functionB%28%29%3A%0A%20%20%20%20%20%20%20%20b%20%3D%203%0A%20%20%20%20%20%20%20%20print%28%22a%22,%20a%29%0A%20%20%20%20%20%20%20%20print%28%22b%22,%20b%29%0A%20%20%20%20%20%20%20%20return%20b%0A%20%20%20%20return%20functionB%28%29%0A%0A%0A%0AfunctionA%28%29&cumulative=false&curInstr=14&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=3&rawInputLstJSON=%5B%5D&textReferences=false) 
+
+Similar to the above logic, the environment variables will flow from the parent node to its children node. More concretely, whatever workflow/action calls a composite action, that composite action has access to whatever environment variables its caller workflow/action has. Note that the composite action can append its own environment variables or overwrite its parent's environment variables. 
 
 
 ### If condition?

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -134,9 +134,8 @@ env:
 steps: 
   - id: my-step
     run: |
-      echo NAME1: ${{ env.NAME1 }} 
-      echo NAME2: ${{ env.NAME2 }} 
-      echo Server: ${{ env.SERVER }} 
+      echo NAME2: $NAME2
+      echo Server: $SERVER 
 ```
 
 Example `workflow.yml`:
@@ -147,12 +146,11 @@ env:
 steps: 
   - id: foo
     uses: user/test@v1
-  - run: echo Server: ${{ env.SERVER }} 
+  - run: echo Server: $SERVER
 ```
 
 Example Output:
 ```
-NAME1: test1
 NAME2: test2
 Server: development
 Server: production

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -75,7 +75,6 @@ steps:
     uses: user/composite@v1
     with:
       your_name: "Octocat"
-  - run: echo hello ${{ steps.foo.inputs.your_name }} 2
 ```
 
 Example `user/composite/action.yml`:
@@ -94,10 +93,9 @@ Example Output:
 
 ```
 hello Octocat
-Error
 ```
 
-Each input variable in the composite action is only viewable in its own scope (unlike environment variables). As seen in the last line in the example output, in the workflow file, it will not have access to the action's `inputs` attribute.
+Each input variable in the composite action is only viewable in its own scope.
 
 ## Outputs
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -134,8 +134,8 @@ env:
 steps: 
   - id: my-step
     run: |
-      echo NAME2: $NAME2
-      echo Server: $SERVER 
+      echo NAME2 $NAME2
+      echo Server $SERVER 
 ```
 
 Example `workflow.yml`:
@@ -146,14 +146,14 @@ env:
 steps: 
   - id: foo
     uses: user/test@v1
-  - run: echo Server: $SERVER
+  - run: echo Server $SERVER
 ```
 
 Example Output:
 ```
-NAME2: test2
-Server: development
-Server: production
+NAME2 test2
+Server development
+Server production
 ```
 
 We plan to use environment variables for Composite Actions similar to the parent/child relationship between nested function calls in programming languages like Python in terms of [lexical scoping](https://inst.eecs.berkeley.edu/~cs61a/fa19/assets/slides/29-Tail_Calls_full.pdf). In Python, let's say you have `functionA` that has local variables called `a` and `b` in this function frame. Let's say we have a `functionB` whose parent frame is `functionA` and has local variable `a` (aka `functionB` is called and defined in `functionA`). `functionB` will have access to its parent input variables that are not overwritten in the local scope (`a`) as well as its own local variable `b`. [Visual Example](http://www.pythontutor.com/visualize.html#code=def%20functionA%28%29%3A%0A%20%20%20%20a%20%3D%201%0A%20%20%20%20b%20%3D%202%0A%20%20%20%20def%20functionB%28%29%3A%0A%20%20%20%20%20%20%20%20b%20%3D%203%0A%20%20%20%20%20%20%20%20print%28%22a%22,%20a%29%0A%20%20%20%20%20%20%20%20print%28%22b%22,%20b%29%0A%20%20%20%20%20%20%20%20return%20b%0A%20%20%20%20return%20functionB%28%29%0A%0A%0A%0AfunctionA%28%29&cumulative=false&curInstr=14&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=3&rawInputLstJSON=%5B%5D&textReferences=false) 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -185,31 +185,6 @@ In the child action (in this example, this is the `action.yml`), it starts with 
 
 
 What if a step has `cancelled()`? We do the opposite of our approach above if `cancelled()` is used for any of our composite run steps. We will cancel any step that has this condition if the workflow is cancelled at all.
-
-#### Exposing Parent's If Condition to Children Via a Variable
-It would be nice to have a way to access information from a parent's if condition. We could have a parent variable that is contained in the context similar to other context variables `github`, `strategy`, etc.:
-
-Example `workflow.yml`
-
-```yaml
-steps:
-  - run: exit 1
-  - uses: user/composite@v1
-    if: always()
-```
-
-Example `user/composite/action.yml`
-
-```yaml
-runs:
-  using: "composite"
-  steps:
-    - run: echo "preparing the slack bot..."  # <--- This will run, as nothing has failed within the composite yet
-    - run: slack.post("All builds passing, ready for a deploy")  # <-- this will not run, as the parent fails
-      if: ${{ parent.success() }}
-    - run: slack.post("A failure has happened, fix things now", alert=true)  # <--- This will run, as the parent fails
-      if: ${{ parent.failure() }}
-```
     
 ## Timeout-minutes
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -242,7 +242,7 @@ runs:
 
 A composite action in its entirety is a job. You can set both timeout-minutes for the whole composite action or its steps as long as the the sum of the `timeout-minutes` for each composite action step that has the attribute `timeout-minutes` is less than or equals to `timeout-minutes` for the composite action. There is no default timeout-minutes for each composite action step. 
 
-If the time taken for any of the steps in combination or individually exceed the whole composite action `timeout-minutes` attribute, the whole job will fail. If an individual step exceeds its own `timeout-minutes` attribute but the total time that has been used including this step is below the overall composite action `timeout-minutes`, the individual step will fail but the rest of the steps will run based on their `timeout-minutes` attribute. 
+If the time taken for any of the steps in combination or individually exceed the whole composite action `timeout-minutes` attribute, the whole job will fail (1). If an individual step exceeds its own `timeout-minutes` attribute but the total time that has been used including this step is below the overall composite action `timeout-minutes`, the individual step will fail but the rest of the steps will run based on their own `timeout-minutes` attribute (they will still abide by condition (1) though).
 
 For reference, in the example above, if the composite step `foo1` takes 11 minutes to run, that step will fail but the rest of the steps, `foo1` and `foo2`, will proceed as long as their total runtime with the previous failed `foo1` action is less than the composite action's `timeout-minutes` (50 minutes). If the composite step `foo2` takes 51 minutes to run, it will cause the whole composite action job to fail. I
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -147,7 +147,7 @@ env:
 steps: 
   - id: foo
     uses: user/test@v1
-  - run: Server: ${{ env.SERVER }} 
+  - run: echo Server: ${{ env.SERVER }} 
 ```
 
 Example Output:
@@ -155,7 +155,7 @@ Example Output:
 NAME1: test1
 NAME2: test2
 Server: development
-server: production
+Server: production
 ```
 
 We plan to use environment variables for Composite Actions similar to the parent/child relationship between nested function calls in programming languages like Python in terms of [lexical scoping](https://inst.eecs.berkeley.edu/~cs61a/fa19/assets/slides/29-Tail_Calls_full.pdf). In Python, let's say you have `functionA` that has local variables called `a` and `b` in this function frame. Let's say we have a `functionB` whose parent frame is `functionA` and has local variable `a` (aka `functionB` is called and defined in `functionA`). `functionB` will have access to its parent input variables that are not overwritten in the local scope (`a`) as well as its own local variable `b`. [Visual Example](http://www.pythontutor.com/visualize.html#code=def%20functionA%28%29%3A%0A%20%20%20%20a%20%3D%201%0A%20%20%20%20b%20%3D%202%0A%20%20%20%20def%20functionB%28%29%3A%0A%20%20%20%20%20%20%20%20b%20%3D%203%0A%20%20%20%20%20%20%20%20print%28%22a%22,%20a%29%0A%20%20%20%20%20%20%20%20print%28%22b%22,%20b%29%0A%20%20%20%20%20%20%20%20return%20b%0A%20%20%20%20return%20functionB%28%29%0A%0A%0A%0AfunctionA%28%29&cumulative=false&curInstr=14&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=3&rawInputLstJSON=%5B%5D&textReferences=false) 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -16,7 +16,7 @@ An important step towards meeting this goal is to build in functionality for act
 
 We don't want the workflow author to need to know how the internal workings of the action work. Users shouldn't know the internal workings of the composite action (for example, `default.shell` and `default.workingDir` should not be inherited from the workflow file to the action file). When deciding how to design certain parts of composite run steps, we want to think one logical step from the consumer.
 
-A composite action is treated as **one** individual job step. 
+A composite action is treated as **one** individual job step (aka encapsulation).
 
 
 ## Decision

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -113,7 +113,7 @@ oh hello Octocat
 ```
 Each of the output variables from the composite action is viewable from the workflow file that uses the composite action. In other words, every child action output(s) is viewable only by its immediete parent.
 
-Moreover, the output ids are only accessible within the scope where it was defined. In the example above, note that in our `workflow.yml` file, it should not have access to output id (i.e. `my-output`). For example, in the `workflow.yml` file, you can't run `foo.steps.my-step.my-output`.
+Moreover, the output ids are only accessible within the scope where it was defined. Note that in the example above, in our `workflow.yml` file, it should not have access to output id (i.e. `my-output`). For example, in the `workflow.yml` file, you can't run `foo.steps.my-step.my-output`.
 
 ### Context
 Similar to the workflow file, the composite action has access to the [same context objects](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts) (ex: `github`, `env`, `strategy`). 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -119,7 +119,7 @@ runs:
   using: "composite"
   steps: 
     - id: random-number-generator
-      run: echo "::set-output name=random-id::$(echo $RANDOM)"
+      run: echo "::set-output name=random-number::$(echo $RANDOM)"
 ```
 
 Example Output:

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -181,6 +181,8 @@ We plan to use environment variables for Composite Actions similar to the parent
 
 Similar to the above logic, the environment variables will flow from the parent node to its children node. More concretely, whatever workflow/action calls a composite action, that composite action has access to whatever environment variables its caller workflow/action has. Note that the composite action can append its own environment variables or overwrite its parent's environment variables. 
 
+`::set-env::` will only scope to the composite action.
+
 ## Secrets
 
 We'll pass the secrets from the composite action's parents (ex: the workflow file) to the composite action. Secrets cannot be created in a composite action.
@@ -300,7 +302,7 @@ TODO
 
 Shell & WorkingDir
 
-Initial thoughts: the composite action takes the workingDir from the workflow file. On the other hand, the shell for the composite action is set by default only by the composite action itself. 
+Initial thoughts: the composite action should not be able to take the workingDir from the workflow file. Similarly, the shell for the composite action is set by default only by the composite action itself. 
 
 ## Visualizing Composite Action in the GitHub Actions UI
 We want all the composite action's steps to be condensed into the original composite action node. 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -141,7 +141,7 @@ Similar to the workflow file, the composite action has access to the [same conte
 
 ## Environment
 
-Example `workflow.yml`:
+<del> Example `workflow.yml`:
 
 ```yaml
 env:
@@ -181,9 +181,9 @@ Server production
 
 We plan to use environment variables for Composite Actions similar to the parent/child relationship between nested function calls in programming languages like Python in terms of [lexical scoping](https://inst.eecs.berkeley.edu/~cs61a/fa19/assets/slides/29-Tail_Calls_full.pdf). In Python, let's say you have `functionA` that has local variables called `a` and `b` in this function frame. Let's say we have a `functionB` whose parent frame is `functionA` and has local variable `a` (aka `functionB` is called and defined in `functionA`). `functionB` will have access to its parent input variables that are not overwritten in the local scope (`a`) as well as its own local variable `b`. [Visual Example](http://www.pythontutor.com/visualize.html#code=def%20functionA%28%29%3A%0A%20%20%20%20a%20%3D%201%0A%20%20%20%20b%20%3D%202%0A%20%20%20%20def%20functionB%28%29%3A%0A%20%20%20%20%20%20%20%20b%20%3D%203%0A%20%20%20%20%20%20%20%20print%28%22a%22,%20a%29%0A%20%20%20%20%20%20%20%20print%28%22b%22,%20b%29%0A%20%20%20%20%20%20%20%20return%20b%0A%20%20%20%20return%20functionB%28%29%0A%0A%0A%0AfunctionA%28%29&cumulative=false&curInstr=14&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=3&rawInputLstJSON=%5B%5D&textReferences=false) 
 
-Similar to the above logic, the environment variables will flow from the parent node to its children node. More concretely, whatever workflow/action calls a composite action, that composite action has access to whatever environment variables its caller workflow/action has. Note that the composite action can append its own environment variables or overwrite its parent's environment variables. 
+Similar to the above logic, the environment variables will flow from the parent node to its children node. More concretely, whatever workflow/action calls a composite action, that composite action has access to whatever environment variables its caller workflow/action has. Note that the composite action can append its own environment variables or overwrite its parent's environment variables. </del>
 
-`::set-env::` will only scope to the composite action.
+In the Composite Action, you'll only be able to use `::set-env::` to set environment variables just like you could with other actions.
 
 ## Secrets
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -37,7 +37,6 @@ jobs:
     - id: step2
       uses: actions/setup-node@v2
     - uses: actions/checkout@v2
-      needs: [job1, job2]
     - uses: user/composite@v1
     - name: workflow step 1
       run: echo hello world 3

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -222,6 +222,8 @@ The `if` statement in the parent (in the example above, this is the `workflow.ym
 In the child action (in this example, this is the `action.yml`), it starts with a clean slate (in other words, no imposing if conditions). Similar to the logic in the paragraph above, `echo "I will run, as my current scope is succeeding"` will run since the `if` condition checks if the previous steps **within this composite action** has not failed. `run: echo "I will not run, as my current scope is now failing"` will not run since the previous step resulted in an error and by default, the if expression is set to `success()` if the if condition is not set for a step.
 
 
+What if a step has `cancelled()`? We do the opposite of our approach above if `cancelled()` is used for any of our composite run steps. We will cancel any step that has this condition if the workflow is cancelled at all.
+
 #### Exposing Parent's If Condition to Children Via a Variable
 It would be nice to have a way to access information from a parent's if condition. We could have a parent variable that is contained in the context similar to other context variables `github`, `strategy`, etc.:
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -4,7 +4,7 @@ TODO: Change file name to represent the correct PR number (PR is not created yet
 
 **Date**: 2020-06-17
 
-**Status**: In Development
+**Status**: Proposed
 
 ## Context
 Customers want to be able to compose actions from actions (ex: https://github.com/actions/runner/issues/438)
@@ -17,7 +17,7 @@ In this ADR, we support running multiple steps in an Action. In doing so, we bui
 ### Steps
 We add a token called "composite" which allows our Runner code to process composite actions. By invoking "using: composite", our Runner code then processes the "steps" attribute, converts this template code to a list of steps, and finally runs each run step 
 sequentially. 
-Example `user/test/action.yml`
+Example `user/test/composite-action.yml`
 ```
 ...
 using: 'composite' 
@@ -33,7 +33,7 @@ jobs:
     runs-on: self-hosted
     steps:
     - uses: actions/checkout@v2
-    - uses: user/test@v5
+    - uses: user/test@v1
     - name: workflow step 1
       run: echo hello world 3
     - name: workflow step 2
@@ -47,7 +47,7 @@ echo hello world 3
 echo hello world 4
 ```
 ### Inputs
-Example `action.yml`:
+Example `user/test/composite-action.yml`:
 ```
 using: 'composite' 
 inputs:
@@ -57,23 +57,67 @@ inputs:
 steps: 
   - run: echo hello ${{ inputs.your_name }}
 ```
-// inputs:
-//   - name: your_name
-//     default: John Doe
-// steps:
-//   - run: echo hello ${{ inputs.your_name }}
 
-#### Mapping Inputs
-We plan to correctly set the scope of each input variable by loading inputs from the parent action. Then, if there are any local 
+Example `workflow.yml`:
+```
+...
+steps: 
+  - id: foo
+    uses: user/test@v1
+    with:
+      your_name: "Octocat"
+  - run: echo hello ${{ steps.inputs.your_name }} 2
+```
 
-Along those same lines, we don't want the workflow file to have access to the inner inputs. 
+Example Output:
+```
+hello Octocat
+ERROR
+```
+Each input variable in the composite action is only viewable to those in the same scope as composite action or is a child of the composite action such as the composite steps (and eventually nested actions).
 
-to have access to the ste
+As seen in the last output message, in the workflow file, you cannot access the inputs of the composite action.
 
 ### Outputs
-// outputs:
-//   ...
-// example usage (scoped namespaces)
+Example `user/test/composite-action.yml`:
+```
+using: 'composite' 
+inputs:
+  your_name:
+    description: 'Your name'
+    default: 'Ethan'
+outputs:
+  bar: ${{ steps.my-step.my-output}}
+steps: 
+  - id: my-step
+    run: |
+      echo ::set-output name=my-output::my-value
+      echo hello ${{ inputs.your_name }} 
+```
+
+Example `workflow.yml`:
+```
+...
+steps: 
+  - id: foo
+    uses: user/test@v1
+    with:
+      your_name: "Octocat"
+  - run: echo woahhhhhh ${{ steps.foo.outputs.bar }} 
+```
+
+Example Output:
+```
+hello Octocat
+woahhhhhh hello Octocat
+```
+Each of the output variables from the composite action is viewable from the workflow file that uses the composite action. 
+
+In the example above, note that in our `workflow.yml` file, it should not have access to all of the input variables (i.e. `your_name`) nor should it have access to `my-step`. For example, in the `workflow.yml` file, you can't run `my-step.outputs.bar`
+
+### Context
+Similar to the workflow file, the composite action has access to the [same context objects](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts) (ex: `github`, `env`, `strategy`). 
+
 ### If condition?
 TODO: Figure out: What does it mean if the composite step is "always()" but inner step is not? What should the behavior be:
 steps:

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -184,6 +184,9 @@ We plan to use environment variables for Composite Actions similar to the parent
 
 Similar to the above logic, the environment variables will flow from the parent node to its children node. More concretely, whatever workflow/action calls a composite action, that composite action has access to whatever environment variables its caller workflow/action has. Note that the composite action can append its own environment variables or overwrite its parent's environment variables. 
 
+## Secrets
+
+We'll pass the secrets from the composite action's parents (ex: the workflow file) to the composite action. Secrets cannot be created in a composite action.
 
 ## If Condition
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -115,10 +115,7 @@ using: 'composite'
 outputs:
   random-number: ${{ steps.my-step.my-output}}
 steps: 
-  - id: my-step
-    run: |
-      echo ::set-output name=my-output::my-value
-      echo $RANDOM
+  - run: echo "::set-output name=my-output::$(echo $RANDOM)"
 ```
 
 Example Output:

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -1,0 +1,97 @@
+TODO: Change file name to represent the correct PR number (PR is not created yet for this ADR)
+
+# ADR 0549: Composite Run Steps
+
+**Date**: 2020-06-17
+
+**Status**: In Development
+
+## Context
+Customers want to be able to compose actions from actions (ex: https://github.com/actions/runner/issues/438)
+
+An important step towards meeting this goal is to build in functionality for actions where users can simply execute any number of steps. 
+
+## Decision
+In this ADR, we support running multiple steps in an Action. In doing so, we build in support for mapping and flowing the inputs, outputs, and env variables (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables).
+
+### Steps
+We add a token called "composite" which allows our Runner code to process composite actions. By invoking "using: composite", our Runner code then processes the "steps" attribute, converts this template code to a list of steps, and finally runs each run step 
+sequentially. 
+Example `user/test/action.yml`
+```
+...
+using: 'composite' 
+steps:
+  - run: echo hello world 1
+  - run: echo hello world 2
+```
+Example `workflow.yml`
+```
+...
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+    - uses: actions/checkout@v2
+    - uses: user/test@v5
+    - name: workflow step 1
+      run: echo hello world 3
+    - name: workflow step 2
+      run: echo hello world 4
+```
+Example Output
+```
+echo hello world 1
+echo hello world 2
+echo hello world 3
+echo hello world 4
+```
+### Inputs
+Example `action.yml`:
+```
+using: 'composite' 
+inputs:
+  your_name:
+    description: 'Your name'
+    default: 'Ethan'
+steps: 
+  - run: echo hello ${{ inputs.your_name }}
+```
+// inputs:
+//   - name: your_name
+//     default: John Doe
+// steps:
+//   - run: echo hello ${{ inputs.your_name }}
+
+#### Mapping Inputs
+We plan to correctly set the scope of each input variable by loading inputs from the parent action. Then, if there are any local 
+
+Along those same lines, we don't want the workflow file to have access to the inner inputs. 
+
+to have access to the ste
+
+### Outputs
+// outputs:
+//   ...
+// example usage (scoped namespaces)
+### If condition?
+TODO: Figure out: What does it mean if the composite step is "always()" but inner step is not? What should the behavior be:
+steps:
+  - uses: my-composite-action@v1
+    if: cancel()
+    
+### Visualizing Composite Action in the GitHub Actions UI
+We want all the composite action's steps to be condensed into the original composite action node. 
+
+Here is a visual represenation of the [first example](#Steps)
+```
+| composite_action_node |
+    | echo hello world 1 | 
+    | echo hello world 2 |
+| echo hello world 3 | 
+| echo hello world 4 |
+
+```
+
+
+## Conclusion

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -293,16 +293,37 @@ The rationale behind this is that users can configure their steps with the `if` 
 ## Continue-on-error
 
 **TODO: This continue-on-error condition implementation is up to discussion.** 
-For now, if `continue-on-error` is set to `true` for any of the composite action steps, the composite action job proceeds to the next step and ignores that failure. 
 
-Note, that since the composite action is not a workflow, it does not have jobs and thus it is not within scope at the moment to support something like `strategy` with `continue-on-error` as seen in this [example](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error).
+Example `workflow.yml`:
+
+```yaml
+steps: 
+  - run: exit 1
+  - id: bar
+    uses: user/test@v1
+    continue-on-error: false
+  - id: foo
+    run: echo "Hello World" <------- This step will not run
+```
+
+Example `user/composite/action.yml`:
+
+```yaml
+runs:
+  using: "composite"
+  steps: 
+    - run: exit 1
+      continue-on-error: true
+    - run: echo "Hello World 2" <----- This step will run
+```
+
+If any of the steps fail in the composite action and the `continue-on-error` is set to `false` for the whole composite action step in the workflow file, then the steps below it will run. On the flip side, if `continue-on-error` is set to `true` for the whole composite action step in the workflow file, the next job step will run.
+
+For the composite action steps, it follows the same logic as above. In this example, `"Hello World 2"` will be outputted because the previous step has `continue-on-error` set to `true` although that previous step errored. 
 
 ## Defaults
-TODO
 
-Shell & WorkingDir
-
-Initial thoughts: the composite action should not be able to take the workingDir from the workflow file. Similarly, the shell for the composite action is set by default only by the composite action itself. 
+The composite action author will be required to set the `shell` and `workingDir` of the composite action. Moreover, the composite action author will be able to explicitly set the shell for each composite run step. The workflow author will not have the ability to change these attributes. 
 
 ## Visualizing Composite Action in the GitHub Actions UI
 We want all the composite action's steps to be condensed into the original composite action node. 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -47,10 +47,11 @@ jobs:
 Example `user/composite/action.yml`
 
 ```yaml
-using: 'composite' 
-steps:
-  - run: pip install -r requirements.txt
-  - run: npm install
+runs:
+  using: "composite"
+  steps:
+    - run: pip install -r requirements.txt
+    - run: npm install
 ```
 
 Example Output
@@ -79,13 +80,14 @@ steps:
 Example `user/composite/action.yml`:
 
 ```yaml
-using: 'composite' 
 inputs:
   your_name:
     description: 'Your name'
     default: 'Ethan'
-steps: 
-  - run: echo hello ${{ inputs.your_name }}
+runs:
+  using: "composite"
+  steps: 
+    - run: echo hello ${{ inputs.your_name }}
 ```
 
 Example Output:
@@ -111,12 +113,13 @@ steps:
 Example `user/composite/action.yml`:
 
 ```yaml
-using: 'composite' 
 outputs:
   random-number: 
     description: "random number"
-steps: 
-  - run: echo "::set-output name=my-output::$(echo $RANDOM)"
+runs:
+  using: "composite"
+  steps: 
+    - run: echo "::set-output name=my-output::$(echo $RANDOM)"
 ```
 
 Example Output:
@@ -155,13 +158,15 @@ using: 'composite'
 env:
   NAME2: test2
   SERVER: development
-steps: 
-  - id: my-step
-    run: |
-      echo NAME2 $NAME2
-      echo Server $SERVER 
-    env:
-      NAME2: test3
+runs:
+  using: "composite"
+  steps: 
+    - id: my-step
+      run: |
+        echo NAME2 $NAME2
+        echo Server $SERVER 
+      env:
+        NAME2: test3
 ```
 
 Example Output:
@@ -194,12 +199,14 @@ steps:
 Example `user/composite/action.yml`:
 
 ```yaml
-steps:
-  - run: echo "just succeeding"
-  - run: echo "I will run, as my current scope is succeeding"
-    if: success()
-  - run: exit 1
-  - run: echo "I will not run, as my current scope is now failing"
+runs:
+  using: "composite"
+  steps:
+    - run: echo "just succeeding"
+    - run: echo "I will run, as my current scope is succeeding"
+      if: success()
+    - run: exit 1
+    - run: echo "I will not run, as my current scope is now failing"
 ```
 
 **TODO: This if condition implementation is up to discussion.
@@ -231,12 +238,14 @@ steps:
 Example `user/composite/action.yml`
 
 ```yaml
-steps:
-  - run: echo "preparing the slack bot..."  # <--- This will run, as nothing has failed within the composite yet
-  - run: slack.post("All builds passing, ready for a deploy")  # <-- this will not run, as the parent fails
-    if: ${{ parent.success() }}
-  - run: slack.post("A failure has happened, fix things now", alert=true)  # <--- This will run, as the parent fails
-    if: ${{ parent.failure() }}
+runs:
+  using: "composite"
+  steps:
+    - run: echo "preparing the slack bot..."  # <--- This will run, as nothing has failed within the composite yet
+    - run: slack.post("All builds passing, ready for a deploy")  # <-- this will not run, as the parent fails
+      if: ${{ parent.success() }}
+    - run: slack.post("A failure has happened, fix things now", alert=true)  # <--- This will run, as the parent fails
+      if: ${{ parent.failure() }}
 ```
     
 ## Timeout-minutes
@@ -253,16 +262,17 @@ steps:
 Example `user/composite/action.yml`:
 
 ```yaml
-using: 'composite' 
-steps: 
-  - id: foo1
-    run: echo test 1
-    timeout-minutes: 10
-  - id: foo2
-    run: echo test 2
-  - id: foo3
-    run: echo test 3
-    timeout-minutes: 10
+runs:
+  using: "composite"
+  steps: 
+    - id: foo1
+      run: echo test 1
+      timeout-minutes: 10
+    - id: foo2
+      run: echo test 2
+    - id: foo3
+      run: echo test 3
+      timeout-minutes: 10
 ```
 
 **TODO: This timeout-minutes condition implementation is up to discussion.** 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -136,6 +136,8 @@ steps:
     run: |
       echo NAME2 $NAME2
       echo Server $SERVER 
+    env:
+      NAME2: test3
 ```
 
 Example `workflow.yml`:
@@ -151,7 +153,7 @@ steps:
 
 Example Output:
 ```
-NAME2 test2
+NAME2 test3
 Server development
 Server production
 ```

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -236,7 +236,9 @@ The rationale behind this is that users can configure their steps with the `if` 
 ### Continue-on-error
 
 **TODO: This continue-on-error condition implementation is up to discussion.** 
-For now, if `continue-on-error` is set to `true` for any of the composite action steps, the composite action job proceeds with the next step and ignores that failure. 
+For now, if `continue-on-error` is set to `true` for any of the composite action steps, the composite action job proceeds to the next step and ignores that failure. 
+
+Note, that since the composite action is not a workflow, it does not have jobs and thus it is not within scope at the moment to support something like `strategy` with `continue-on-error` as seen in this [example](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error).
 
 ### Visualizing Composite Action in the GitHub Actions UI
 We want all the composite action's steps to be condensed into the original composite action node. 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -172,9 +172,6 @@ runs:
     - run: echo "I will not run, as my current scope is now failing"
 ```
 
-**TODO: This if condition implementation is up to discussion.
-Discussions: https://github.com/actions/runner/pull/554#discussion_r443661891, ...** 
-
 See the paragraph below for a rudimentary approach (thank you to @cybojenix for the idea, example, and explanation for this approach):
 
 The `if` statement in the parent (in the example above, this is the `workflow.yml`) shows whether or not we should run the composite action. So, our composite action will run since the `if` condition for running the composite action is `always()`.
@@ -213,8 +210,6 @@ runs:
       timeout-minutes: 10
 ```
 
-**TODO: This timeout-minutes condition implementation is up to discussion.** 
-
 A composite action in its entirety is a job. You can set both timeout-minutes for the whole composite action or its steps as long as the the sum of the `timeout-minutes` for each composite action step that has the attribute `timeout-minutes` is less than or equals to `timeout-minutes` for the composite action. There is no default timeout-minutes for each composite action step. 
 
 If the time taken for any of the steps in combination or individually exceed the whole composite action `timeout-minutes` attribute, the whole job will fail (1). If an individual step exceeds its own `timeout-minutes` attribute but the total time that has been used including this step is below the overall composite action `timeout-minutes`, the individual step will fail but the rest of the steps will run based on their own `timeout-minutes` attribute (they will still abide by condition (1) though).
@@ -227,8 +222,6 @@ The rationale behind this is that users can configure their steps with the `if` 
 
 
 ## Continue-on-error
-
-**TODO: This continue-on-error condition implementation is up to discussion.** 
 
 Example `workflow.yml`:
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -184,8 +184,7 @@ steps:
 ```
 
 **TODO: This if condition implementation is up to discussion.
-Discussions: https://github.com/actions/runner/pull/554#discussion_r443661891, ...
-** 
+Discussions: https://github.com/actions/runner/pull/554#discussion_r443661891, ...** 
 
 See the paragraph below for a rudimentary approach (thank you to @cybojenix for the idea, example, and explanation for this approach):
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -23,7 +23,7 @@ We don't want the workflow author to need to know how the internal workings of t
 
 **In this ADR, we only support running multiple run steps in an Action.** In doing so, we build in support for mapping and flowing the inputs, outputs, and env variables (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables).
 
-### Steps
+## Steps
 
 Example `workflow.yml`
 
@@ -65,7 +65,7 @@ echo hello world 4
 
 We add a token called "composite" which allows our Runner code to process composite actions. By invoking "using: composite", our Runner code then processes the "steps" attribute, converts this template code to a list of steps, and finally runs each run step sequentially. If any step fails and there are no `if` conditions defined, the whole composite action job fails. 
 
-### Inputs
+## Inputs
 
 Example `workflow.yml`:
 
@@ -99,7 +99,7 @@ Error
 
 Each input variable in the composite action is only viewable in its own scope (unlike environment variables). As seen in the last line in the example output, in the workflow file, it will not have access to the action's `inputs` attribute.
 
-### Outputs
+## Outputs
 
 Example `workflow.yml`:
 
@@ -141,11 +141,11 @@ Each of the output variables from the composite action is viewable from the work
 
 Moreover, the output ids are only accessible within the scope where it was defined. Note that in the example above, in our `workflow.yml` file, it should not have access to output id (i.e. `my-output`). For example, in the `workflow.yml` file, you can't run `foo.steps.my-step.my-output`.
 
-### Context
+## Context
 
 Similar to the workflow file, the composite action has access to the [same context objects](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts) (ex: `github`, `env`, `strategy`). 
 
-### Environment
+## Environment
 
 Example `workflow.yml`:
 
@@ -188,7 +188,7 @@ We plan to use environment variables for Composite Actions similar to the parent
 Similar to the above logic, the environment variables will flow from the parent node to its children node. More concretely, whatever workflow/action calls a composite action, that composite action has access to whatever environment variables its caller workflow/action has. Note that the composite action can append its own environment variables or overwrite its parent's environment variables. 
 
 
-### If Condition
+## If Condition
 
 Example `workflow.yml`:
 
@@ -247,7 +247,7 @@ steps:
     if: ${{ parent.failure() }}
 ```
     
-### Timeout-minutes
+## Timeout-minutes
 
 Example `workflow.yml`:
 
@@ -286,14 +286,14 @@ The rationale behind this is that users can configure their steps with the `if` 
 [Usage limits still apply](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions?query=if%28%29#usage-limits)
 
 
-### Continue-on-error
+## Continue-on-error
 
 **TODO: This continue-on-error condition implementation is up to discussion.** 
 For now, if `continue-on-error` is set to `true` for any of the composite action steps, the composite action job proceeds to the next step and ignores that failure. 
 
 Note, that since the composite action is not a workflow, it does not have jobs and thus it is not within scope at the moment to support something like `strategy` with `continue-on-error` as seen in this [example](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error).
 
-### Visualizing Composite Action in the GitHub Actions UI
+## Visualizing Composite Action in the GitHub Actions UI
 We want all the composite action's steps to be condensed into the original composite action node. 
 
 Here is a visual represenation of the [first example](#Steps)

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -141,53 +141,14 @@ Similar to the workflow file, the composite action has access to the [same conte
 
 ## Environment
 
-<del> Example `workflow.yml`:
-
-```yaml
-env:
-  NAME1: test1
-  SERVER: production
-steps: 
-  - id: foo
-    uses: user/test@v1
-  - run: echo Server $SERVER
-```
-
-Example `user/composite/action.yml`:
-
-```yaml
-using: 'composite' 
-env:
-  NAME2: test2
-  SERVER: development
-runs:
-  using: "composite"
-  steps: 
-    - id: my-step
-      run: |
-        echo NAME2 $NAME2
-        echo Server $SERVER 
-      env:
-        NAME2: test3
-```
-
-Example Output:
-
-```
-NAME2 test3
-Server development
-Server production
-```
-
-We plan to use environment variables for Composite Actions similar to the parent/child relationship between nested function calls in programming languages like Python in terms of [lexical scoping](https://inst.eecs.berkeley.edu/~cs61a/fa19/assets/slides/29-Tail_Calls_full.pdf). In Python, let's say you have `functionA` that has local variables called `a` and `b` in this function frame. Let's say we have a `functionB` whose parent frame is `functionA` and has local variable `a` (aka `functionB` is called and defined in `functionA`). `functionB` will have access to its parent input variables that are not overwritten in the local scope (`a`) as well as its own local variable `b`. [Visual Example](http://www.pythontutor.com/visualize.html#code=def%20functionA%28%29%3A%0A%20%20%20%20a%20%3D%201%0A%20%20%20%20b%20%3D%202%0A%20%20%20%20def%20functionB%28%29%3A%0A%20%20%20%20%20%20%20%20b%20%3D%203%0A%20%20%20%20%20%20%20%20print%28%22a%22,%20a%29%0A%20%20%20%20%20%20%20%20print%28%22b%22,%20b%29%0A%20%20%20%20%20%20%20%20return%20b%0A%20%20%20%20return%20functionB%28%29%0A%0A%0A%0AfunctionA%28%29&cumulative=false&curInstr=14&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=3&rawInputLstJSON=%5B%5D&textReferences=false) 
-
-Similar to the above logic, the environment variables will flow from the parent node to its children node. More concretely, whatever workflow/action calls a composite action, that composite action has access to whatever environment variables its caller workflow/action has. Note that the composite action can append its own environment variables or overwrite its parent's environment variables. </del>
-
 In the Composite Action, you'll only be able to use `::set-env::` to set environment variables just like you could with other actions.
 
 ## Secrets
 
-We'll pass the secrets from the composite action's parents (ex: the workflow file) to the composite action. Secrets cannot be created in a composite action.
+**Note** : This feature will be focused on in a future ADR.
+
+We'll pass the secrets from the composite action's parents (ex: the workflow file) to the composite action. Secrets can be created in the composite action with the secrets context. In the actions yaml, we'll automatically mask the secret. 
+
 
 ## If Condition
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -298,7 +298,7 @@ TODO
 
 Shell & WorkingDir
 
-Initial thoughts: the composite action takes the workingDir from the workflow file and the shell for the composite action is set by default only by the composite action itself. 
+Initial thoughts: the composite action takes the workingDir from the workflow file. On the other hand, the shell for the composite action is set by default only by the composite action itself. 
 
 ## Visualizing Composite Action in the GitHub Actions UI
 We want all the composite action's steps to be condensed into the original composite action node. 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -168,19 +168,19 @@ Similar to the above logic, the environment variables will flow from the parent 
 Example `user/composite/action.yml`:
 ```
 steps:
-  - run: exit 1
-  - uses: user/composite@v1  # <--- this will run, as it's marked as always runing
-    if: always()
-```
-
-Example `workflow.yml`:
-```
-steps:
   - run: echo "just succeeding"
   - run: echo "I will run, as my current scope is succeeding"
     if: success()
   - run: exit 1
   - run: echo "I will not run, as my current scope is now failing"
+```
+
+Example `workflow.yml`:
+```
+steps:
+  - run: exit 1
+  - uses: user/composite@v1  # <--- this will run, as it's marked as always runing
+    if: always()
 ```
 
 **TODO: This if condition implementation is up to discussion.

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -22,8 +22,8 @@ Example `user/test/composite-action.yml`
 ...
 using: 'composite' 
 steps:
-  - run: echo hello world 1
-  - run: echo hello world 2
+  - run: pip install -r requirements.txt
+  - run: npm install
 ```
 Example `workflow.yml`
 ```
@@ -32,7 +32,12 @@ jobs:
   build:
     runs-on: self-hosted
     steps:
+    - id: job1
+      uses: actions/setup-python@v1
+    - id: job2
+      uses: actions/setup-node@v2
     - uses: actions/checkout@v2
+      needs: [job1, job2]
     - uses: user/test@v1
     - name: workflow step 1
       run: echo hello world 3
@@ -41,8 +46,8 @@ jobs:
 ```
 Example Output
 ```
-echo hello world 1
-echo hello world 2
+[npm installation output]
+[pip requirements output]
 echo hello world 3
 echo hello world 4
 ```

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -1,6 +1,6 @@
 TODO: Change file name to represent the correct PR number (PR is not created yet for this ADR)
 
-# ADR 0549: Composite Run Steps
+# ADR 054x: Composite Run Steps
 
 **Date**: 2020-06-17
 
@@ -13,6 +13,11 @@ TODO: Change file name to represent the correct PR number (PR is not created yet
 Customers want to be able to compose actions from actions (ex: https://github.com/actions/runner/issues/438)
 
 An important step towards meeting this goal is to build in functionality for actions where users can simply execute any number of steps. 
+
+## Guiding Principles
+
+We don't want the workflow author to need to know how the internal workings of the action work. Users shouldn't know the internal workings of the composite action (for example, `default.shell` and `default.workingDir` should not be inherited from the workflow file to the action file). When deciding how to design certain parts of composite run steps, we want to think one logical step from the consumer.
+
 
 ## Decision
 
@@ -135,8 +140,6 @@ oh hello Octocat
 Each of the output variables from the composite action is viewable from the workflow file that uses the composite action. In other words, every child action output(s) is viewable only by its parent using dot notation (ex `steps.foo.outputs.bar`).
 
 Moreover, the output ids are only accessible within the scope where it was defined. Note that in the example above, in our `workflow.yml` file, it should not have access to output id (i.e. `my-output`). For example, in the `workflow.yml` file, you can't run `foo.steps.my-step.my-output`.
-
-Our philosophy is we don't want the workflow author to need to know how the internal workings of the action work.
 
 ### Context
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -1,5 +1,3 @@
-TODO: Change file name to represent the correct PR number (PR is not created yet for this ADR)
-
 # ADR 054x: Composite Run Steps
 
 **Date**: 2020-06-17
@@ -244,7 +242,7 @@ runs:
 
 A composite action in its entirety is a job. You can set both timeout-minutes for the whole composite action or its steps as long as the the sum of the `timeout-minutes` for each composite action step that has the attribute `timeout-minutes` is less than or equals to `timeout-minutes` for the composite action. There is no default timeout-minutes for each composite action step. 
 
-If the time taken for any of the steps in combination or individually exceed the whole composite action `timeout-minutes` attribute, the whole job will fail. If an individual step exceeds its own `timeout-minutes` attribute but the total time that has been used including this step is below the overall composite action `timeout-minutes`, the individual step will fail but the rest of the steps will run. 
+If the time taken for any of the steps in combination or individually exceed the whole composite action `timeout-minutes` attribute, the whole job will fail. If an individual step exceeds its own `timeout-minutes` attribute but the total time that has been used including this step is below the overall composite action `timeout-minutes`, the individual step will fail but the rest of the steps will run based on their `timeout-minutes` attribute. 
 
 For reference, in the example above, if the composite step `foo1` takes 11 minutes to run, that step will fail but the rest of the steps, `foo1` and `foo2`, will proceed as long as their total runtime with the previous failed `foo1` action is less than the composite action's `timeout-minutes` (50 minutes). If the composite step `foo2` takes 51 minutes to run, it will cause the whole composite action job to fail. I
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -119,7 +119,7 @@ outputs:
 runs:
   using: "composite"
   steps: 
-    - run: echo "::set-output name=my-output::$(echo $RANDOM)"
+    - run: echo "::set-output name=random-number::$(echo $RANDOM)"
 ```
 
 Example Output:

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -113,7 +113,8 @@ Example `user/composite/action.yml`:
 ```yaml
 using: 'composite' 
 outputs:
-  random-number: ${{ steps.my-step.my-output}}
+  random-number: 
+    description: "random number"
 steps: 
   - run: echo "::set-output name=my-output::$(echo $RANDOM)"
 ```
@@ -121,7 +122,7 @@ steps:
 Example Output:
 
 ```
-43243
+::set-output name=my-output::43243
 random-number 43243
 ```
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -105,33 +105,27 @@ Example `workflow.yml`:
 steps: 
   - id: foo
     uses: user/composite@v1
-    with:
-      your_name: "Octocat"
-  - run: echo oh ${{ steps.foo.outputs.bar }} 
+  - run: echo random-number ${{ steps.foo.outputs.random-number }} 
 ```
 
 Example `user/composite/action.yml`:
 
 ```yaml
 using: 'composite' 
-inputs:
-  your_name:
-    description: 'Your name'
-    default: 'Ethan'
 outputs:
-  bar: ${{ steps.my-step.my-output}}
+  random-number: ${{ steps.my-step.my-output}}
 steps: 
   - id: my-step
     run: |
       echo ::set-output name=my-output::my-value
-      echo hello ${{ inputs.your_name }} 
+      echo $RANDOM
 ```
 
 Example Output:
 
 ```
-hello Octocat
-oh hello Octocat
+43243
+random-number 43243
 ```
 
 Each of the output variables from the composite action is viewable from the workflow file that uses the composite action. In other words, every child action output(s) is viewable only by its parent using dot notation (ex `steps.foo.outputs.bar`).


### PR DESCRIPTION
In this ADR, I propose building the first version of Composite Actions which will allow users to run multiple run steps with the support of inputs, outputs, environment, and context for use in any steps as well as the if, timeout-minutes, and the continue-on-error attributes for each Composite Action step. 

https://github.com/actions/runner/blob/users/ethanchewy/compositeADR/docs/adrs/0549-composite-run-steps.md

This feature will eventually lead us on our way to develop a full functioning Composite Steps feature that addresses https://github.com/actions/runner/issues/438 (i.e. allowing actions to compose other actions).