### PR TITLE
Fix config error if path contains spaces

### DIFF
--- a/src/Misc/layoutroot/config.sh
+++ b/src/Misc/layoutroot/config.sh
@@ -67,7 +67,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-cd $DIR
+cd "$DIR"
 
 source ./env.sh
 


### PR DESCRIPTION
Minor bug fix.  Documented in issue:  https://github.com/actions/runner/issues/601
Example volume with space: `/Volumes/Macintosh HD - Data`
```
➜  actions-runner ./config.sh --url https://github.com/myorg --token redacted
./config.sh: line 70: cd: /Volumes/Macintosh: No such file or directory
```