### PR TITLE
log runner group name

### DIFF
--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -74,6 +74,10 @@ namespace GitHub.Runner.Worker
                         {
                             // print out HostName for self-hosted runner
                             context.Output($"Runner name: '{setting.AgentName}'");
+                            if (message.Variables.TryGetValue("system.runnerGroupName", out VariableValue runnerGroupName))
+                            {
+                              context.Output($"Runner group name: '{runnerGroupName}'");
+                            }
                             context.Output($"Machine name: '{Environment.MachineName}'");
                         }
                     }

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -76,7 +76,7 @@ namespace GitHub.Runner.Worker
                             context.Output($"Runner name: '{setting.AgentName}'");
                             if (message.Variables.TryGetValue("system.runnerGroupName", out VariableValue runnerGroupName))
                             {
-                              context.Output($"Runner group name: '{runnerGroupName}'");
+                                context.Output($"Runner group name: '{runnerGroupName.Value}'");
                             }
                             context.Output($"Machine name: '{Environment.MachineName}'");
                         }


### PR DESCRIPTION
This PR logs the runner group name in the Set up job step.

This variable isn't being sent yet but this PR should work fine without it (it'll have no affect) and then once it starts getting sent it'll start being logged.