### PR TITLE
Clean Up Composite UI

### DIFF
--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -222,12 +222,6 @@ namespace GitHub.Runner.Worker.Handlers
 
         private async Task RunStepAsync(IStep step)
         {
-            // Try to evaluate the display name
-            // if (step is IActionRunner actionRunner && actionRunner.Stage == ActionRunStage.Main)
-            // {
-            //     actionRunner.TryEvaluateDisplayName(step.ExecutionContext.ExpressionValues, step.ExecutionContext);
-            // }
-
             // Start the step.
             Trace.Info("Starting the step.");
             step.ExecutionContext.Debug($"Starting: {step.DisplayName}");

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -223,10 +223,10 @@ namespace GitHub.Runner.Worker.Handlers
         private async Task RunStepAsync(IStep step)
         {
             // Try to evaluate the display name
-            if (step is IActionRunner actionRunner && actionRunner.Stage == ActionRunStage.Main)
-            {
-                actionRunner.TryEvaluateDisplayName(step.ExecutionContext.ExpressionValues, step.ExecutionContext);
-            }
+            // if (step is IActionRunner actionRunner && actionRunner.Stage == ActionRunStage.Main)
+            // {
+            //     actionRunner.TryEvaluateDisplayName(step.ExecutionContext.ExpressionValues, step.ExecutionContext);
+            // }
 
             // Start the step.
             Trace.Info("Starting the step.");

--- a/src/Runner.Worker/Handlers/ScriptHandler.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandler.cs
@@ -52,7 +52,7 @@ namespace GitHub.Runner.Worker.Handlers
                     firstLine = firstLine.Substring(0, firstNewLine);
                 }
 
-                writeDetails($"##[group]Run {firstLine}");
+                writeDetails(ExecutionContext.InsideComposite ? $"Run {firstLine}" : $"##[group]Run {firstLine}");
             }
             else
             {
@@ -84,17 +84,17 @@ namespace GitHub.Runner.Worker.Handlers
             if (string.IsNullOrEmpty(shell))
             {
 #if OS_WINDOWS
-                    shellCommand = "pwsh";
-                    if (validateShellOnHost)
+                shellCommand = "pwsh";
+                if (validateShellOnHost)
+                {
+                    shellCommandPath = WhichUtil.Which(shellCommand, require: false, Trace, prependPath);
+                    if (string.IsNullOrEmpty(shellCommandPath))
                     {
-                        shellCommandPath = WhichUtil.Which(shellCommand, require: false, Trace, prependPath);
-                        if (string.IsNullOrEmpty(shellCommandPath))
-                        {
-                            shellCommand = "powershell";
-                            Trace.Info($"Defaulting to {shellCommand}");
-                            shellCommandPath = WhichUtil.Which(shellCommand, require: true, Trace, prependPath);
-                        }
+                        shellCommand = "powershell";
+                        Trace.Info($"Defaulting to {shellCommand}");
+                        shellCommandPath = WhichUtil.Which(shellCommand, require: true, Trace, prependPath);
                     }
+                }
 #else
                 shellCommand = "sh";
                 if (validateShellOnHost)

--- a/src/Runner.Worker/Handlers/ScriptHandler.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandler.cs
@@ -138,7 +138,7 @@ namespace GitHub.Runner.Worker.Handlers
                 }
             }
 
-            writeDetails("##[endgroup]");
+            writeDetails(ExecutionContext.InsideComposite ? "" : "##[endgroup]");
         }
 
         public async Task RunAsync(ActionRunStage stage)


### PR DESCRIPTION
In this PR, I remove all of the "extra" information for each run step inside of the composite action. 

It's easier to see through an example:

- Before UI: https://github.com/ethanchewy/testing-actions/runs/895584439?check_suite_focus=true (debug off)
- New UI: https://github.com/ethanchewy/testing-actions/runs/899580810 (debugging turned on)

As you can see, our existing code has the equivalent information written to the debugging console as the "extra" information node.

Before Changes:
<img width="508" alt="Screen Shot 2020-07-22 at 1 52 57 PM" src="https://user-images.githubusercontent.com/8660827/88210745-a8225c80-cc22-11ea-9665-5437ad76b1b9.png">

After Changes:
<img width="380" alt="Screen Shot 2020-07-22 at 1 54 17 PM" src="https://user-images.githubusercontent.com/8660827/88210898-e28bf980-cc22-11ea-8875-8d35760fbbf7.png">
