### PR TITLE
Notify on unsecure commands

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -142,7 +142,7 @@ namespace GitHub.Runner.Common
             public static readonly string WorkerCrash = "WORKER_CRASH";
             public static readonly string UnsupportedCommand = "UNSUPPORTED_COMMAND";
             public static readonly string UnsupportedCommandMessage = "The `{0}` command is depreciated and will soon be disabled. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
-            public static readonly string UnsupportedCommandMessageGHES = "The `{0}` command is disabled. Please upgrade to using Environment Files or to opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable on the Runner to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
+            public static readonly string UnsupportedCommandMessageDisabled = "The `{0}` command is disabled. Please upgrade to using Environment Files or to opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable on the Runner to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
         }
 
         public static class RunnerEvent

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -141,7 +141,7 @@ namespace GitHub.Runner.Common
             public static readonly string InternalTelemetryIssueDataKey = "_internal_telemetry";
             public static readonly string WorkerCrash = "WORKER_CRASH";
             public static readonly string UnsupportedCommand = "UNSUPPORTED_COMMAND";
-            public static readonly string UnsupportedCommandMessage = "The `{0}` command is disabled. Please upgrade to using Environment Files to set the env, or to opt into unsecure command execution by setting `ACTIONS_ALLOW_UNSECURE_COMMANDS` to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
+            public static readonly string UnsupportedCommandMessage = "The `{0}` command is depreciated and will soon be disabled. Please upgrade to using Environment Files to set the env. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
             public static readonly string UnsupportedCommandMessageGHES = "The `{0}` command is disabled. Please upgrade to using Environment Files to set the env, or to opt into unsecure command execution by setting `ACTIONS_ALLOW_UNSECURE_COMMANDS` on the Runner to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
         }
 

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -141,8 +141,8 @@ namespace GitHub.Runner.Common
             public static readonly string InternalTelemetryIssueDataKey = "_internal_telemetry";
             public static readonly string WorkerCrash = "WORKER_CRASH";
             public static readonly string UnsupportedCommand = "UNSUPPORTED_COMMAND";
-            public static readonly string UnsupportedCommandMessage = "The `{0}` command is depreciated and will soon be disabled. Please upgrade to using Environment Files to set the env. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
-            public static readonly string UnsupportedCommandMessageGHES = "The `{0}` command is disabled. Please upgrade to using Environment Files to set the env, or to opt into unsecure command execution by setting `ACTIONS_ALLOW_UNSECURE_COMMANDS` on the Runner to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
+            public static readonly string UnsupportedCommandMessage = "The `{0}` command is depreciated and will soon be disabled. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
+            public static readonly string UnsupportedCommandMessageGHES = "The `{0}` command is disabled. Please upgrade to using Environment Files or to opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable on the Runner to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
         }
 
         public static class RunnerEvent

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -141,6 +141,8 @@ namespace GitHub.Runner.Common
             public static readonly string InternalTelemetryIssueDataKey = "_internal_telemetry";
             public static readonly string WorkerCrash = "WORKER_CRASH";
             public static readonly string UnsupportedCommand = "UNSUPPORTED_COMMAND";
+            public static readonly string UnsupportedCommandMessage = "The `{0}` command is disabled. Please upgrade to using Environment Files to set the env, or to opt into unsecure command execution by setting `ACTIONS_ALLOW_UNSECURE_COMMANDS` to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
+            public static readonly string UnsupportedCommandMessageGHES = "The `{0}` command is disabled. Please upgrade to using Environment Files to set the env, or to opt into unsecure command execution by setting `ACTIONS_ALLOW_UNSECURE_COMMANDS` on the Runner to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
         }
 
         public static class RunnerEvent
@@ -199,6 +201,7 @@ namespace GitHub.Runner.Common
                 //
                 // Keep alphabetical
                 //
