### PR TITLE
Add configuration to ignore ICU requirement.

### DIFF
--- a/src/Runner.Listener/runtimeconfig.template.json
+++ b/src/Runner.Listener/runtimeconfig.template.json
@@ -1,0 +1,6 @@
+{
+ "$schema": "https://gist.githubusercontent.com/natemcmaster/0bdee16450f8ec1823f2c11af880ceeb/raw/runtimeconfig.template.schema.json",
+ "configProperties": {
+  "System.Globalization.Invariant": true
+ }
+}

--- a/src/Runner.PluginHost/runtimeconfig.template.json
+++ b/src/Runner.PluginHost/runtimeconfig.template.json
@@ -1,0 +1,6 @@
+{
+ "$schema": "https://gist.githubusercontent.com/natemcmaster/0bdee16450f8ec1823f2c11af880ceeb/raw/runtimeconfig.template.schema.json",
+ "configProperties": {
+  "System.Globalization.Invariant": true
+ }
+}

--- a/src/Runner.Worker/runtimeconfig.template.json
+++ b/src/Runner.Worker/runtimeconfig.template.json
@@ -1,0 +1,6 @@
+{
+ "$schema": "https://gist.githubusercontent.com/natemcmaster/0bdee16450f8ec1823f2c11af880ceeb/raw/runtimeconfig.template.schema.json",
+ "configProperties": {
+  "System.Globalization.Invariant": true
+ }
+}


### PR DESCRIPTION
See https://github.com/actions/runner/issues/629

* Three runtimes are present in the ARM actions-runner: [Listener, PluginHost, Worker]
* Use `runtimeconfig.template.json` to define the `System.Globalization.Invariant` value to true.

**Caveat**: I am no .NET Core dev, never used it, just following the docs I found [here](https://natemcmaster.com/blog/2019/01/09/netcore-primitives-3/). There's likely a better way to do this - just throwing this up as a follow-up/contribution to #629.