### PR TITLE
MacOS: Fix poor performance of process spawned from svc daemon

### DIFF
--- a/src/Misc/layoutbin/actions.runner.plist.template
+++ b/src/Misc/layoutbin/actions.runner.plist.template
@@ -23,5 +23,7 @@
       <key>ACTIONS_RUNNER_SVC</key>
       <string>1</string>
     </dict>
+    <key>ProcessType</key>
+    <string>Interactive</string>
   </dict>
 </plist>


### PR DESCRIPTION
By default daemon running from `launchd` have a lower priority compared to when running straight from terminal. A simple test case to show that behavior is the following:

- Create a big dummy file `dd if=/dev/zero of=/tmp/tmp_10gb bs=1 count=0 seek=10g`
- Run `time shasum /tmp/tmp_10gb` straight from terminal. On our hosted runner that takes around 17sec
- Do the same from a GH action on the same computer it takes around 24sec (!)

Setting `ProcessType` to `Interactive` ensure that the process will run without CPU & I/O restrictions.

From `man launchd.plist`
> **ProcessType <string>**
     This optional key describes, at a high level, the intended purpose of the
     job.  The system will apply resource limits based on what kind of job it
     is. If left unspecified, the system will apply light resource limits to
     the job, throttling its CPU usage and I/O bandwidth. The following are
     valid values:
>  -  **Background**
           Background jobs are generally processes that do work that was not
           directly requested by the user. The resource limits applied to
           Background jobs are intended to prevent them from disrupting the
           user experience.
>  - **Standard**
           Standard jobs are equivalent to no ProcessType being set.
>  - **Adaptive**
           Adaptive jobs move between the Background and Interactive classifi-
           cations based on activity over XPC connections. See
           xpc_transaction_begin(3) for details.
>  - **Interactive**
           Interactive jobs run with the same resource limitations as apps,
           that is to say, none. Interactive jobs are critical to maintaining
           a responsive user experience, and this key should only be used if
           an app's ability to be responsive depends on it, and cannot be made
           Adaptive.

This setting is especially important to us as we're running performance tests within github action. It's also valuable to everyone as it will slightly improve CI times (we've shaved 30sec of 4min of CI)