### PR TITLE
Support configure runner as ephemeral.

### DIFF
--- a/src/Runner.Common/ConfigurationStore.cs
+++ b/src/Runner.Common/ConfigurationStore.cs
@@ -34,6 +34,9 @@ namespace GitHub.Runner.Common
         public string PoolName { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
+        public bool Ephemeral { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
         public string ServerUrl { get; set; }
 
         [DataMember(EmitDefaultValue = false)]

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -125,9 +125,10 @@ namespace GitHub.Runner.Common
                 {
                     public static readonly string Check = "check";
                     public static readonly string Commit = "commit";
+                    public static readonly string Ephemeral = "ephemeral";
                     public static readonly string Help = "help";
                     public static readonly string Replace = "replace";
-                    public static readonly string Once = "once";
+                    public static readonly string Once = "once"; // TODO: Remove in 10/2021
                     public static readonly string RunAsService = "runasservice";
                     public static readonly string Unattended = "unattended";
                     public static readonly string Version = "version";

--- a/src/Runner.Listener/CommandSettings.cs
+++ b/src/Runner.Listener/CommandSettings.cs
@@ -29,10 +29,10 @@ namespace GitHub.Runner.Listener
         {
             Constants.Runner.CommandLine.Flags.Check,
             Constants.Runner.CommandLine.Flags.Commit,
+            Constants.Runner.CommandLine.Flags.Ephemeral,
             Constants.Runner.CommandLine.Flags.Help,
             Constants.Runner.CommandLine.Flags.Replace,
             Constants.Runner.CommandLine.Flags.RunAsService,
-            Constants.Runner.CommandLine.Flags.Once,
             Constants.Runner.CommandLine.Flags.Unattended,
             Constants.Runner.CommandLine.Flags.Version
         };
@@ -66,7 +66,9 @@ namespace GitHub.Runner.Listener
         public bool Help => TestFlag(Constants.Runner.CommandLine.Flags.Help);
         public bool Unattended => TestFlag(Constants.Runner.CommandLine.Flags.Unattended);
         public bool Version => TestFlag(Constants.Runner.CommandLine.Flags.Version);
+        public bool Ephemeral => TestFlag(Constants.Runner.CommandLine.Flags.Ephemeral);
 
+        // TODO: Remove in 10/2021
         public bool RunOnce => TestFlag(Constants.Runner.CommandLine.Flags.Once);
 
         // Constructor.

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -234,7 +234,7 @@ namespace GitHub.Runner.Listener
                     HostContext.StartupType = startType;
 
                     // Run the runner interactively or as service
-                    return await RunAsync(settings, command.RunOnce);
+                    return await RunAsync(settings, command.RunOnce || settings.Ephemeral);  // TODO: Remove RunOnce later.
                 }
                 else
                 {
@@ -512,7 +512,9 @@ Config Options:
  --labels string        Extra labels in addition to the default: 'self-hosted,{Constants.Runner.Platform},{Constants.Runner.PlatformArchitecture}'
  --work string          Relative runner work directory (default {Constants.Path.WorkDirectory})
  --replace              Replace any existing runner with the same name (default false)
- --pat                  GitHub personal access token used for checking network connectivity when executing `.{separator}run.{ext} --check`");
+ --pat                  GitHub personal access token used for checking network connectivity when executing `.{separator}run.{ext} --check`
+ --ephemeral            Configure the runner to only take one job and then let the service un-configure the runner after the job finishes (default false)");
+
 #if OS_WINDOWS
     _term.WriteLine($@" --runasservice   Run the runner as a service");
     _term.WriteLine($@" --windowslogonaccount string   Account to run the service as. Requires runasservice");

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -466,8 +466,16 @@ namespace GitHub.Runner.Listener
                         await jobDispatcher.ShutdownAsync();
                     }
 
-                    //TODO: make sure we don't mask more important exception
-                    await _listener.DeleteSessionAsync();
+                    try
+                    {
+                        await _listener.DeleteSessionAsync();
+                    }
+                    catch (Exception ex) when (runOnce)
+                    {
+                        // ignore exception during delete session for ephemeral runner since the runner might already be deleted from the server side
+                        // and the delete session call will ends up with 401.
+                        Trace.Info($"Ignore any exception during DeleteSession for an ephemeral runner. {ex}");
+                    }
 
                     messageQueueLoopTokenSource.Dispose();
                 }

--- a/src/Sdk/DTWebApi/WebApi/TaskAgentReference.cs
+++ b/src/Sdk/DTWebApi/WebApi/TaskAgentReference.cs
@@ -24,6 +24,7 @@ namespace GitHub.DistributedTask.WebApi
             this.OSDescription = referenceToBeCloned.OSDescription;
             this.ProvisioningState = referenceToBeCloned.ProvisioningState;
             this.AccessPoint = referenceToBeCloned.AccessPoint;
+            this.Ephemeral = referenceToBeCloned.Ephemeral;
 
             if (referenceToBeCloned.m_links != null)
             {
@@ -76,6 +77,16 @@ namespace GitHub.DistributedTask.WebApi
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
         public Boolean? Enabled
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Signifies that this Agent can only run one job and will be removed by the server after that one job finish.
+        /// </summary>
+        [DataMember]
+        public bool? Ephemeral
         {
             get;
             set;

--- a/src/Test/L0/Listener/RunnerL0.cs
+++ b/src/Test/L0/Listener/RunnerL0.cs
@@ -243,7 +243,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 runner.Initialize(hc);
                 var settings = new RunnerSettings
                 {
-                    PoolId = 43242
+                    PoolId = 43242,
+                    Ephemeral = true
                 };
 
                 var message = new TaskAgentMessage()
@@ -294,7 +295,7 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _configStore.Setup(x => x.IsServiceConfigured()).Returns(false);
                 //Act
-                var command = new CommandSettings(hc, new string[] { "run", "--once" });
+                var command = new CommandSettings(hc, new string[] { "run" });
                 Task<int> runnerTask = runner.ExecuteCommand(command);
 
                 //Assert
@@ -332,7 +333,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 runner.Initialize(hc);
                 var settings = new RunnerSettings
                 {
-                    PoolId = 43242
+                    PoolId = 43242,
+                    Ephemeral = true
                 };
 
                 var message1 = new TaskAgentMessage()
@@ -390,7 +392,7 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _configStore.Setup(x => x.IsServiceConfigured()).Returns(false);
                 //Act
-                var command = new CommandSettings(hc, new string[] { "run", "--once" });
+                var command = new CommandSettings(hc, new string[] { "run" });
                 Task<int> runnerTask = runner.ExecuteCommand(command);
 
                 //Assert
@@ -431,7 +433,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 var settings = new RunnerSettings
                 {
                     PoolId = 43242,
-                    AgentId = 5678
+                    AgentId = 5678,
+                    Ephemeral = true
                 };
 
                 var message1 = new TaskAgentMessage()
@@ -475,7 +478,7 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 _configStore.Setup(x => x.IsServiceConfigured()).Returns(false);
                 //Act
-                var command = new CommandSettings(hc, new string[] { "run", "--once" });
+                var command = new CommandSettings(hc, new string[] { "run" });
                 Task<int> runnerTask = runner.ExecuteCommand(command);
 
                 //Assert


### PR DESCRIPTION
The service will make sure to only ever send one job to this runner.
The service will remove the runner registration from service after the job finish.