### PR TITLE
(In progress) Refactor Codebase to Support Modular Composite Actions 

### DIFF
--- a/src/Runner.Worker/ActionManifestManager.cs
+++ b/src/Runner.Worker/ActionManifestManager.cs
@@ -376,6 +376,7 @@ namespace GitHub.Runner.Worker
                         {
                             var steps = run.Value.AssertSequence("steps");
                             var evaluator = executionContext.ToPipelineTemplateEvaluator();
+                            // TODO: Change this so that we process each type of step
                             stepsLoaded = evaluator.LoadCompositeSteps(steps);
                             break;
                         }

--- a/src/Runner.Worker/ActionManifestManager.cs
+++ b/src/Runner.Worker/ActionManifestManager.cs
@@ -325,7 +325,7 @@ namespace GitHub.Runner.Worker
             var postToken = default(StringToken);
             var postEntrypointToken = default(StringToken);
             var postIfToken = default(StringToken);
-            var stepsLoaded = default(List<Pipelines.ActionStep>);
+            var stepsLoaded = default(List<Pipelines.Step>);
 
             foreach (var run in runsMapping)
             {

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -48,50 +48,68 @@ namespace GitHub.Runner.Worker.Handlers
             // Add each composite action step to the front of the queue
             int location = 0;
 
+            
+
+            // While loop till we have reached the last layer?
+            Stack<Pipelines.Step> stepsToAppend = new Stack<Pipelines.Step>();
             // TODO: Assume that each step is not an actionStep
             // How do we handle all types of steps?????
-            
-            foreach (Pipelines.ActionStep aStep in actionSteps)
+
+            // Append in reverse order since we are using a stack
+            for (int i = actionSteps.Count - 1; i --> 0; )
             {
-                // Ex: 
-                // runs:
-                //      using: "composite"
-                //      steps:
-                //          - uses: example/test-composite@v2 (a)
-                //          - run echo hello world (b)
-                //          - run echo hello world 2 (c)
-                // 
-                // ethanchewy/test-composite/action.yaml
-                // runs:
-                //      using: "composite"
-                //      steps: 
-                //          - run echo hello world 3 (d)
-                //          - run echo hello world 4 (e)
-                // 
-                // Steps processed as follow:
-                // | a |
-                // | a | => | d |
-                // (Run step d)
-                // | a | 
-                // | a | => | e |
-                // (Run step e)
-                // | a | 
-                // (Run step a)
-                // | b | 
-                // (Run step b)
-                // | c |
-                // (Run step c)
-                // Done.
-
-                var actionRunner = HostContext.CreateService<IActionRunner>();
-                actionRunner.Action = aStep;
-                actionRunner.Stage = stage;
-                actionRunner.Condition = aStep.Condition;
-                actionRunner.DisplayName = aStep.DisplayName;
-
-                ExecutionContext.RegisterNestedStep(actionRunner, inputsData, location, Environment);
-                location++;
+                stepsToAppend.Append(actionSteps[i]);
             }
+            while (stepsToAppend != null)
+            {
+                var currentStep = stepsToAppend.Pop();
+            }
+
+            // foreach (Pipelines.Step aStep in actionSteps)
+            // {
+            //     // Ex: 
+            //     // runs:
+            //     //      using: "composite"
+            //     //      steps:
+            //     //          - uses: example/test-composite@v2 (a)
+            //     //          - run echo hello world (b)
+            //     //          - run echo hello world 2 (c)
+            //     // 
+            //     // ethanchewy/test-composite/action.yaml
+            //     // runs:
+            //     //      using: "composite"
+            //     //      steps: 
+            //     //          - run echo hello world 3 (d)
+            //     //          - run echo hello world 4 (e)
+            //     // 
+            //     // Steps processed as follow:
+            //     // | a |
+            //     // | a | => | d |
+            //     // (Run step d)
+            //     // | a | 
+            //     // | a | => | e |
+            //     // (Run step e)
+            //     // | a | 
+            //     // (Run step a)
+            //     // | b | 
+            //     // (Run step b)
+            //     // | c |
+            //     // (Run step c)
+            //     // Done.
+
+            //     // TODO: how are we going to order each step?
+            //     // How is this going to look in the UI (will we have a bunch of nesting)
+            //     // ^ We need to focus on how we are going to get the steps to run in the right order. 
+
+            //     var actionRunner = HostContext.CreateService<IActionRunner>();
+            //     actionRunner.Action = aStep;
+            //     actionRunner.Stage = stage;
+            //     actionRunner.Condition = aStep.Condition;
+            //     actionRunner.DisplayName = aStep.DisplayName;
+
+            //     ExecutionContext.RegisterNestedStep(actionRunner, inputsData, location, Environment);
+            //     location++;
+            // }
 
             return Task.CompletedTask;
         }

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -35,9 +35,6 @@ namespace GitHub.Runner.Worker.Handlers
 
             var tempDirectory = HostContext.GetDirectory(WellKnownDirectory.Temp);
 
-            // Resolve action steps
-            var actionSteps = Data.Steps;
-
             // Create Context Data to reuse for each composite action step
             var inputsData = new DictionaryContextData();
             foreach (var i in Inputs)