+                public static readonly string AllowUnsupportedCommands = "ACTIONS_ALLOW_UNSECURE_COMMANDS";
                 public static readonly string RunnerDebug = "ACTIONS_RUNNER_DEBUG";
                 public static readonly string StepDebug = "ACTIONS_STEP_DEBUG";
             }

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -142,7 +142,7 @@ namespace GitHub.Runner.Common
             public static readonly string WorkerCrash = "WORKER_CRASH";
             public static readonly string UnsupportedCommand = "UNSUPPORTED_COMMAND";
             public static readonly string UnsupportedCommandMessage = "The `{0}` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
-            public static readonly string UnsupportedCommandMessageDisabled = "The `{0}` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable on the Runner to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
+            public static readonly string UnsupportedCommandMessageDisabled = "The `{0}` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
         }
 
         public static class RunnerEvent

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -141,7 +141,7 @@ namespace GitHub.Runner.Common
             public static readonly string InternalTelemetryIssueDataKey = "_internal_telemetry";
             public static readonly string WorkerCrash = "WORKER_CRASH";
             public static readonly string UnsupportedCommand = "UNSUPPORTED_COMMAND";
-            public static readonly string UnsupportedCommandMessage = "The `{0}` command is depreciated and will soon be disabled. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
+            public static readonly string UnsupportedCommandMessage = "The `{0}` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
             public static readonly string UnsupportedCommandMessageDisabled = "The `{0}` command is disabled. Please upgrade to using Environment Files or to opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable on the Runner to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
         }
 

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -140,6 +140,7 @@ namespace GitHub.Runner.Common
 
             public static readonly string InternalTelemetryIssueDataKey = "_internal_telemetry";
             public static readonly string WorkerCrash = "WORKER_CRASH";
+            public static readonly string UnsupportedCommand = "UNSUPPORTED_COMMAND";
         }
 
         public static class RunnerEvent

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -142,7 +142,7 @@ namespace GitHub.Runner.Common
             public static readonly string WorkerCrash = "WORKER_CRASH";
             public static readonly string UnsupportedCommand = "UNSUPPORTED_COMMAND";
             public static readonly string UnsupportedCommandMessage = "The `{0}` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
-            public static readonly string UnsupportedCommandMessageDisabled = "The `{0}` command is disabled. Please upgrade to using Environment Files or to opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable on the Runner to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
+            public static readonly string UnsupportedCommandMessageDisabled = "The `{0}` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable on the Runner to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
         }
 
         public static class RunnerEvent

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -183,22 +183,23 @@ namespace GitHub.Runner.Worker
 
         public void ProcessCommand(IExecutionContext context, string line, ActionCommand command, ContainerInfo container)
         {
-            var serverUrl = context.GetGitHubContext("server_url");
-            var isNotGithub = false;
-            if(!String.IsNullOrWhiteSpace(serverUrl) && serverUrl != "https://github.com")
-            {
-                isNotGithub = true;
-            }
+            var configurationStore = HostContext.GetService<IConfigurationStore>();
+            var isHostedServer = configurationStore.GetSettings().IsHostedServer;
             
             var allowUnsecureCommands = false;
             bool.TryParse(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands), out allowUnsecureCommands);
 
-            // TODO: Eventually remove isNotGithub and apply this to dotcom customers as well
-            if (isNotGithub && !allowUnsecureCommands)
+            if (!allowUnsecureCommands && context.Global.EnvironmentVariables.ContainsKey(Constants.Variables.Actions.AllowUnsupportedCommands))
+            {
+                bool.TryParse(context.Global.EnvironmentVariables[Constants.Variables.Actions.AllowUnsupportedCommands], out allowUnsecureCommands);
+            }
+
+            // TODO: Eventually remove isHostedServer and apply this to dotcom customers as well
+            if (!isHostedServer && !allowUnsecureCommands)
             {
                 throw new Exception(String.Format(Constants.Runner.UnsupportedCommandMessageDisabled, this.Command));
             }
