### PR TITLE
fixed bug in check of libicu presence

### DIFF
--- a/src/Misc/layoutroot/config.sh
+++ b/src/Misc/layoutroot/config.sh
@@ -50,7 +50,7 @@ then
     fi
 
     libpath=${LD_LIBRARY_PATH:-}
-    $LDCONFIG_COMMAND -NXv ${libpath//:/} 2>&1 | grep libicu >/dev/null 2>&1
+    $LDCONFIG_COMMAND -NXv ${libpath//:/ } 2>&1 | grep libicu >/dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "Libicu's dependencies is missing for Dotnet Core 3.0"
         echo "Execute ./bin/installdependencies.sh to install any missing Dotnet Core 3.0 dependencies."


### PR DESCRIPTION
### The bug
If the `LD_LIBRARY_PATH` variable consists of multiple paths separated by ":", and `libicu` is installed in one of these paths, the `./config.sh` script erroneously say that *Libicu's dependencies is missing for Dotnet Core 3.0*.

### The reason
In the line 53, the `${libpath//:/}` replaces the ":" symbol with empty string, which just concatenates the multiple paths from `LD_LIBRARY_PATH`. This results in a gibberish path, and libraries are not being found.

### The solution
I changed this line to replace the ":" symbol with space, which causes `ldconfig` to search all the paths and find the libraries.
