### PR TITLE
Adding Documentation to ADR for Support for Script Execution + Explicit Definition

### DIFF
--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -4,7 +4,7 @@
 
 **Status**: Accepted
 
-## Context
+### Context
 
 Customers want to be able to compose actions from actions (ex: https://github.com/actions/runner/issues/438)
 
@@ -16,12 +16,12 @@ We don't want the workflow author to need to know how the internal workings of t
 
 A composite action is treated as **one** individual job step (this is known as encapsulation).
 
-## Decision
+### Decision
 
 **In this ADR, we only support running multiple run steps in an Action.** In doing so, we build in support for mapping and flowing the inputs, outputs, and env variables (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables).
 
-## Composite Run Steps Features
-This feature supports at the top action leve:
+### Composite Run Steps Features
+This feature supports at the top action level:
 - name
 - description
 - inputs
@@ -373,6 +373,6 @@ Here is a visual represenation of the [first example](#Steps)
 ```
 
 
-## Consequences
+### Consequences
 
 This ADR lays the framework for eventually supporting nested Composite Actions within Composite Actions. This ADR allows for users to run multiple run steps within a GitHub Composite Action with the support of inputs, outputs, environment, and context for use in any steps as well as the if, timeout-minutes, and the continue-on-error attributes for each Composite Action step. 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -20,6 +20,28 @@ A composite action is treated as **one** individual job step (this is known as e
 
 **In this ADR, we only support running multiple run steps in an Action.** In doing so, we build in support for mapping and flowing the inputs, outputs, and env variables (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables).
 
+## Composite Run Steps Features
+This feature supports at the top action leve:
+- name
+- description
+- inputs
+- runs
+- outputs
+
+This feature supports at the run step level:
+- name
+- id
+- run
+- env
+- shell
+- working-directory
+
+This feature **does not support** at the run step level:
+- timeout-minutes
+- secrets
+- conditionals (needs, if, etc.)
+- continue-on-error
+
 ### Steps
 
 Example `workflow.yml`

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -63,6 +63,40 @@ echo hello world 4
 
 We add a token called "composite" which allows our Runner code to process composite actions. By invoking "using: composite", our Runner code then processes the "steps" attribute, converts this template code to a list of steps, and finally runs each run step sequentially. If any step fails and there are no `if` conditions defined, the whole composite action job fails. 
 
+### Running Local Scripts
+
+Example 'workflow.yml':
+```yaml
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+    - uses: user/composite@v1
+```
+
+Example `user/composite/action.yml`:
+
+```yaml
+runs:
+  using: "composite"
+  steps: 
+    - run: chmod +x ${{env.GITHUB_ACTION_PATH}}/script.sh
+    - run: chmod +x ${{env.GITHUB_ACTION_PATH}}/test/script2.sh
+    - run: ${{env.GITHUB_ACTION_PATH}}/script.sh
+    - run: ${{env.GITHUB_ACTION_PATH}}/test/script2.sh
+```
+Where `user/composite` has the file structure:
+```
+.
++-- action.yml
++-- script.sh
++-- test
+|   +-- script2.sh
+```
+
+
+Users will be able to run scripts located in their action folder by first prepending the relative path and script name with `GITHUB_ACTION_PATH` which contains the path in which the composite action is downloaded to and where those "files" live.
+
 ### Inputs
 
 Example `workflow.yml`:

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -16,7 +16,6 @@ We don't want the workflow author to need to know how the internal workings of t
 
 A composite action is treated as **one** individual job step (this is known as encapsulation).
 
-
 ## Decision
 
 **In this ADR, we only support running multiple run steps in an Action.** In doing so, we build in support for mapping and flowing the inputs, outputs, and env variables (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables).
@@ -211,7 +210,7 @@ In the Composite Action, you'll only be able to use `::set-env::` to set environ
 
 ### Secrets
 
-**Note** : This feature will be focused on in a future ADR.
+**We will not support "Secrets" in a composite action for now. This functionality will be focused on in a future ADR.**
 
 We'll pass the secrets from the composite action's parents (ex: the workflow file) to the composite action. Secrets can be created in the composite action with the secrets context. In the actions yaml, we'll automatically mask the secret. 
 
@@ -247,6 +246,8 @@ runs:
     - run: echo "I will not run, as my current scope is now failing"
       shell: bash
 ```
+
+**We will not support "if Condition" in a composite action for now. This functionality will be focused on in a future ADR.**
 
 See the paragraph below for a rudimentary approach (thank you to @cybojenix for the idea, example, and explanation for this approach):
 
@@ -289,6 +290,8 @@ runs:
       shell: bash
 ```
 
+**We will not support "timeout-minutes" in a composite action for now. This functionality will be focused on in a future ADR.**
+
 A composite action in its entirety is a job. You can set both timeout-minutes for the whole composite action or its steps as long as the the sum of the `timeout-minutes` for each composite action step that has the attribute `timeout-minutes` is less than or equals to `timeout-minutes` for the composite action. There is no default timeout-minutes for each composite action step. 
 
 If the time taken for any of the steps in combination or individually exceed the whole composite action `timeout-minutes` attribute, the whole job will fail (1). If an individual step exceeds its own `timeout-minutes` attribute but the total time that has been used including this step is below the overall composite action `timeout-minutes`, the individual step will fail but the rest of the steps will run based on their own `timeout-minutes` attribute (they will still abide by condition (1) though).
@@ -326,6 +329,8 @@ runs:
     - run: echo "Hello World 2" <----- This step will run
       shell: bash
 ```
+
+**We will not support "continue-on-error" in a composite action for now. This functionality will be focused on in a future ADR.**
 
 If any of the steps fail in the composite action and the `continue-on-error` is set to `false` for the whole composite action step in the workflow file, then the steps below it will run. On the flip side, if `continue-on-error` is set to `true` for the whole composite action step in the workflow file, the next job step will run.
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -80,10 +80,10 @@ Example `user/composite/action.yml`:
 runs:
   using: "composite"
   steps: 
-    - run: chmod +x ${{env.GITHUB_ACTION_PATH}}/script.sh
-    - run: chmod +x ${{env.GITHUB_ACTION_PATH}}/test/script2.sh
-    - run: ${{env.GITHUB_ACTION_PATH}}/script.sh
-    - run: ${{env.GITHUB_ACTION_PATH}}/test/script2.sh
+    - run: chmod +x ${{ github.action_path }}/test/script2.sh
+    - run: chmod +x $GITHUB_ACTION_PATH/script.sh
+    - run: ${{ github.action_path }}/test/script2.sh
+    - run: $GITHUB_ACTION_PATH/script.sh
 ```
 Where `user/composite` has the file structure:
 ```
@@ -95,7 +95,7 @@ Where `user/composite` has the file structure:
 ```
 
 
-Users will be able to run scripts located in their action folder by first prepending the relative path and script name with `GITHUB_ACTION_PATH` which contains the path in which the composite action is downloaded to and where those "files" live.
+Users will be able to run scripts located in their action folder by first prepending the relative path and script name with `$GITHUB_ACTION_PATH` or `github.action_path` which contains the path in which the composite action is downloaded to and where those "files" live. Note, you'll have to use `chmod` before running each script if you do not git check in your script files into your github repo with the executable bit turned on.
 
 ### Inputs
 

--- a/docs/adrs/0549-composite-run-steps.md
+++ b/docs/adrs/0549-composite-run-steps.md
@@ -4,7 +4,7 @@
 
 **Status**: Accepted
 
-### Context
+## Context
 
 Customers want to be able to compose actions from actions (ex: https://github.com/actions/runner/issues/438)
 
@@ -16,7 +16,7 @@ We don't want the workflow author to need to know how the internal workings of t
 
 A composite action is treated as **one** individual job step (this is known as encapsulation).
 
-### Decision
+## Decision
 
 **In this ADR, we only support running multiple run steps in an Action.** In doing so, we build in support for mapping and flowing the inputs, outputs, and env variables (ex: All nested steps should have access to its parents' input variables and nested steps can overwrite the input variables).
 
@@ -373,6 +373,6 @@ Here is a visual represenation of the [first example](#Steps)
 ```
 
 
-### Consequences
+## Consequences
 
 This ADR lays the framework for eventually supporting nested Composite Actions within Composite Actions. This ADR allows for users to run multiple run steps within a GitHub Composite Action with the support of inputs, outputs, environment, and context for use in any steps as well as the if, timeout-minutes, and the continue-on-error attributes for each Composite Action step. 


### PR DESCRIPTION
Add documentation for script execution + explicit definition.

See: https://github.com/actions/runner/pull/615 , https://github.com/actions/runner/pull/605