### PR TITLE
Fold logs for intermediate docker commands

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -468,7 +468,7 @@ namespace GitHub.Runner.Worker
             ArgUtil.NotNull(setupInfo, nameof(setupInfo));
             ArgUtil.NotNullOrEmpty(setupInfo.Container.Image, nameof(setupInfo.Container.Image));
 
-            executionContext.Output($"Pull down action image '{setupInfo.Container.Image}'");
+            executionContext.Output($"##[group]Pull down action image '{setupInfo.Container.Image}'");
 
             // Pull down docker image with retry up to 3 times
             var dockerManger = HostContext.GetService<IDockerCommandManager>();
@@ -492,6 +492,7 @@ namespace GitHub.Runner.Worker
                     }
                 }
             }
+            executionContext.Output("##[endgroup");
 
             if (retryCount == 3 && pullExitCode != 0)
             {
@@ -511,7 +512,7 @@ namespace GitHub.Runner.Worker
             ArgUtil.NotNull(setupInfo, nameof(setupInfo));
             ArgUtil.NotNullOrEmpty(setupInfo.Container.Dockerfile, nameof(setupInfo.Container.Dockerfile));
 
-            executionContext.Output($"Build container for action use: '{setupInfo.Container.Dockerfile}'.");
+            executionContext.Output($"##[group]Build container for action use: '{setupInfo.Container.Dockerfile}'.");
 
             // Build docker image with retry up to 3 times
             var dockerManger = HostContext.GetService<IDockerCommandManager>();
@@ -541,6 +542,7 @@ namespace GitHub.Runner.Worker
                     }
                 }
             }
+            executionContext.Output("##[endgroup]");
 
             if (retryCount == 3 && buildExitCode != 0)
             {

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -49,8 +49,9 @@ namespace GitHub.Runner.Worker.Handlers
                 // ensure docker file exist
                 var dockerFile = Path.Combine(ActionDirectory, Data.Image);
                 ArgUtil.File(dockerFile, nameof(Data.Image));
-                ExecutionContext.Output($"Dockerfile for action: '{dockerFile}'.");
 
+                ExecutionContext.Output($"##[group]Building docker image");
+                ExecutionContext.Output($"Dockerfile for action: '{dockerFile}'.");
                 var imageName = $"{dockerManger.DockerInstanceLabel}:{ExecutionContext.Id.ToString("N")}";
                 var buildExitCode = await dockerManger.DockerBuild(
                     ExecutionContext,
@@ -58,6 +59,8 @@ namespace GitHub.Runner.Worker.Handlers
                     dockerFile,
                     Directory.GetParent(dockerFile).FullName,
                     imageName);
+                ExecutionContext.Output("##[endgroup]");
+
                 if (buildExitCode != 0)
                 {
                     throw new InvalidOperationException($"Docker build failed with exit code {buildExitCode}");


### PR DESCRIPTION
This tidies up the logs and makes them more consistent. For example, we fold logs for git and other operations that are not explicitly part of a workflow

This folds system level stuff like initialization of job/service containers, docker pull/build logs, etc. But, it does not fold every docker command, particularly `docker run` because those logs are the actual action output, usually. 

Since the usage of a particular docker command varies by context, I put the grouping at the caller, as to avoid folding everything with a generic line like `docker run` (see above: docker run is often important output that shouldnt be folded, but sometimes docker run/start are "system level" eg starting a service container)

Example: 
![image](https://user-images.githubusercontent.com/34109004/88109166-0d6d4380-cb78-11ea-84d2-5b49e89a41da.png)

Above, the logs for starting the different containers in my job are grouped together, and some of the extra intermediate stuff pulling/building the action image is collapses while maintaining the step output in my action step 