-            else if(!allowUnsecureCommands)
+            else if (!allowUnsecureCommands)
             {
                 // Log Telemetry and let user know they shouldn't do this
                 var issue = new Issue() 
@@ -309,22 +310,23 @@ namespace GitHub.Runner.Worker
 
         public void ProcessCommand(IExecutionContext context, string line, ActionCommand command, ContainerInfo container)
         {
-            var serverUrl = context.GetGitHubContext("server_url");
-            var isNotGithub = false;
-            if(!String.IsNullOrWhiteSpace(serverUrl) && serverUrl != "https://github.com")
-            {
-                isNotGithub = true;
-            }
+            var configurationStore = HostContext.GetService<IConfigurationStore>();
+            var isHostedServer = configurationStore.GetSettings().IsHostedServer;
             
             var allowUnsecureCommands = false;
             bool.TryParse(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands), out allowUnsecureCommands);
 
-            // TODO: Eventually remove isNotGithub and apply this to dotcom customers as well
-            if (isNotGithub && !allowUnsecureCommands)
+            if (!allowUnsecureCommands && context.Global.EnvironmentVariables.ContainsKey(Constants.Variables.Actions.AllowUnsupportedCommands))
+            {
+                bool.TryParse(context.Global.EnvironmentVariables[Constants.Variables.Actions.AllowUnsupportedCommands], out allowUnsecureCommands);
+            }
+
+            // TODO: Eventually remove isHostedServer and apply this to dotcom customers as well
+            if (!isHostedServer && !allowUnsecureCommands)
             {
                 throw new Exception(String.Format(Constants.Runner.UnsupportedCommandMessageDisabled, this.Command));
             }
-            else if(!allowUnsecureCommands)
+            else if (!allowUnsecureCommands)
             {
                 // Log Telemetry and let user know they shouldn't do this
                 var issue = new Issue() 

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -183,23 +183,18 @@ namespace GitHub.Runner.Worker
 
         public void ProcessCommand(IExecutionContext context, string line, ActionCommand command, ContainerInfo container)
         {
-
             var serverUrl = context.GetGitHubContext("server_url");
-            var isGHES = false;
+            var isNotGithub = false;
             if(!String.IsNullOrWhiteSpace(serverUrl) && serverUrl != "https://github.com")
             {
-                isGHES = true;
+                isNotGithub = true;
             }
             
             var allowUnsecureCommands = false;
-            if (!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands)) 
-                && Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands).ToUpper() == "TRUE")
-            {
-                allowUnsecureCommands = true;
-            }
+            bool.TryParse(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands), out allowUnsecureCommands);
 
-            // TODO: Eventually remove isGHES and apply this to dotcom customers as well
-            if (isGHES && !allowUnsecureCommands)
+            // TODO: Eventually remove isNotGithub and apply this to dotcom customers as well
+            if (isNotGithub && !allowUnsecureCommands)
             {
                 throw new Exception(String.Format(Constants.Runner.UnsupportedCommandMessageDisabled, this.Command));
             }
@@ -315,21 +310,17 @@ namespace GitHub.Runner.Worker
         public void ProcessCommand(IExecutionContext context, string line, ActionCommand command, ContainerInfo container)
         {
             var serverUrl = context.GetGitHubContext("server_url");
-            var isGHES = false;
+            var isNotGithub = false;
             if(!String.IsNullOrWhiteSpace(serverUrl) && serverUrl != "https://github.com")
             {
-                isGHES = true;
+                isNotGithub = true;
             }
             
             var allowUnsecureCommands = false;
-            if (!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands)) 
-                && Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands).ToUpper() == "TRUE")
-            {
-                allowUnsecureCommands = true;
-            }
+            bool.TryParse(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands), out allowUnsecureCommands);
 
-            // TODO: Eventually remove isGHES and apply this to dotcom customers as well
-            if (isGHES && !allowUnsecureCommands)
+            // TODO: Eventually remove isNotGithub and apply this to dotcom customers as well
+            if (isNotGithub && !allowUnsecureCommands)
             {
                 throw new Exception(String.Format(Constants.Runner.UnsupportedCommandMessageDisabled, this.Command));
             }

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -194,19 +194,16 @@ namespace GitHub.Runner.Worker
             var allowUnsecureCommands = false;
             if (!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands)) 
                 && Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands).ToUpper() == "TRUE")
