### PR TITLE
Only pull if not exist

### DIFF
--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -202,9 +202,9 @@ namespace GitHub.Runner.Worker
             {
 
                 // See if the container already exists locally
-                await _dockerManager.DockerInspect(executionContext, container.ContainerImage, "")
+                await _dockerManger.DockerInspect(executionContext, container.ContainerImage, "");
             }
-            catch (Exception ex)
+            catch (Exception)
             {
 
 	            // TODO: Add at a later date. This currently no local package registry to test with


### PR DESCRIPTION
First check if a docker image exists locally before trying to pull it.  This resolves #791.  Note that most of the change shown below is whitespace (from indent), so adding the "w=1" option to the URL shows the actual change, which is to do a "docker inspect" before the "docker pull".