### PR TITLE
Improve apt handling

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -53,65 +53,43 @@ then
         command -v apt
         if [ $? -eq 0 ]
         then
-            apt update && apt install -y liblttng-ust0 libkrb5-3 zlib1g
-            if [ $? -ne 0 ]
-            then
-                echo "'apt' failed with exit code '$?'"
-                print_errormessage
-                exit 1
-            fi
-
-            # libissl version prefer: libssl1.1 -> libssl1.0.2 -> libssl1.0.0
-            apt install -y libssl1.1$ || apt install -y libssl1.0.2$ || apt install -y libssl1.0.0$
-            if [ $? -ne 0 ]
-            then
-                echo "'apt' failed with exit code '$?'"
-                print_errormessage
-                exit 1
-            fi
-
-            # libicu version prefer: libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
-            apt install -y libicu66 || apt install -y libicu63 || apt install -y libicu60 || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
-            if [ $? -ne 0 ]
-            then
-                echo "'apt' failed with exit code '$?'"
-                print_errormessage
-                exit 1
-            fi
+            apt_get=apt
         else
             command -v apt-get
             if [ $? -eq 0 ]
             then
-                apt-get update && apt-get install -y liblttng-ust0 libkrb5-3 zlib1g
-                if [ $? -ne 0 ]
-                then
-                    echo "'apt-get' failed with exit code '$?'"
-                    print_errormessage
-                    exit 1
-                fi
-                
-                # libissl version prefer: libssl1.1 -> libssl1.0.2 -> libssl1.0.0
-                apt-get install -y libssl1.1$ || apt-get install -y libssl1.0.2$ || apt install -y libssl1.0.0$
-                if [ $? -ne 0 ]
-                then
-                    echo "'apt-get' failed with exit code '$?'"
-                    print_errormessage
-                    exit 1
-                fi
-
-                # libicu version prefer: libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
-                apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
-                if [ $? -ne 0 ]
-                then
-                    echo "'apt-get' failed with exit code '$?'"
-                    print_errormessage
-                    exit 1
-                fi
+                apt_get=apt-get
             else
                 echo "Can not find 'apt' or 'apt-get'"
                 print_errormessage
                 exit 1
             fi
+        fi
+            
+        $apt_get update && $apt_get install -y liblttng-ust0 libkrb5-3 zlib1g
+        if [ $? -ne 0 ]
+        then
+            echo "'$apt_get' failed with exit code '$?'"
+            print_errormessage
+            exit 1
+        fi
+
+        # libissl version prefer: libssl1.1 -> libssl1.0.2 -> libssl1.0.0
+        $apt_get install -y libssl1.1$ || $apt_get install -y libssl1.0.2$ || $apt_get install -y libssl1.0.0$
+        if [ $? -ne 0 ]
+        then
+            echo "'$apt_get' failed with exit code '$?'"
+            print_errormessage
+            exit 1
+        fi
+
+        # libicu version prefer: libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+        $apt_get install -y libicu66 || $apt_get install -y libicu63 || $apt_get install -y libicu60 || $apt_get install -y libicu57 || $apt_get install -y libicu55 || $apt_get install -y libicu52
+        if [ $? -ne 0 ]
+        then
+            echo "'$apt_get' failed with exit code '$?'"
+            print_errormessage
+            exit 1
         fi
     elif [ -e /etc/redhat-release ]
     then

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -49,18 +49,18 @@ then
         cat /etc/debian_version
         echo "------------------------------"
         
-        # prefer apt over apt-get        
-        command -v apt
+        # prefer apt-get over apt
+        command -v apt-get
         if [ $? -eq 0 ]
         then
-            apt_get=apt
+            apt_get=apt-get
         else
-            command -v apt-get
+            command -v apt
             if [ $? -eq 0 ]
             then
-                apt_get=apt-get
+                apt_get=apt
             else
-                echo "Can not find 'apt' or 'apt-get'"
+                echo "Can not find 'apt-get' or 'apt'"
                 print_errormessage
                 exit 1
             fi

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -60,7 +60,7 @@ then
             then
                 apt_get=apt
             else
-                echo "Can not find 'apt-get' or 'apt'"
+                echo "Found neither 'apt-get' nor 'apt'"
                 print_errormessage
                 exit 1
             fi

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -94,7 +94,7 @@ then
             fi
         }
 
-        # libissl version prefer: libssl1.1 -> libssl1.0.2 -> libssl1.0.0
+        # libssl version prefer: libssl1.1 -> libssl1.0.2 -> libssl1.0.0
         apt_get_with_fallbacks libssl1.1$ libssl1.0.2$ libssl1.0.0$
         if [ $? -ne 0 ]
         then


### PR DESCRIPTION
1. apt's cli isn't stable, and it certainly isn't stable across the supported platforms for this script.
    ```sh
    $ docker run debian:buster-slim sh -c 'apt update'
    
    WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
    ```
1. this script prior to this series occasionally tries to use `apt` even though it already knows `apt` isn't available.
1. minor grammatical / stylistic issues, a typo, and some whitespace.
1. the way `apt`/`apt-get` handle `$` is interesting, yielding some unfortunate outcomes:

```sh
root@fac33d9cb74a:/# apt install -y libssl1.0.2$ || apt install -y libssl1.0.0$ || apt-get install -y libssl1.1$
+ apt install -y 'libssl1.0.2$'
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'libssl1.0.2' for regex 'libssl1.0.2$'
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```

```sh
root@fac33d9cb74a:/# apt_get_with_fallbacks libssl1.0.0$ libssl1.2$ libssl1.1$ libssl1.0.2$
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'libssl1.0.0' for regex 'libssl1.0.0$'
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package libssl1.2$
E: Couldn't find any package by glob 'libssl1.2$'
E: Couldn't find any package by regex 'libssl1.2$'
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'libssl1.1' for regex 'libssl1.1$'
The following NEW packages will be installed:
  libssl1.1
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 1538 kB of archives.
After this operation, 4175 kB of additional disk space will be used.
Get:1 http://deb.debian.org/debian buster/main amd64 libssl1.1 amd64 1.1.1d-0+deb10u3 [1538 kB]
Fetched 1538 kB in 0s (9933 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package libssl1.1:amd64.
(Reading database ... 6476 files and directories currently installed.)
Preparing to unpack .../libssl1.1_1.1.1d-0+deb10u3_amd64.deb ...
Unpacking libssl1.1:amd64 (1.1.1d-0+deb10u3) ...
Setting up libssl1.1:amd64 (1.1.1d-0+deb10u3) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.28.1 /usr/local/share/perl/5.28.1 /usr/lib/x86_64-linux-gnu/perl5/5.28 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.28 /usr/share/perl/5.28 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Processing triggers for libc-bin (2.28-10) ...
```