-                {
-                    allowUnsecureCommands = true;
-                }
-            // TODO REMOVE DEBUG
-            context.Output("Server URL" + context.GetGitHubContext("server_url"));
-            context.Output("is GHES" + isGHES.ToString());
-            context.Output("env" + allowUnsecureCommands.ToString());
+            {
+                allowUnsecureCommands = true;
+            }
 
+            // TODO: Eventually remove isGHES and apply this to dotcom customers as well
             if (isGHES && !allowUnsecureCommands)
             {
-                throw new Exception(String.Format(Constants.Runner.UnsupportedCommandMessageGHES, this.Command));
+                throw new Exception(String.Format(Constants.Runner.UnsupportedCommandMessageDisabled, this.Command));
             }
-            else
+            else if(!allowUnsecureCommands)
             {
                 // Log Telemetry and let user know they shouldn't do this
                 var issue = new Issue() 
@@ -327,19 +324,16 @@ namespace GitHub.Runner.Worker
             var allowUnsecureCommands = false;
             if (!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands)) 
                 && Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands).ToUpper() == "TRUE")
-                {
-                    allowUnsecureCommands = true;
-                }
-            // TODO REMOVE DEBUG
-            context.Output("Server URL" + context.GetGitHubContext("server_url"));
-            context.Output("is GHES" + isGHES.ToString());
-            context.Output("env" + allowUnsecureCommands.ToString());
+            {
+                allowUnsecureCommands = true;
+            }
 
+            // TODO: Eventually remove isGHES and apply this to dotcom customers as well
             if (isGHES && !allowUnsecureCommands)
             {
-                throw new Exception(String.Format(Constants.Runner.UnsupportedCommandMessageGHES, this.Command));
+                throw new Exception(String.Format(Constants.Runner.UnsupportedCommandMessageDisabled, this.Command));
             }
-            else
+            else if(!allowUnsecureCommands)
             {
                 // Log Telemetry and let user know they shouldn't do this
                 var issue = new Issue() 
@@ -350,7 +344,7 @@ namespace GitHub.Runner.Worker
                 issue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.UnsupportedCommand;
                 context.AddIssue(issue);
             }
-            
+
             ArgUtil.NotNullOrEmpty(command.Data, "path");
             context.Global.PrependPath.RemoveAll(x => string.Equals(x, command.Data, StringComparison.CurrentCulture));
             context.Global.PrependPath.Add(command.Data);

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -1,4 +1,5 @@
 ﻿using GitHub.DistributedTask.Pipelines;
+using GitHub.DistributedTask.Pipelines.ContextData;
 using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Common.Util;
 using GitHub.Runner.Worker.Container;
@@ -187,11 +188,16 @@ namespace GitHub.Runner.Worker
             var isHostedServer = configurationStore.GetSettings().IsHostedServer;
             
             var allowUnsecureCommands = false;
-            bool.TryParse(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands), out allowUnsecureCommands);
+            #if OS_WINDOWS
+            var envContext = context.ExpressionValues["env"] as DictionaryContextData;
+            #else
+            var envContext = context.ExpressionValues["env"] as CaseSensitiveDictionaryContextData;
+            #endif
+            // Apply environment from env context, env context contains job level env and action's env block
 
-            if (!allowUnsecureCommands && context.Global.EnvironmentVariables.ContainsKey(Constants.Variables.Actions.AllowUnsupportedCommands))
+            if (!allowUnsecureCommands && envContext.ContainsKey(Constants.Variables.Actions.AllowUnsupportedCommands))
             {
-                bool.TryParse(context.Global.EnvironmentVariables[Constants.Variables.Actions.AllowUnsupportedCommands], out allowUnsecureCommands);
+                bool.TryParse(envContext[Constants.Variables.Actions.AllowUnsupportedCommands].ToString(), out allowUnsecureCommands);
             }
 
             // TODO: Eventually remove isHostedServer and apply this to dotcom customers as well
@@ -314,11 +320,16 @@ namespace GitHub.Runner.Worker
             var isHostedServer = configurationStore.GetSettings().IsHostedServer;
             
             var allowUnsecureCommands = false;
