### PR TITLE
Allow registry credentials for job/service containers

### DIFF
--- a/src/Runner.Worker/Container/ContainerInfo.cs
+++ b/src/Runner.Worker/Container/ContainerInfo.cs
@@ -34,6 +34,9 @@ namespace GitHub.Runner.Worker.Container
             _environmentVariables = container.Environment;
             this.IsJobContainer = isJobContainer;
             this.ContainerNetworkAlias = networkAlias;
+            this.RegistryAuthUsername = container.Credentials?.Username;
+            this.RegistryAuthPassword = container.Credentials?.Password;
+            this.RegistryServer = ParseRegistryServer(this.ContainerImage);
 
 #if OS_WINDOWS
             _pathMappings.Add(new PathMapping(hostContext.GetDirectory(WellKnownDirectory.Work), "C:\\__w"));
@@ -79,6 +82,9 @@ namespace GitHub.Runner.Worker.Container
         public string ContainerWorkDirectory { get; set; }
         public string ContainerCreateOptions { get; private set; }
         public string ContainerRuntimePath { get; set; }
+        public string RegistryServer { get; set; }
+        public string RegistryAuthUsername { get; set; }
+        public string RegistryAuthPassword { get; set; }
         public bool IsJobContainer { get; set; }
 
         public IDictionary<string, string> ContainerEnvironmentVariables
@@ -224,6 +230,16 @@ namespace GitHub.Runner.Worker.Container
         public void AddPathTranslateMapping(string hostCommonPath, string containerCommonPath)
         {
             _pathMappings.Insert(0, new PathMapping(hostCommonPath, containerCommonPath));
+        }
+
+        private string ParseRegistryServer(string image)
+        {
+            var imageSplit = image.Split('/');
+            if (imageSplit.Length > 0 && !string.IsNullOrEmpty(imageSplit[0]))
+            {
+                return imageSplit[0];
+            }
+            return "";
         }
 
         private void UpdateWebProxyEnv(RunnerWebProxy webProxy)

--- a/src/Runner.Worker/Container/ContainerInfo.cs
+++ b/src/Runner.Worker/Container/ContainerInfo.cs
@@ -36,7 +36,7 @@ namespace GitHub.Runner.Worker.Container
             this.ContainerNetworkAlias = networkAlias;
             this.RegistryAuthUsername = container.Credentials?.Username;
             this.RegistryAuthPassword = container.Credentials?.Password;
-            this.RegistryServer = ParseRegistryServer(this.ContainerImage);
+            this.RegistryServer = DockerUtil.ParseRegistryHostnameFromImageName(this.ContainerImage);
 
 #if OS_WINDOWS
             _pathMappings.Add(new PathMapping(hostContext.GetDirectory(WellKnownDirectory.Work), "C:\\__w"));
@@ -230,16 +230,6 @@ namespace GitHub.Runner.Worker.Container
         public void AddPathTranslateMapping(string hostCommonPath, string containerCommonPath)
         {
             _pathMappings.Insert(0, new PathMapping(hostCommonPath, containerCommonPath));
-        }
-
-        private string ParseRegistryServer(string image)
-        {
-            var imageSplit = image.Split('/');
-            if (imageSplit.Length > 0 && !string.IsNullOrEmpty(imageSplit[0]))
-            {
-                return imageSplit[0];
-            }
-            return "";
         }
 
         private void UpdateWebProxyEnv(RunnerWebProxy webProxy)

--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -17,7 +17,8 @@ namespace GitHub.Runner.Worker.Container
         string DockerPath { get; }
         string DockerInstanceLabel { get; }
         Task<DockerVersion> DockerVersion(IExecutionContext context);
-        Task<int> DockerPull(IExecutionContext context, string image, string configFileDirectory = null);
+        Task<int> DockerPull(IExecutionContext context, string image);
+        Task<int> DockerPull(IExecutionContext context, string image, string configFileDirectory);
         Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string dockerContext, string tag);
         Task<string> DockerCreate(IExecutionContext context, ContainerInfo container);
         Task<int> DockerRun(IExecutionContext context, ContainerInfo container, EventHandler<ProcessDataReceivedEventArgs> stdoutDataReceived, EventHandler<ProcessDataReceivedEventArgs> stderrDataReceived);
@@ -82,6 +83,11 @@ namespace GitHub.Runner.Worker.Container
             }
 
             return new DockerVersion(serverVersion, clientVersion);
+        }
+
+        public Task<int> DockerPull(IExecutionContext context, string image)
+        {
+            return DockerPull(context, image, null);
         }
 
         public async Task<int> DockerPull(IExecutionContext context, string image, string configFileDirectory)

--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using GitHub.Runner.Common;
 using GitHub.Runner.Sdk;
