### PR TITLE
Add a "once" mode to RunnerService.js

### DIFF
--- a/src/Misc/layoutbin/RunnerService.js
+++ b/src/Misc/layoutbin/RunnerService.js
@@ -19,12 +19,16 @@ var listener = null;
 var runService = function() {
     var listenerExePath = path.join(__dirname, '../bin/Runner.Listener');
     var interactive = process.argv[2] === "interactive";
+    var runonce = process.argv[2] === "once";
 
     if(!stopping) {
         try {
             if (interactive) {
                 console.log('Starting Runner listener interactively');
                 listener = childProcess.spawn(listenerExePath, ['run'], { env: process.env });
+            } else if {
+                console.log('Staring runner listener in RunOnce mode');
+                listener = childProcess.spawn(listenerExePath, ['run', '--once'], { env: process.env });
             } else {
                 console.log('Starting Runner listener with startup type: service');
                 listener = childProcess.spawn(listenerExePath, ['run', '--startuptype', 'service'], { env: process.env });


### PR DESCRIPTION
This PR adds a "once" option to RunnerService.js that can be used like this:

```
./externals/node12/bin/node ./bin/RunnerService.js once
```

It does not add the option to runsvc.sh.

## Motivation

We are baking the runner into an AMI (AWS Machine Image) with Packer. We get the version by looking at the latest stable release via this API: https://api.github.com/repos/actions/runner/releases/latest , which at the time of writing is 2.263.0. We would like to run in RunOnce mode (for one-time-use org-level runners). At the time of writing, running 2.263.0 will automatically download 2.267.1 (which is listed as a pre-release version on GitHub) and shut down.

So we need to do the kind of handling that RunnerService.js is doing. Our options are to provide our own wrapper (that passes `--once`), patch the official one inside our AMI (we'd probably do this via Packer) or have this be officially supported like in this PR.

If you don't intend RunnerService.js to be something we launch directly (part of the "public API") I'm OK if you don't want to merge this.