### PR TITLE
Fixes #759 doesn't change proxy environment variables

### DIFF
--- a/src/Runner.Sdk/RunnerWebProxy.cs
+++ b/src/Runner.Sdk/RunnerWebProxy.cs
@@ -74,8 +74,8 @@ namespace GitHub.Runner.Sdk
                 _httpProxyAddress = proxyHttpUri.AbsoluteUri;
 
                 // Set both environment variables since there are tools support both casing (curl, wget) and tools support only one casing (docker)
-                Environment.SetEnvironmentVariable("HTTP_PROXY", _httpProxyAddress);
-                Environment.SetEnvironmentVariable("http_proxy", _httpProxyAddress);
+                Environment.SetEnvironmentVariable("HTTP_PROXY", httpProxyAddress);
+                Environment.SetEnvironmentVariable("http_proxy", httpProxyAddress);
 
                 // the proxy url looks like http://[user:pass@]127.0.0.1:8888
                 var userInfo = Uri.UnescapeDataString(proxyHttpUri.UserInfo).Split(':', 2, StringSplitOptions.RemoveEmptyEntries);
@@ -104,8 +104,8 @@ namespace GitHub.Runner.Sdk
                 _httpsProxyAddress = proxyHttpsUri.AbsoluteUri;
 
                 // Set both environment variables since there are tools support both casing (curl, wget) and tools support only one casing (docker)