-            bool.TryParse(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands), out allowUnsecureCommands);
+            #if OS_WINDOWS
+            var envContext = context.ExpressionValues["env"] as DictionaryContextData;
+            #else
+            var envContext = context.ExpressionValues["env"] as CaseSensitiveDictionaryContextData;
+            #endif
+            // Apply environment from env context, env context contains job level env and action's env block
 
-            if (!allowUnsecureCommands && context.Global.EnvironmentVariables.ContainsKey(Constants.Variables.Actions.AllowUnsupportedCommands))
+            if (!allowUnsecureCommands && envContext.ContainsKey(Constants.Variables.Actions.AllowUnsupportedCommands))
             {
-                bool.TryParse(context.Global.EnvironmentVariables[Constants.Variables.Actions.AllowUnsupportedCommands], out allowUnsecureCommands);
+                bool.TryParse(envContext[Constants.Variables.Actions.AllowUnsupportedCommands].ToString(), out allowUnsecureCommands);
             }
 
             // TODO: Eventually remove isHostedServer and apply this to dotcom customers as well

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -188,13 +188,14 @@ namespace GitHub.Runner.Worker
             var isHostedServer = configurationStore.GetSettings().IsHostedServer;
             
             var allowUnsecureCommands = false;
-            #if OS_WINDOWS
-            var envContext = context.ExpressionValues["env"] as DictionaryContextData;
-            #else
-            var envContext = context.ExpressionValues["env"] as CaseSensitiveDictionaryContextData;
-            #endif
-            // Apply environment from env context, env context contains job level env and action's env block
+            bool.TryParse(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands), out allowUnsecureCommands);
 
+            // Apply environment from env context, env context contains job level env and action's env block
+#if OS_WINDOWS
+            var envContext = context.ExpressionValues["env"] as DictionaryContextData;
+#else
+            var envContext = context.ExpressionValues["env"] as CaseSensitiveDictionaryContextData;
+#endif
             if (!allowUnsecureCommands && envContext.ContainsKey(Constants.Variables.Actions.AllowUnsupportedCommands))
             {
                 bool.TryParse(envContext[Constants.Variables.Actions.AllowUnsupportedCommands].ToString(), out allowUnsecureCommands);
@@ -216,7 +217,7 @@ namespace GitHub.Runner.Worker
                 issue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.UnsupportedCommand;
                 context.AddIssue(issue);
             }
-            
+
             if (!command.Properties.TryGetValue(SetEnvCommandProperties.Name, out string envName) || string.IsNullOrEmpty(envName))
             {
                 throw new Exception("Required field 'name' is missing in ##[set-env] command.");
@@ -320,13 +321,14 @@ namespace GitHub.Runner.Worker
             var isHostedServer = configurationStore.GetSettings().IsHostedServer;
             
             var allowUnsecureCommands = false;
-            #if OS_WINDOWS
-            var envContext = context.ExpressionValues["env"] as DictionaryContextData;
-            #else
-            var envContext = context.ExpressionValues["env"] as CaseSensitiveDictionaryContextData;
-            #endif
-            // Apply environment from env context, env context contains job level env and action's env block
+            bool.TryParse(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands), out allowUnsecureCommands);
 
+            // Apply environment from env context, env context contains job level env and action's env block
+#if OS_WINDOWS
+            var envContext = context.ExpressionValues["env"] as DictionaryContextData;
+#else
+            var envContext = context.ExpressionValues["env"] as CaseSensitiveDictionaryContextData;
+#endif
             if (!allowUnsecureCommands && envContext.ContainsKey(Constants.Variables.Actions.AllowUnsupportedCommands))
             {
                 bool.TryParse(envContext[Constants.Variables.Actions.AllowUnsupportedCommands].ToString(), out allowUnsecureCommands);

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -183,27 +183,28 @@ namespace GitHub.Runner.Worker
 
         public void ProcessCommand(IExecutionContext context, string line, ActionCommand command, ContainerInfo container)
         {
-            var url = context.GetGitHubContext("server_url");
-            var isGHES = false;
 
-            if(!String.IsNullOrWhiteSpace(url) && url != "https://github.com")
+            var serverUrl = context.GetGitHubContext("server_url");
+            var isGHES = false;
+            if(!String.IsNullOrWhiteSpace(serverUrl) && serverUrl != "https://github.com")
             {
                 isGHES = true;
             }
             
             var allowUnsecureCommands = false;
-            if (!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("ACTIONS_ALLOW_UNSECURE_COMMANDS")) 
-                && Environment.GetEnvironmentVariable("ACTIONS_ALLOW_UNSECURE_COMMANDS").ToUpper() == "TRUE")
+            if (!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands)) 
+                && Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands).ToUpper() == "TRUE")
                 {
                     allowUnsecureCommands = true;
                 }
