### PR TITLE
Add Null Checks to fix null ref and null key errors in Composite Actions

### DIFF
--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -142,9 +142,13 @@ namespace GitHub.Runner.Worker.Handlers
                     {
                         var outputsValue = val as StringContextData;
                         // Set output in the whole composite scope. 
-                        if (!String.IsNullOrEmpty(outputsName) && !String.IsNullOrEmpty(outputsValue))
+                        if (!String.IsNullOrEmpty(outputsValue))
                         {
                             ExecutionContext.SetOutput(outputsName, outputsValue, out _);
+                        }
+                        else
+                        {
+                            ExecutionContext.SetOutput(outputsName, "", out _);
                         }
                     }
                 }

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -91,7 +91,7 @@ namespace GitHub.Runner.Worker.Handlers
 
                 ProcessCompositeActionOutputs();
 
-                ExecutionContext.Global.StepsContext.ClearScope(ExecutionContext.GetFullyQualifiedContextName());
+                ExecutionContext.Global.StepsContext.ClearScope(childScopeName);
             }
             catch (Exception ex)
             {

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -89,10 +89,7 @@ namespace GitHub.Runner.Worker.Handlers
                 ExecutionContext.ExpressionValues["inputs"] = inputsData;
                 ExecutionContext.ExpressionValues["steps"] = ExecutionContext.Global.StepsContext.GetScope(ExecutionContext.GetFullyQualifiedContextName());
 
-                if (ExecutionContext.Result == TaskResult.Succeeded && ExecutionContext.Result == TaskResult.SucceededWithIssues)
-                {
-                    ProcessCompositeActionOutputs();
-                }
+                ProcessCompositeActionOutputs();
 
                 ExecutionContext.Global.StepsContext.ClearScope(ExecutionContext.GetFullyQualifiedContextName());
             }
@@ -137,15 +134,19 @@ namespace GitHub.Runner.Worker.Handlers
                 // }
                 foreach (var pair in actionOutputs)
                 {
+                    Trace.Info($"{StringUtil.ConvertToJson(pair)}");
                     var outputsName = pair.Key;
                     var outputsAttributes = pair.Value as DictionaryContextData;
                     outputsAttributes.TryGetValue("value", out var val);
-                    var outputsValue = val as StringContextData;
 
-                    // Set output in the whole composite scope. 
-                    if (!String.IsNullOrEmpty(outputsName) && !String.IsNullOrEmpty(outputsValue))
+                    if (val != null)
                     {
-                        ExecutionContext.SetOutput(outputsName, outputsValue, out _);
+                        var outputsValue = val as StringContextData;
+                        // Set output in the whole composite scope. 
+                        if (!String.IsNullOrEmpty(outputsName) && !String.IsNullOrEmpty(outputsValue))
+                        {
+                            ExecutionContext.SetOutput(outputsName, outputsValue, out _);
+                        }
                     }
                 }
             }

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -89,7 +89,10 @@ namespace GitHub.Runner.Worker.Handlers
                 ExecutionContext.ExpressionValues["inputs"] = inputsData;
                 ExecutionContext.ExpressionValues["steps"] = ExecutionContext.Global.StepsContext.GetScope(ExecutionContext.GetFullyQualifiedContextName());
 
-                ProcessCompositeActionOutputs();
+                if (ExecutionContext.Result == TaskResult.Succeeded && ExecutionContext.Result == TaskResult.SucceededWithIssues)
+                {
+                    ProcessCompositeActionOutputs();
+                }
 
                 ExecutionContext.Global.StepsContext.ClearScope(ExecutionContext.GetFullyQualifiedContextName());
             }

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -134,7 +134,6 @@ namespace GitHub.Runner.Worker.Handlers
                 // }
                 foreach (var pair in actionOutputs)
                 {
-                    Trace.Info($"{StringUtil.ConvertToJson(pair)}");
                     var outputsName = pair.Key;
                     var outputsAttributes = pair.Value as DictionaryContextData;
                     outputsAttributes.TryGetValue("value", out var val);

--- a/src/Runner.Worker/StepsContext.cs
+++ b/src/Runner.Worker/StepsContext.cs
@@ -20,7 +20,7 @@ namespace GitHub.Runner.Worker
             if (_contextData.TryGetValue(scopeName, out _))
             {
                 _contextData[scopeName] = new DictionaryContextData();
-            }
+            } 
         }
 
         public DictionaryContextData GetScope(string scopeName)