@@ -16,7 +17,7 @@ namespace GitHub.Runner.Worker.Container
         string DockerPath { get; }
         string DockerInstanceLabel { get; }
         Task<DockerVersion> DockerVersion(IExecutionContext context);
-        Task<int> DockerPull(IExecutionContext context, string image);
+        Task<int> DockerPull(IExecutionContext context, string image, string configFileDirectory = null);
         Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string dockerContext, string tag);
         Task<string> DockerCreate(IExecutionContext context, ContainerInfo container);
         Task<int> DockerRun(IExecutionContext context, ContainerInfo container, EventHandler<ProcessDataReceivedEventArgs> stdoutDataReceived, EventHandler<ProcessDataReceivedEventArgs> stderrDataReceived);
@@ -31,6 +32,7 @@ namespace GitHub.Runner.Worker.Container
         Task<int> DockerExec(IExecutionContext context, string containerId, string options, string command, List<string> outputs);
         Task<List<string>> DockerInspect(IExecutionContext context, string dockerObject, string options);
         Task<List<PortMapping>> DockerPort(IExecutionContext context, string containerId);
+        Task<int> DockerLogin(IExecutionContext context, string configFileDirectory, string registry, string username, string password);
     }
 
     public class DockerCommandManager : RunnerService, IDockerCommandManager
@@ -82,9 +84,13 @@ namespace GitHub.Runner.Worker.Container
             return new DockerVersion(serverVersion, clientVersion);
         }
 
-        public async Task<int> DockerPull(IExecutionContext context, string image)
+        public async Task<int> DockerPull(IExecutionContext context, string image, string configFileDirectory)
         {
-            return await ExecuteDockerCommandAsync(context, "pull", image, context.CancellationToken);
+            if (string.IsNullOrEmpty(configFileDirectory))
+            {
+                return await ExecuteDockerCommandAsync(context, $"pull", image, context.CancellationToken);
+            }
+            return await ExecuteDockerCommandAsync(context, $"--config {configFileDirectory} pull", image, context.CancellationToken);
         }
 
         public async Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string dockerContext, string tag)
@@ -345,6 +351,31 @@ namespace GitHub.Runner.Worker.Container
             List<string> portMappingLines = await ExecuteDockerCommandAsync(context, "port", containerId);
             return DockerUtil.ParseDockerPort(portMappingLines);
         }
+
+        public async Task<int> DockerLogin(IExecutionContext context, string configFileDirectory, string registry, string username, string password)
+        {
+            string args = $"--config {configFileDirectory} login {registry} -u {username} --password-stdin";
+            context.Command($"{DockerPath} {args}");
+
+            var input = Channel.CreateBounded<string>(new BoundedChannelOptions(1) { SingleReader = true, SingleWriter = true });
+            input.Writer.TryWrite(password);
+
+            var processInvoker = HostContext.CreateService<IProcessInvoker>();
+
+            var task = processInvoker.ExecuteAsync(
+                workingDirectory: context.GetGitHubContext("workspace"),
+                fileName: DockerPath,
+                arguments: args,
+                environment: null,
+                requireExitCodeZero: false,
+                outputEncoding: null,
+                killProcessOnCancel: false,
+                redirectStandardIn: input,
+                cancellationToken: context.CancellationToken);
+
+            return await task;
+        }
+
 
         private Task<int> ExecuteDockerCommandAsync(IExecutionContext context, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -358,7 +358,7 @@ namespace GitHub.Runner.Worker.Container
             return DockerUtil.ParseDockerPort(portMappingLines);
         }
 
-        public async Task<int> DockerLogin(IExecutionContext context, string configFileDirectory, string registry, string username, string password)
+        public Task<int> DockerLogin(IExecutionContext context, string configFileDirectory, string registry, string username, string password)
         {
             string args = $"--config {configFileDirectory} login {registry} -u {username} --password-stdin";
             context.Command($"{DockerPath} {args}");
@@ -368,7 +368,7 @@ namespace GitHub.Runner.Worker.Container
 
             var processInvoker = HostContext.CreateService<IProcessInvoker>();
 
-            var task = processInvoker.ExecuteAsync(
+            return processInvoker.ExecuteAsync(
                 workingDirectory: context.GetGitHubContext("workspace"),
                 fileName: DockerPath,
                 arguments: args,
@@ -378,10 +378,7 @@ namespace GitHub.Runner.Worker.Container
                 killProcessOnCancel: false,
                 redirectStandardIn: input,
                 cancellationToken: context.CancellationToken);
-
-            return await task;
         }
-
 
         private Task<int> ExecuteDockerCommandAsync(IExecutionContext context, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/src/Runner.Worker/Container/DockerUtil.cs
+++ b/src/Runner.Worker/Container/DockerUtil.cs
@@ -45,5 +45,21 @@ namespace GitHub.Runner.Worker.Container
             }
             return "";
         }
