### PR TITLE
Use POSIX syntax for `fatal` function def

### DIFF
--- a/scripts/create-latest-svc.sh
+++ b/scripts/create-latest-svc.sh
@@ -40,8 +40,7 @@ sudo echo
 runner_plat=linux
 [ ! -z "$(which sw_vers)" ] && runner_plat=osx;
 
-function fatal()
-{
+fatal() {
    echo "error: $1" >&2
    exit 1
 }


### PR DESCRIPTION
I invoked this script from a `/bin/sh` script, as `./create-latest-svc.sh`, and got:

```
./create-latest-svc.sh: 43: ./create-latest-svc.sh: Syntax error: "(" unexpected 
```

The Bash version on this machine is `GNU bash, version 5.0.3(1)-release (x86_64-pc-linux-gnu) `.

`man bash` seems to indicate the parentheses are optional, so I'm not sure why it's complaining. The POSIX shell command language ([here](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09_05) doesn't keywordize `function`, but does require parens:

```
foo() {
  ...
}
```

While I'm not 100% sure what set of modes Bash has that's causing it to reject the `function` + parens syntax, removing the bashism does fix it for me.  ¯\_(ツ)_/¯