+            // TODO REMOVE DEBUG
             context.Output("Server URL" + context.GetGitHubContext("server_url"));
             context.Output("is GHES" + isGHES.ToString());
             context.Output("env" + allowUnsecureCommands.ToString());
 
             if (isGHES && !allowUnsecureCommands)
             {
-                throw new Exception("The `set-env` command is disabled. Please upgrade to using Environment Files to set the env, or to disable secure command execution set `ACTIONS_ALLOW_UNSECURE_COMMANDS` to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/");
+                throw new Exception(String.Format(Constants.Runner.UnsupportedCommandMessageGHES, this.Command));
             }
             else
             {
@@ -211,7 +212,7 @@ namespace GitHub.Runner.Worker
                 var issue = new Issue() 
                 { 
                     Type = IssueType.Warning, 
-                    Message = "The `set-env` command is depreciated and will soon be disabled. Please upgrade to using Environment Files to set the env. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/"
+                    Message = String.Format(Constants.Runner.UnsupportedCommandMessage, this.Command)
                 };
                 issue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.UnsupportedCommand;
                 context.AddIssue(issue);
@@ -316,6 +317,40 @@ namespace GitHub.Runner.Worker
 
         public void ProcessCommand(IExecutionContext context, string line, ActionCommand command, ContainerInfo container)
         {
+            var serverUrl = context.GetGitHubContext("server_url");
+            var isGHES = false;
+            if(!String.IsNullOrWhiteSpace(serverUrl) && serverUrl != "https://github.com")
+            {
+                isGHES = true;
+            }
+            
+            var allowUnsecureCommands = false;
+            if (!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands)) 
+                && Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowUnsupportedCommands).ToUpper() == "TRUE")
+                {
+                    allowUnsecureCommands = true;
+                }
+            // TODO REMOVE DEBUG
+            context.Output("Server URL" + context.GetGitHubContext("server_url"));
+            context.Output("is GHES" + isGHES.ToString());
+            context.Output("env" + allowUnsecureCommands.ToString());
+
+            if (isGHES && !allowUnsecureCommands)
+            {
+                throw new Exception(String.Format(Constants.Runner.UnsupportedCommandMessageGHES, this.Command));
+            }
+            else
+            {
+                // Log Telemetry and let user know they shouldn't do this
+                var issue = new Issue() 
+                { 
+                    Type = IssueType.Warning, 
+                    Message = String.Format(Constants.Runner.UnsupportedCommandMessage, this.Command)
+                };
+                issue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.UnsupportedCommand;
+                context.AddIssue(issue);
+            }
+            
             ArgUtil.NotNullOrEmpty(command.Data, "path");
             context.Global.PrependPath.RemoveAll(x => string.Equals(x, command.Data, StringComparison.CurrentCulture));
             context.Global.PrependPath.Add(command.Data);


### PR DESCRIPTION
The purpose of this PR is to add telemetry and notify PR's when they are using the [unsecure commands in the runner](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). Eventually, we will need to disable these commands, but getting people to migrate off of them is the first step. This pr will create annotations on runs where these commands are used. For example:
![image](https://user-images.githubusercontent.com/52323235/94857611-cc0ed500-03ff-11eb-9070-9f0124a44358.png)


### Testing
- [x] MacOS
- [x] Ubuntu
- [x] Ubuntu Job container
- [x] Ubuntu container action
- [x] GHES (In progress)