+
+        public static string ParseRegistryHostnameFromImageName(string name)
+        {
+            var nameSplit = name.Split('/');
+            // Single slash is implictly from Dockerhub, unless first part has .tld or :port
+            if (nameSplit.Length == 2 && (nameSplit[0].Contains(":") || nameSplit[0].Contains(".")))
+            {
+                return nameSplit[0];
+            }
+            // All other non Dockerhub registries
+            else if (nameSplit.Length > 2)
+            {
+                return nameSplit[0];
+            }
+            return "";
+        }
     }
 }

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -449,9 +449,9 @@ namespace GitHub.Runner.Worker
 
         private async Task<string> ContainerRegistryLogin(IExecutionContext executionContext, ContainerInfo container)
         {
-            if (string.IsNullOrEmpty(container.RegistryAuthUsername) || string.IsNullOrEmpty(container.RegistryAuthUsername))
+            if (string.IsNullOrEmpty(container.RegistryAuthUsername) || string.IsNullOrEmpty(container.RegistryAuthPassword))
             {
-                // No client config required
+                // No valid client config can be generated
                 return "";
             }
             var configLocation = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Temp), $".docker_{Guid.NewGuid()}");

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -198,6 +198,9 @@ namespace GitHub.Runner.Worker
                 }
             }
 
+            // TODO: Add at a later date. This currently no local package registry to test with
+            // UpdateRegistryAuthForGitHubToken(executionContext, container);
+
             // Before pulling, generate client authentication if required
             var configLocation = await ContainerRegistryLogin(executionContext, container);
 
@@ -486,6 +489,39 @@ namespace GitHub.Runner.Worker
             catch (Exception e)
             {
                 throw new InvalidOperationException($"Failed to remove directory containing Docker client credentials: {e.Message}");
+            }
+        }
+
+        private void UpdateRegistryAuthForGitHubToken(IExecutionContext executionContext, ContainerInfo container)
+        {
+            var registryIsTokenCompatible = container.RegistryServer.Equals("docker.pkg.github.com", StringComparison.OrdinalIgnoreCase);
+            if (!registryIsTokenCompatible)
+            {
+                return;
+            }
+
+            var registryMatchesWorkflow = false;
+
+            // REGISTRY/OWNER/REPO/IMAGE[:TAG]
+            var imageParts = container.ContainerImage.Split('/');
+            if (imageParts.Length != 4)
+            {
+                executionContext.Warning($"Could not identify owner and repo for container image {container.ContainerImage}. Skipping automatic token auth");
+                return;
+            }
+            var owner = imageParts[1];
+            var repo = imageParts[2];
+            var nwo = $"{owner}/{repo}";
+            if (nwo.Equals(executionContext.GetGitHubContext("repository"), StringComparison.OrdinalIgnoreCase))
+            {
+                registryMatchesWorkflow = true;
+            }
+
+            var registryCredentialsNotSupplied = string.IsNullOrEmpty(container.RegistryAuthUsername) && string.IsNullOrEmpty(container.RegistryAuthPassword);
+            if (registryCredentialsNotSupplied && registryMatchesWorkflow)
+            {
+                container.RegistryAuthUsername = executionContext.GetGitHubContext("actor");
+                container.RegistryAuthPassword = executionContext.GetGitHubContext("token");
             }
         }
     }

--- a/src/Sdk/DTPipelines/Pipelines/JobContainer.cs
+++ b/src/Sdk/DTPipelines/Pipelines/JobContainer.cs
@@ -56,5 +56,36 @@ namespace GitHub.DistributedTask.Pipelines
             get;
             set;
         }
+
+        /// <summary>
+        /// Gets or sets the credentials used for pulling the container iamge.
+        /// </summary>
+        public ContainerRegistryCredentials Credentials
+        {
+            get;
+            set;
+        }
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class ContainerRegistryCredentials
+    {
+        /// <summary>
+        /// Gets or sets the user to authenticate to a registry with
+        /// </summary>
+        public String Username
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the password to authenticate to a registry with
+        /// </summary>
+        public String Password
+        {
+            get;
+            set;
+        }
     }
 }

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
@@ -14,6 +14,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
         public const String Clean= "clean";
         public const String Container = "container";
         public const String ContinueOnError = "continue-on-error";
+        public const String Credentials = "credentials";
         public const String Defaults = "defaults";
         public const String Env = "env";
         public const String Event = "event";
@@ -45,6 +46,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
         public const String Options = "options";
         public const String Outputs = "outputs";
         public const String OutputsPattern = "needs.*.outputs";
+        public const String Password = "password";
         public const String Path = "path";
         public const String Pool = "pool";
         public const String Ports = "ports";