-                Environment.SetEnvironmentVariable("HTTPS_PROXY", _httpsProxyAddress);
-                Environment.SetEnvironmentVariable("https_proxy", _httpsProxyAddress);
+                Environment.SetEnvironmentVariable("HTTPS_PROXY", httpsProxyAddress);
+                Environment.SetEnvironmentVariable("https_proxy", httpsProxyAddress);
 
                 // the proxy url looks like http://[user:pass@]127.0.0.1:8888
                 var userInfo = Uri.UnescapeDataString(proxyHttpsUri.UserInfo).Split(':', 2, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Runner.Sdk/RunnerWebProxy.cs
+++ b/src/Runner.Sdk/RunnerWebProxy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Text.RegularExpressions;
@@ -71,11 +71,11 @@ namespace GitHub.Runner.Sdk
 
             if (!string.IsNullOrEmpty(httpProxyAddress) && Uri.TryCreate(httpProxyAddress, UriKind.Absolute, out var proxyHttpUri))
             {
-                _httpProxyAddress = proxyHttpUri.AbsoluteUri;
+                _httpProxyAddress = proxyHttpUri.OriginalString;
 
                 // Set both environment variables since there are tools support both casing (curl, wget) and tools support only one casing (docker)
-                Environment.SetEnvironmentVariable("HTTP_PROXY", httpProxyAddress);
-                Environment.SetEnvironmentVariable("http_proxy", httpProxyAddress);
+                Environment.SetEnvironmentVariable("HTTP_PROXY", _httpProxyAddress);
+                Environment.SetEnvironmentVariable("http_proxy", _httpProxyAddress);
 
                 // the proxy url looks like http://[user:pass@]127.0.0.1:8888
                 var userInfo = Uri.UnescapeDataString(proxyHttpUri.UserInfo).Split(':', 2, StringSplitOptions.RemoveEmptyEntries);
@@ -101,11 +101,11 @@ namespace GitHub.Runner.Sdk
 
             if (!string.IsNullOrEmpty(httpsProxyAddress) && Uri.TryCreate(httpsProxyAddress, UriKind.Absolute, out var proxyHttpsUri))
             {
-                _httpsProxyAddress = proxyHttpsUri.AbsoluteUri;
+                _httpsProxyAddress = proxyHttpsUri.OriginalString;
 
                 // Set both environment variables since there are tools support both casing (curl, wget) and tools support only one casing (docker)
-                Environment.SetEnvironmentVariable("HTTPS_PROXY", httpsProxyAddress);
-                Environment.SetEnvironmentVariable("https_proxy", httpsProxyAddress);
+                Environment.SetEnvironmentVariable("HTTPS_PROXY", _httpsProxyAddress);
+                Environment.SetEnvironmentVariable("https_proxy", _httpsProxyAddress);
 
                 // the proxy url looks like http://[user:pass@]127.0.0.1:8888
                 var userInfo = Uri.UnescapeDataString(proxyHttpsUri.UserInfo).Split(':', 2, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Test/L0/RunnerWebProxyL0.cs
+++ b/src/Test/L0/RunnerWebProxyL0.cs
@@ -145,6 +145,36 @@ namespace GitHub.Runner.Common.Tests
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void WebProxyFromEnvironmentVariablesWithPort80()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("http_proxy", "http://127.0.0.1:80");
+                Environment.SetEnvironmentVariable("https_proxy", "http://user:pass@127.0.0.1:80");
+                Environment.SetEnvironmentVariable("no_proxy", "github.com, google.com,");
+                var proxy = new RunnerWebProxy();
+
+                Assert.Equal("http://127.0.0.1:80", Environment.GetEnvironmentVariable("http_proxy"));
+                Assert.Null(proxy.HttpProxyUsername);
+                Assert.Null(proxy.HttpProxyPassword);
+
+                Assert.Equal("http://user:pass@127.0.0.1:80", Environment.GetEnvironmentVariable("https_proxy"));
+                Assert.Equal("user", proxy.HttpsProxyUsername);
+                Assert.Equal("pass", proxy.HttpsProxyPassword);
+
+                Assert.Equal(2, proxy.NoProxyList.Count);
+                Assert.Equal("github.com", proxy.NoProxyList[0].Host);
+                Assert.Equal("google.com", proxy.NoProxyList[1].Host);
+            }
+            finally
+            {
+                CleanProxyEnv();
+            }
+        }
+
 #if !OS_WINDOWS
         [Fact]
         [Trait("Level", "L0")]

--- a/src/Test/L0/RunnerWebProxyL0.cs
+++ b/src/Test/L0/RunnerWebProxyL0.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.Runner.Common.Util;
+using GitHub.Runner.Common.Util;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -127,41 +127,11 @@ namespace GitHub.Runner.Common.Tests
                 Environment.SetEnvironmentVariable("no_proxy", "github.com, google.com,");
                 var proxy = new RunnerWebProxy();
 
-                Assert.Equal("http://127.0.0.1:8888/", proxy.HttpProxyAddress);
+                Assert.Equal("http://127.0.0.1:8888", proxy.HttpProxyAddress);
                 Assert.Null(proxy.HttpProxyUsername);
                 Assert.Null(proxy.HttpProxyPassword);
 
-                Assert.Equal("http://user:pass@127.0.0.1:9999/", proxy.HttpsProxyAddress);
-                Assert.Equal("user", proxy.HttpsProxyUsername);
-                Assert.Equal("pass", proxy.HttpsProxyPassword);
-
-                Assert.Equal(2, proxy.NoProxyList.Count);
-                Assert.Equal("github.com", proxy.NoProxyList[0].Host);
-                Assert.Equal("google.com", proxy.NoProxyList[1].Host);
-            }
-            finally
-            {
-                CleanProxyEnv();
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Common")]
-        public void WebProxyFromEnvironmentVariablesWithPort80()
-        {
-            try
-            {
-                Environment.SetEnvironmentVariable("http_proxy", "http://127.0.0.1:80");
-                Environment.SetEnvironmentVariable("https_proxy", "http://user:pass@127.0.0.1:80");
-                Environment.SetEnvironmentVariable("no_proxy", "github.com, google.com,");
-                var proxy = new RunnerWebProxy();
-
-                Assert.Equal("http://127.0.0.1:80", Environment.GetEnvironmentVariable("http_proxy"));
-                Assert.Null(proxy.HttpProxyUsername);
-                Assert.Null(proxy.HttpProxyPassword);
-
-                Assert.Equal("http://user:pass@127.0.0.1:80", Environment.GetEnvironmentVariable("https_proxy"));
+                Assert.Equal("http://user:pass@127.0.0.1:9999", proxy.HttpsProxyAddress);
                 Assert.Equal("user", proxy.HttpsProxyUsername);
                 Assert.Equal("pass", proxy.HttpsProxyPassword);
 
@@ -191,11 +161,11 @@ namespace GitHub.Runner.Common.Tests
                 Environment.SetEnvironmentVariable("NO_PROXY", "github.com, google.com,");
                 var proxy = new RunnerWebProxy();
 
-                Assert.Equal("http://127.0.0.1:7777/", proxy.HttpProxyAddress);
+                Assert.Equal("http://127.0.0.1:7777", proxy.HttpProxyAddress);
                 Assert.Null(proxy.HttpProxyUsername);
                 Assert.Null(proxy.HttpProxyPassword);
 
-                Assert.Equal("http://user:pass@127.0.0.1:8888/", proxy.HttpsProxyAddress);
+                Assert.Equal("http://user:pass@127.0.0.1:8888", proxy.HttpsProxyAddress);
                 Assert.Equal("user", proxy.HttpsProxyUsername);
                 Assert.Equal("pass", proxy.HttpsProxyPassword);
 
@@ -248,19 +218,19 @@ namespace GitHub.Runner.Common.Tests
                 Environment.SetEnvironmentVariable("no_proxy", "github.com, google.com,");
                 var proxy = new RunnerWebProxy();
 
-                Assert.Equal("http://user1@127.0.0.1:8888/", proxy.HttpProxyAddress);
+                Assert.Equal("http://user1@127.0.0.1:8888", proxy.HttpProxyAddress);
                 Assert.Equal("user1", proxy.HttpProxyUsername);
                 Assert.Null(proxy.HttpProxyPassword);
 
-                var cred = proxy.Credentials.GetCredential(new Uri("http://user1@127.0.0.1:8888/"), "Basic");
+                var cred = proxy.Credentials.GetCredential(new Uri("http://user1@127.0.0.1:8888"), "Basic");
                 Assert.Equal("user1", cred.UserName);
                 Assert.Equal(string.Empty, cred.Password);
 
-                Assert.Equal("http://user2:pass@127.0.0.1:9999/", proxy.HttpsProxyAddress);
+                Assert.Equal("http://user2:pass@127.0.0.1:9999", proxy.HttpsProxyAddress);
                 Assert.Equal("user2", proxy.HttpsProxyUsername);
                 Assert.Equal("pass", proxy.HttpsProxyPassword);
 
-                cred = proxy.Credentials.GetCredential(new Uri("http://user2:pass@127.0.0.1:9999/"), "Basic");
+                cred = proxy.Credentials.GetCredential(new Uri("http://user2:pass@127.0.0.1:9999"), "Basic");
                 Assert.Equal("user2", cred.UserName);
                 Assert.Equal("pass", cred.Password);
 
@@ -286,19 +256,19 @@ namespace GitHub.Runner.Common.Tests
                 Environment.SetEnvironmentVariable("no_proxy", "github.com, google.com,");
                 var proxy = new RunnerWebProxy();
 
-                Assert.Equal("http://user1:pass1%40@127.0.0.1:8888/", proxy.HttpProxyAddress);
+                Assert.Equal("http://user1:pass1%40@127.0.0.1:8888", proxy.HttpProxyAddress);
                 Assert.Equal("user1", proxy.HttpProxyUsername);
                 Assert.Equal("pass1@", proxy.HttpProxyPassword);
 
-                var cred = proxy.Credentials.GetCredential(new Uri("http://user1:pass1%40@127.0.0.1:8888/"), "Basic");
+                var cred = proxy.Credentials.GetCredential(new Uri("http://user1:pass1%40@127.0.0.1:8888"), "Basic");
                 Assert.Equal("user1", cred.UserName);
                 Assert.Equal("pass1@", cred.Password);
 
-                Assert.Equal("http://user2:pass2%40@127.0.0.1:9999/", proxy.HttpsProxyAddress);
+                Assert.Equal("http://user2:pass2%40@127.0.0.1:9999", proxy.HttpsProxyAddress);
                 Assert.Equal("user2", proxy.HttpsProxyUsername);
                 Assert.Equal("pass2@", proxy.HttpsProxyPassword);
 
-                cred = proxy.Credentials.GetCredential(new Uri("http://user2:pass2%40@127.0.0.1:9999/"), "Basic");
+                cred = proxy.Credentials.GetCredential(new Uri("http://user2:pass2%40@127.0.0.1:9999"), "Basic");
                 Assert.Equal("user2", cred.UserName);
                 Assert.Equal("pass2@", cred.Password);
 
@@ -428,6 +398,36 @@ namespace GitHub.Runner.Common.Tests
 
                 Assert.Equal("http://user2:pass2%40@127.0.0.1:9999/", proxy.GetProxy(new Uri("https://something.com")).AbsoluteUri);
                 Assert.Equal("http://user2:pass2%40@127.0.0.1:9999/", proxy.GetProxy(new Uri("https://www.something2.com")).AbsoluteUri);
+            }
+            finally
+            {
+                CleanProxyEnv();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void WebProxyFromEnvironmentVariablesWithPort80()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("http_proxy", "http://127.0.0.1:80");
+                Environment.SetEnvironmentVariable("https_proxy", "http://user:pass@127.0.0.1:80");
+                Environment.SetEnvironmentVariable("no_proxy", "github.com, google.com,");
+                var proxy = new RunnerWebProxy();
+
+                Assert.Equal("http://127.0.0.1:80", Environment.GetEnvironmentVariable("http_proxy"));
+                Assert.Null(proxy.HttpProxyUsername);
+                Assert.Null(proxy.HttpProxyPassword);
+
+                Assert.Equal("http://user:pass@127.0.0.1:80", Environment.GetEnvironmentVariable("https_proxy"));
+                Assert.Equal("user", proxy.HttpsProxyUsername);
+                Assert.Equal("pass", proxy.HttpsProxyPassword);
+
+                Assert.Equal(2, proxy.NoProxyList.Count);
+                Assert.Equal("github.com", proxy.NoProxyList[0].Host);
+                Assert.Equal("google.com", proxy.NoProxyList[1].Host);
             }
             finally
             {


### PR DESCRIPTION
Fixes #759 

Sets the environment variables for proxies based on what the user set them as and not based on .net's Uri which strips default ports off