### PR TITLE
Expose retention days in env for toolkit/artifacts package

### DIFF
--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -23,6 +23,7 @@ namespace GitHub.Runner.Worker
             "ref",
             "repository",
             "repository_owner",
+            "retention_days",
             "run_id",
             "run_number",
             "server_url",


### PR DESCRIPTION
We want to enable custom retention days for artifacts.  Artifacts are backed by the `toolkit/artifacts` package so we need to expose this value as an environment variable, and then the `artifacts` package will be able to consume it.