@@ -68,6 +70,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
         public const String Success = "success";
         public const String Template = "template";
         public const String TimeoutMinutes = "timeout-minutes";
+        public const String Username = "username";
         public const String Uses = "uses";
         public const String VmImage = "vmImage";
         public const String Volumes = "volumes";

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -209,6 +209,30 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             return (Int32)numberToken.Value;
         }
 
+        internal static ContainerRegistryCredentials ConvertToContainerCredentials(TemplateToken token)
+        {
+            var credentials = token.AssertMapping(PipelineTemplateConstants.Credentials);
+            var result = new ContainerRegistryCredentials();
+            foreach (var credentialProperty in credentials)
+            {
+                var propertyName = credentialProperty.Key.AssertString($"{PipelineTemplateConstants.Credentials} key");
+                switch (propertyName.Value)
+                {
+                    case PipelineTemplateConstants.Username:
+                        result.Username = credentialProperty.Value.AssertString(PipelineTemplateConstants.Username).Value;
+                        break;
+                    case PipelineTemplateConstants.Password:
+                        result.Password = credentialProperty.Value.AssertString(PipelineTemplateConstants.Password).Value;
+                        break;
+                    default:
+                        propertyName.AssertUnexpectedValue($"{PipelineTemplateConstants.Credentials} key {propertyName}");
+                        break;
+                }
+            }
+
+            return result;
+        }
+
         internal static JobContainer ConvertToJobContainer(
             TemplateContext context,
             TemplateToken value,
@@ -274,6 +298,9 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                                 volumeList.Add(volumeString);
                             }
                             result.Volumes = volumeList;
+                            break;
+                        case PipelineTemplateConstants.Credentials:
+                            result.Credentials = ConvertToContainerCredentials(containerPropertyPair.Value);
                             break;
                         default:
                             propertyName.AssertUnexpectedValue($"{PipelineTemplateConstants.Container} key");

--- a/src/Sdk/DTPipelines/workflow-v1.0.json
+++ b/src/Sdk/DTPipelines/workflow-v1.0.json
@@ -373,7 +373,8 @@
           "options": "non-empty-string",
           "env": "container-env",
           "ports": "sequence-of-non-empty-string",
-          "volumes": "sequence-of-non-empty-string"
+          "volumes": "sequence-of-non-empty-string",
+          "credentials": "container-registry-credentials"
         }
       }
     },
@@ -402,6 +403,20 @@
         "non-empty-string",
         "container-mapping"
       ]
+    },
+
+    "container-registry-credentials": {
+      "context": [
+        "secrets",
+        "env",
+        "github"
+      ],
+      "mapping": {
+        "properties": {
+          "username": "non-empty-string",
+          "password": "non-empty-string"
+        }
+      }
     },
 
     "container-env": {

--- a/src/Test/L0/Container/DockerUtilL0.cs
+++ b/src/Test/L0/Container/DockerUtilL0.cs
@@ -126,5 +126,23 @@ namespace GitHub.Runner.Common.Tests.Worker.Container
             Assert.NotNull(result5);
             Assert.Equal("/foo/bar:/baz", result5);
         }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData("dockerhub/repo", "")]
+        [InlineData("localhost/doesnt_work", "")]
+        [InlineData("localhost:port/works", "localhost:port")]
+        [InlineData("host.tld/works", "host.tld")]
+        [InlineData("ghcr.io/owner/image", "ghcr.io")]
+        [InlineData("gcr.io/project/image", "gcr.io")]
+        [InlineData("myregistry.azurecr.io/namespace/image", "myregistry.azurecr.io")]
+        [InlineData("account.dkr.ecr.region.amazonaws.com/image", "account.dkr.ecr.region.amazonaws.com")]
+        [InlineData("docker.pkg.github.com/owner/repo/image", "docker.pkg.github.com")]
+        public void ParseRegistryHostnameFromImageName(string input, string expected)
+        {
+            var actual = DockerUtil.ParseRegistryHostnameFromImageName(input);
+            Assert.Equal(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
This lets you specify credentials for job and service containers, with the following example syntax:

```yaml
jobs:
  private-container:
    runs-on: [ self-hosted ]
    env:
      USER: username
    services:
      myservice: 
        image: ghcr.io/OWNER/NAME
        credentials:
          username: ${{ env.USER }}
          password: ${{ secrets.GHCR_TOKEN }}
    container:
      image: ghcr.io/OWNER/NAME
      credentials:
        username: ${{ github.actor }}
        password: ${{ secrets.GHCR_TOKEN }}
    steps:
    - run: echo hi
```

Where values can come from `github`,`env`, or `secrets` contexts.

Mechanically, it just runs `docker login` before running `docker pull`, creating a temporary, container-specific docker config file, which is deleted after the pull