@@ -48,21 +45,47 @@ namespace GitHub.Runner.Worker.Handlers
             // Add each composite action step to the front of the queue
             int location = 0;
 
-            
+            // Resolve action steps
+            var compositeSteps = Data.Steps;
 
-            // While loop till we have reached the last layer?
-            Stack<Pipelines.Step> stepsToAppend = new Stack<Pipelines.Step>();
             // TODO: Assume that each step is not an actionStep
             // How do we handle all types of steps?????
 
-            // Append in reverse order since we are using a stack
-            for (int i = actionSteps.Count - 1; i --> 0; )
+            // While loop till we have reached the last layer?
+            List<Pipelines.Step> stepsToAppend = new List<Pipelines.Step>();
+
+            // First put each step in stepsToAppend
+            foreach (var step in compositeSteps)
             {
-                stepsToAppend.Append(actionSteps[i]);
+                stepsToAppend.Append(step);
             }
+
+            // We go through each step and push to the top of the stack its children. 
+            // That way, we go through each steps, steps of steps in order
+            // This is an ITERATIVE approach. While a recursive approach may be more elegant, 
+            // that would use a lot more memory in the call stack.
+            // Ex: 
+            // Let's say we have 4 composite steps with the first step that has 3 children
+            // A (composite step)=> a1, a2, a3
+            // B (non composite)
+            // C (non composite)
+            // D (non composite)
+            // It would be executed in this order => a1, a2, a3, A (steps within A), B, C, D
             while (stepsToAppend != null)
             {
-                var currentStep = stepsToAppend.Pop();
+                var currentStep = stepsToAppend[0];
+
+                // TODO: Create another StepsContext?
+                // In the original StepsRunner, we could lock the thread and only proceed after we finish processing these steps
+                // Then, we invoke the CompositeStepsRunner class?
+
+                // TODO: We have to create another Execution Context for Composite Actions
+                // See below
+
+                // TODO: Append to StepsRunner
+                // by invoking a RegisterNestedStep on the Composite Action Exeuction Context for Composite Action Steps
+
+
             }
 
             // foreach (Pipelines.Step aStep in actionSteps)

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -47,6 +47,10 @@ namespace GitHub.Runner.Worker.Handlers
 
             // Add each composite action step to the front of the queue
             int location = 0;
+
+            // TODO: Assume that each step is not an actionStep
+            // How do we handle all types of steps?????
+            
             foreach (Pipelines.ActionStep aStep in actionSteps)
             {
                 // Ex: 

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -264,14 +264,13 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             return result;
         }
 
-        //Note: originally was List<Step> but we need to change to List<ActionStep> to use the "Inputs" attribute
-        internal static List<ActionStep> ConvertToSteps(
+        internal static List<Step> ConvertToSteps(
             TemplateContext context,
             TemplateToken steps)
         {
             var stepsSequence = steps.AssertSequence($"job {PipelineTemplateConstants.Steps}");
 
-            var result = new List<ActionStep>();
+            var result = new List<Step>();
             foreach (var stepsItem in stepsSequence)
             {
                 var step = ConvertToStep(context, stepsItem);
@@ -287,7 +286,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             return result;
         }
 
-        private static ActionStep ConvertToStep(
+        private static Step ConvertToStep(
             TemplateContext context,
             TemplateToken stepsItem)
         {

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateEvaluator.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateEvaluator.cs
@@ -159,11 +159,11 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             return result;
         }
 
-        // Change to return a variety of steps.
-        public List<ActionStep> LoadCompositeSteps(
+        // TODO: Change to return a variety of steps.
+        public List<Step> LoadCompositeSteps(
             TemplateToken token)
         {
-            var result = default(List<ActionStep>);
+            var result = default(List<Step>);
             if (token != null && token.Type != TokenType.Null)
             {
                 var context = CreateContext(null, null, setMissingContext: false);

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateEvaluator.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateEvaluator.cs
@@ -159,6 +159,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             return result;
         }
 
+        // Change to return a variety of steps.
         public List<ActionStep> LoadCompositeSteps(
             TemplateToken token)
         {


### PR DESCRIPTION
In this PR, we plan to support **recognizing any** type of steps in a composite action. 

We are going to accomplish this by doing:

- [ ] Refactoring StepsRunner to ensure that it's only used for Job Level Steps
- [ ] Create a separate StepsRunner for only Composite Actions
- [ ] Modify existing code to parse through every type of step
  - [ ] Modify LoadCompositeSteps in PipelineTemplate Evaluator to support any step
  - [ ] Change for loop in composite actions handler to handle every type of step and create the "correct" child node with the right context attributes to trigger the correct handler!

- [ ] Refactor Execution Context
  - [ ] Global Execution Context
  - [ ] Job Steps Execution Context
  - [ ] Composite Execution Context
** Let's first start with seperating the composite stuff from the execution context and packaging that into the composite execution context. 

Additional changes that we might do in this PR or another PR depending on complexity:

1. Refactor ExecutionContext => Global => Job, Action => Composite Action

High level view: https://docs.google.com/document/d/1euUp55hp0CcAuaoATDieVvJMUTFbHc6zveNaTEKIY8A/edit#