### PR TITLE
Add to Contribute Docs bash commands for running custom runner and viewing logs

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -51,6 +51,19 @@ cd ./src
 ./dev.(sh/cmd) test # run all unit tests before git commit/push
 ```
 
+View logs:
+```bash
+cd runner/_layout/_diag
+ls
+cat (Runner/Worker)_TIMESTAMP.log # view your log file
+```
+
+Run Runner:
+```bash
+cd runner/_layout
+./run.sh # run your custom runner
+```
+
 ### Editors
 
 [Using Visual Studio Code](https://code.visualstudio.com/)


### PR DESCRIPTION
Add commands in the docs that tell you how to run the runner and how to view the logs. 