### PR TITLE
Improve Debugging Messages for Empty Tokens

### DIFF
--- a/src/Runner.Worker/ActionManifestManager.cs
+++ b/src/Runner.Worker/ActionManifestManager.cs
@@ -135,7 +135,7 @@ namespace GitHub.Runner.Worker
                 // Evaluate Runs Last
                 if (actionRunValueToken != null)
                 {
-                    actionDefinition.Execution = ConvertRuns(executionContext, templateContext, actionRunValueToken, actionOutputs);
+                    actionDefinition.Execution = ConvertRuns(executionContext, templateContext, actionRunValueToken, fileRelativePath, actionOutputs);
                 }
             }
             catch (Exception ex)
@@ -359,6 +359,7 @@ namespace GitHub.Runner.Worker
             IExecutionContext executionContext,
             TemplateContext templateContext,
             TemplateToken inputsToken,
+            String fileRelativePath,
             MappingToken outputs = null)
         {
             var runsMapping = inputsToken.AssertMapping("runs");
@@ -442,7 +443,7 @@ namespace GitHub.Runner.Worker
                 {
                     if (string.IsNullOrEmpty(imageToken?.Value))
                     {
-                        throw new ArgumentNullException($"Image is not provided.");
+                        throw new ArgumentNullException($"You are using a Container Action but an image is not provided in {fileRelativePath}.");
                     }
                     else
                     {
@@ -463,7 +464,7 @@ namespace GitHub.Runner.Worker
                 {
                     if (string.IsNullOrEmpty(mainToken?.Value))
                     {
-                        throw new ArgumentNullException($"Entry javascript file is not provided.");
+                        throw new ArgumentNullException($"You are using a JavaScript Action but there is not an entry JavaScript file provided in {fileRelativePath}.");
                     }
                     else
                     {
@@ -481,8 +482,7 @@ namespace GitHub.Runner.Worker
                 {
                     if (steps == null)
                     {
-                        // TODO: Add a more helpful error message + including file name, etc. to show user that it's because of their yaml file
-                        throw new ArgumentNullException($"No steps provided.");
+                        throw new ArgumentNullException($"You are using a composite action but there are no steps provided in {fileRelativePath}.");
                     }
                     else
                     {

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -846,7 +846,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     var traceFile = Path.GetTempFileName();
                     File.Copy(_hc.TraceFileName, traceFile, true);
-                    Assert.Contains("Entry javascript file is not provided.", File.ReadAllText(traceFile));
+                    Assert.Contains("You are using a JavaScript Action but there is not an entry JavaScript file provided in", File.ReadAllText(traceFile));
                 }
             }
             finally
@@ -2466,7 +2466,7 @@ runs:
                 {
                     var traceFile = Path.GetTempFileName();
                     File.Copy(_hc.TraceFileName, traceFile, true);
-                    Assert.Contains("Entry javascript file is not provided.", File.ReadAllText(traceFile));
+                    Assert.Contains("You are using a JavaScript Action but there is not an entry JavaScript file provided in", File.ReadAllText(traceFile));
                 }
             }
             finally


### PR DESCRIPTION
As part of the process for polishing Composite Run Steps, I've revisited my old TODOs. 

There’s only one TODO related directly to composite run steps (the other TODOs have to do with nested steps).

Namely:
`// TODO: Add a more helpful error message + including file name, etc. to show user that it's because of their yaml file`

In this PR, I add the filename associated with this error as well as add more clear language in the error message. I also change similar error messages that could use some improvement.

**Basically, I change the error message for null tokens to say, "You are using \<TypeOfAction\> but the \<TokenName\> is empty in \<FileRelativePath\>".**

Example: https://github.com/ethanchewy/testing-actions/runs/898870893?check_suite_focus=true