--- a/src/Runner.Worker/StepsContext.cs
+++ b/src/Runner.Worker/StepsContext.cs
@@ -21,7 +21,7 @@ namespace GitHub.Runner.Worker
             {
                 _contextData[scopeName] = new DictionaryContextData();
             }
-        }
+        } 
 
         public DictionaryContextData GetScope(string scopeName)
         {

--- a/src/Runner.Worker/StepsContext.cs
+++ b/src/Runner.Worker/StepsContext.cs
@@ -17,7 +17,7 @@ namespace GitHub.Runner.Worker
 
         public void ClearScope(string scopeName)
         {
-            if (scopeName != null && _contextData.TryGetValue(scopeName, out _))
+            if (_contextData.TryGetValue(scopeName, out _))
             {
                 _contextData[scopeName] = new DictionaryContextData();
             }

--- a/src/Runner.Worker/StepsContext.cs
+++ b/src/Runner.Worker/StepsContext.cs
@@ -21,7 +21,7 @@ namespace GitHub.Runner.Worker
             {
                 _contextData[scopeName] = new DictionaryContextData();
             }
-        } 
+        }
 
         public DictionaryContextData GetScope(string scopeName)
         {

--- a/src/Runner.Worker/StepsContext.cs
+++ b/src/Runner.Worker/StepsContext.cs
@@ -17,10 +17,10 @@ namespace GitHub.Runner.Worker
 
         public void ClearScope(string scopeName)
         {
-            if (_contextData.TryGetValue(scopeName, out _))
+            if (!String.IsNullOrEmpty(scopeName) && _contextData.TryGetValue(scopeName, out _))
             {
                 _contextData[scopeName] = new DictionaryContextData();
-            } 
+            }
         }
 
         public DictionaryContextData GetScope(string scopeName)

--- a/src/Runner.Worker/StepsContext.cs
+++ b/src/Runner.Worker/StepsContext.cs
@@ -17,10 +17,10 @@ namespace GitHub.Runner.Worker
 
         public void ClearScope(string scopeName)
         {
-            if (_contextData.TryGetValue(scopeName, out _))
+            if (scopeName != null && _contextData.TryGetValue(scopeName, out _))
             {
                 _contextData[scopeName] = new DictionaryContextData();
-            } 
+            }
         }
 
         public DictionaryContextData GetScope(string scopeName)

--- a/src/Runner.Worker/StepsContext.cs
+++ b/src/Runner.Worker/StepsContext.cs
@@ -17,10 +17,10 @@ namespace GitHub.Runner.Worker
 
         public void ClearScope(string scopeName)
         {
-            if (!String.IsNullOrEmpty(scopeName) && _contextData.TryGetValue(scopeName, out _))
+            if (_contextData.TryGetValue(scopeName, out _))
             {
                 _contextData[scopeName] = new DictionaryContextData();
-            }
+            } 
         }
 
         public DictionaryContextData GetScope(string scopeName)


### PR DESCRIPTION
If there are outputs defined in the composite action and they are not set in the composite action step, this results `Object reference not set to an instance of an object.`

In this PR, we fix this issue and add a null check so that when an output is not set, we simply move on. We also fix `ClearScope()` by passing the correct child scope name used for all the composite children to avoid `Value cannot be null.` which occurs if there is no ID set for the whole composite action step.

Original issue:

- workflow: https://github.com/cschleiden/include-workflow-test/runs/972658843?check_suite_focus=true
- action: https://github.com/cschleiden/include-workflow/blob/9838c4c085046e8184f04f973c2a28814c6dcfc1/action.yml