### PR TITLE
Crypto cleanup and enable usage of FIPS compliant crypto when required

### DIFF
--- a/src/Runner.Common/ConfigurationStore.cs
+++ b/src/Runner.Common/ConfigurationStore.cs
@@ -45,9 +45,6 @@ namespace GitHub.Runner.Common
         [DataMember(EmitDefaultValue = false)]
         public string MonitorSocketAddress { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
-        public bool? _requireFipsCryptography { get; set; }
-
         [IgnoreDataMember]
         public bool IsHostedServer
         {
@@ -60,21 +57,6 @@ namespace GitHub.Runner.Common
             set
             {
                 _isHostedServer = value;
-            }
-        }
-
-        // This should be temporary. Used for compatibility while both are supported
-        [IgnoreDataMember]
-        public bool RequireFipsCryptography
-        {
-            get
-            {
-                return _requireFipsCryptography ?? false;
-            }
-
-            set
-            {
-                _requireFipsCryptography = value;
             }
         }
 

--- a/src/Runner.Common/ConfigurationStore.cs
+++ b/src/Runner.Common/ConfigurationStore.cs
@@ -45,6 +45,9 @@ namespace GitHub.Runner.Common
         [DataMember(EmitDefaultValue = false)]
         public string MonitorSocketAddress { get; set; }
 
+        [DataMember(EmitDefaultValue = false)]
+        public bool? _requireFipsCryptography { get; set; }
+
         [IgnoreDataMember]
         public bool IsHostedServer
         {
@@ -57,6 +60,21 @@ namespace GitHub.Runner.Common
             set
             {
                 _isHostedServer = value;
+            }
+        }
+
+        // This should be temporary. Used for compatibility while both are supported
+        [IgnoreDataMember]
+        public bool RequireFipsCryptography
+        {
+            get
+            {
+                return _requireFipsCryptography ?? false;
+            }
+
+            set
+            {
+                _requireFipsCryptography = value;
             }
         }
 

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -276,19 +276,6 @@ namespace GitHub.Runner.Listener.Configuration
                 throw new NotSupportedException("Message queue listen OAuth token.");
             }
 
-            _term.WriteSection("Runner settings");
-
-            // We will Combine() what's stored with root.  Defaults to string a relative path
-            runnerSettings.WorkFolder = command.GetWork();
-
-            runnerSettings.MonitorSocketAddress = command.GetMonitorSocketAddress();
-
-            _store.SaveSettings(runnerSettings);
-
-            _term.WriteLine();
-            _term.WriteSuccessMessage("Settings Saved.");
-            _term.WriteLine();
-
             // Testing agent connection, detect any potential connection issue, like local clock skew that cause OAuth token expired.
             var credMgr = HostContext.GetService<ICredentialManager>();
             VssCredentials credential = credMgr.LoadCredentials();
@@ -309,6 +296,19 @@ namespace GitHub.Runner.Listener.Configuration
                 Trace.Error(ex);
                 throw new Exception("The local machine's clock may be out of sync with the server time by more than five minutes. Please sync your clock with your domain or internet time and try again.");
             }
+
+            _term.WriteSection("Runner settings");
+
+            // We will Combine() what's stored with root.  Defaults to string a relative path
+            runnerSettings.WorkFolder = command.GetWork();
+
+            runnerSettings.MonitorSocketAddress = command.GetMonitorSocketAddress();
+
+            _store.SaveSettings(runnerSettings);
+
+            _term.WriteLine();
+            _term.WriteSuccessMessage("Settings Saved.");
+            _term.WriteLine();
 
 #if OS_WINDOWS
             // config windows service

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -275,6 +275,23 @@ namespace GitHub.Runner.Listener.Configuration
                 throw new NotSupportedException("Message queue listen OAuth token.");
             }
 
+            // Configure to use fips-compliant encryption schemes for communication if required by server
+            var requireFipsCryptography = agent.Properties.GetValueOrDefault("RequireFipsCryptography") as bool?;
+            runnerSettings.RequireFipsCryptography = requireFipsCryptography ?? false;
+
+            _term.WriteSection("Runner settings");
+
+            // We will Combine() what's stored with root.  Defaults to string a relative path
+            runnerSettings.WorkFolder = command.GetWork();
+
+            runnerSettings.MonitorSocketAddress = command.GetMonitorSocketAddress();
+
+            _store.SaveSettings(runnerSettings);
+
+            _term.WriteLine();
+            _term.WriteSuccessMessage("Settings Saved.");
+            _term.WriteLine();
+
             // Testing agent connection, detect any potential connection issue, like local clock skew that cause OAuth token expired.
             var credMgr = HostContext.GetService<ICredentialManager>();
             VssCredentials credential = credMgr.LoadCredentials();
@@ -295,19 +312,6 @@ namespace GitHub.Runner.Listener.Configuration
                 Trace.Error(ex);
                 throw new Exception("The local machine's clock may be out of sync with the server time by more than five minutes. Please sync your clock with your domain or internet time and try again.");
             }
-
-            _term.WriteSection("Runner settings");
-
-            // We will Combine() what's stored with root.  Defaults to string a relative path
-            runnerSettings.WorkFolder = command.GetWork();
-
-            runnerSettings.MonitorSocketAddress = command.GetMonitorSocketAddress();
-
-            _store.SaveSettings(runnerSettings);
-
-            _term.WriteLine();
-            _term.WriteSuccessMessage("Settings Saved.");
-            _term.WriteLine();
 
 #if OS_WINDOWS
             // config windows service

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -263,6 +263,7 @@ namespace GitHub.Runner.Listener.Configuration
                     {
                         { "clientId", agent.Authorization.ClientId.ToString("D") },
                         { "authorizationUrl", agent.Authorization.AuthorizationUrl.AbsoluteUri },
+                        { "requireFipsCryptography", agent.Properties.GetValue("RequireFipsCryptography", false).ToString() }
                     },
                 };
 
@@ -274,10 +275,6 @@ namespace GitHub.Runner.Listener.Configuration
 
                 throw new NotSupportedException("Message queue listen OAuth token.");
             }
-
-            // Configure to use fips-compliant encryption schemes for communication if required by server
-            var requireFipsCryptography = agent.Properties.GetValueOrDefault("RequireFipsCryptography") as bool?;
-            runnerSettings.RequireFipsCryptography = requireFipsCryptography ?? false;
 
             _term.WriteSection("Runner settings");
 

--- a/src/Runner.Listener/Configuration/IRSAKeyManager.cs
+++ b/src/Runner.Listener/Configuration/IRSAKeyManager.cs
@@ -20,7 +20,7 @@ namespace GitHub.Runner.Listener.Configuration
         /// key is returned to the caller.
         /// </summary>
         /// <returns>An <c>RSACryptoServiceProvider</c> instance representing the key for the runner</returns>
-        RSACryptoServiceProvider CreateKey();
+        RSA CreateKey();
 
         /// <summary>
         /// Deletes the RSA key managed by the key manager.
@@ -32,7 +32,7 @@ namespace GitHub.Runner.Listener.Configuration
         /// </summary>
         /// <returns>An <c>RSACryptoServiceProvider</c> instance representing the key for the runner</returns>
         /// <exception cref="CryptographicException">No key exists in the store</exception>
-        RSACryptoServiceProvider GetKey();
+        RSA GetKey();
     }
 
     // Newtonsoft 10 is not working properly with dotnet RSAParameters class

--- a/src/Runner.Listener/Configuration/OAuthCredential.cs
+++ b/src/Runner.Listener/Configuration/OAuthCredential.cs
@@ -36,7 +36,8 @@ namespace GitHub.Runner.Listener.Configuration
             // We expect the key to be in the machine store at this point. Configuration should have set all of
             // this up correctly so we can use the key to generate access tokens.
             var keyManager = context.GetService<IRSAKeyManager>();
-            var signingCredentials = VssSigningCredentials.Create(() => keyManager.GetKey());
+            var settings = context.GetService<IConfigurationStore>().GetSettings(); // make sure to save settings before calling this
+            var signingCredentials = VssSigningCredentials.Create(() => keyManager.GetKey(), settings.RequireFipsCryptography);
             var clientCredential = new VssOAuthJwtBearerClientCredential(clientId, authorizationUrl, signingCredentials);
             var agentCredential = new VssOAuthCredential(new Uri(oauthEndpointUrl, UriKind.Absolute), VssOAuthGrant.ClientCredentials, clientCredential);
 

--- a/src/Runner.Listener/Configuration/OAuthCredential.cs
+++ b/src/Runner.Listener/Configuration/OAuthCredential.cs
@@ -36,7 +36,6 @@ namespace GitHub.Runner.Listener.Configuration
             // We expect the key to be in the machine store at this point. Configuration should have set all of
             // this up correctly so we can use the key to generate access tokens.
             var keyManager = context.GetService<IRSAKeyManager>();
-            var settings = context.GetService<IConfigurationStore>().GetSettings();
             var signingCredentials = VssSigningCredentials.Create(() => keyManager.GetKey(), StringUtil.ConvertToBoolean(CredentialData.Data.GetValueOrDefault("requireFipsCryptography"), false));
             var clientCredential = new VssOAuthJwtBearerClientCredential(clientId, authorizationUrl, signingCredentials);
             var agentCredential = new VssOAuthCredential(new Uri(oauthEndpointUrl, UriKind.Absolute), VssOAuthGrant.ClientCredentials, clientCredential);

--- a/src/Runner.Listener/Configuration/OAuthCredential.cs
+++ b/src/Runner.Listener/Configuration/OAuthCredential.cs
@@ -36,7 +36,7 @@ namespace GitHub.Runner.Listener.Configuration
             // We expect the key to be in the machine store at this point. Configuration should have set all of
             // this up correctly so we can use the key to generate access tokens.
             var keyManager = context.GetService<IRSAKeyManager>();
-            var settings = context.GetService<IConfigurationStore>().GetSettings(); // make sure to save settings before calling this
+            var settings = context.GetService<IConfigurationStore>().GetSettings();
             var signingCredentials = VssSigningCredentials.Create(() => keyManager.GetKey(), settings.RequireFipsCryptography);
             var clientCredential = new VssOAuthJwtBearerClientCredential(clientId, authorizationUrl, signingCredentials);
             var agentCredential = new VssOAuthCredential(new Uri(oauthEndpointUrl, UriKind.Absolute), VssOAuthGrant.ClientCredentials, clientCredential);

--- a/src/Runner.Listener/Configuration/OAuthCredential.cs
+++ b/src/Runner.Listener/Configuration/OAuthCredential.cs
@@ -37,7 +37,7 @@ namespace GitHub.Runner.Listener.Configuration
             // this up correctly so we can use the key to generate access tokens.
             var keyManager = context.GetService<IRSAKeyManager>();
             var settings = context.GetService<IConfigurationStore>().GetSettings();
-            var signingCredentials = VssSigningCredentials.Create(() => keyManager.GetKey(), settings.RequireFipsCryptography);
+            var signingCredentials = VssSigningCredentials.Create(() => keyManager.GetKey(), StringUtil.ConvertToBoolean(CredentialData.Data.GetValueOrDefault("requireFipsCryptography"), false));
             var clientCredential = new VssOAuthJwtBearerClientCredential(clientId, authorizationUrl, signingCredentials);
             var agentCredential = new VssOAuthCredential(new Uri(oauthEndpointUrl, UriKind.Absolute), VssOAuthGrant.ClientCredentials, clientCredential);
 

--- a/src/Runner.Listener/Configuration/RSAEncryptedFileKeyManager.cs
+++ b/src/Runner.Listener/Configuration/RSAEncryptedFileKeyManager.cs
@@ -13,14 +13,14 @@ namespace GitHub.Runner.Listener.Configuration
         private string _keyFile;
         private IHostContext _context;
 
-        public RSACryptoServiceProvider CreateKey()
+        public RSA CreateKey()
         {
-            RSACryptoServiceProvider rsa = null;
+            RSA rsa = null;
             if (!File.Exists(_keyFile))
             {
                 Trace.Info("Creating new RSA key using 2048-bit key length");
 
-                rsa = new RSACryptoServiceProvider(2048);
+                rsa = RSA.Create(2048);
 
                 // Now write the parameters to disk
                 SaveParameters(rsa.ExportParameters(true));
@@ -30,7 +30,7 @@ namespace GitHub.Runner.Listener.Configuration
             {
                 Trace.Info("Found existing RSA key parameters file {0}", _keyFile);
 
-                rsa = new RSACryptoServiceProvider();
+                rsa = RSA.Create();
                 rsa.ImportParameters(LoadParameters());
             }
 
@@ -46,7 +46,7 @@ namespace GitHub.Runner.Listener.Configuration
             }
         }
 
-        public RSACryptoServiceProvider GetKey()
+        public RSA GetKey()
         {
             if (!File.Exists(_keyFile))
             {
@@ -55,7 +55,7 @@ namespace GitHub.Runner.Listener.Configuration
 
             Trace.Info("Loading RSA key parameters from file {0}", _keyFile);
 
-            var rsa = new RSACryptoServiceProvider();
+            var rsa = RSA.Create();
             rsa.ImportParameters(LoadParameters());
             return rsa;
         }

--- a/src/Runner.Listener/Configuration/RSAFileKeyManager.cs
+++ b/src/Runner.Listener/Configuration/RSAFileKeyManager.cs
@@ -14,14 +14,14 @@ namespace GitHub.Runner.Listener.Configuration
         private string _keyFile;
         private IHostContext _context;
 
-        public RSACryptoServiceProvider CreateKey()
+        public RSA CreateKey()
         {
-            RSACryptoServiceProvider rsa = null;
+            RSA rsa = null;
             if (!File.Exists(_keyFile))
             {
                 Trace.Info("Creating new RSA key using 2048-bit key length");
 
-                rsa = new RSACryptoServiceProvider(2048);
+                rsa = RSA.Create(2048);
 
                 // Now write the parameters to disk
                 IOUtil.SaveObject(new RSAParametersSerializable(rsa.ExportParameters(true)), _keyFile);
@@ -54,7 +54,7 @@ namespace GitHub.Runner.Listener.Configuration
             {
                 Trace.Info("Found existing RSA key parameters file {0}", _keyFile);
 
-                rsa = new RSACryptoServiceProvider();
+                rsa = RSA.Create();
                 rsa.ImportParameters(IOUtil.LoadObject<RSAParametersSerializable>(_keyFile).RSAParameters);
             }
 
@@ -70,7 +70,7 @@ namespace GitHub.Runner.Listener.Configuration
             }
         }
 
-        public RSACryptoServiceProvider GetKey()
+        public RSA GetKey()
         {
             if (!File.Exists(_keyFile))
             {
@@ -80,7 +80,7 @@ namespace GitHub.Runner.Listener.Configuration
             Trace.Info("Loading RSA key parameters from file {0}", _keyFile);
 
             var parameters = IOUtil.LoadObject<RSAParametersSerializable>(_keyFile).RSAParameters;
-            var rsa = new RSACryptoServiceProvider();
+            var rsa = RSA.Create();
             rsa.ImportParameters(parameters);
             return rsa;
         }

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -319,7 +319,8 @@ namespace GitHub.Runner.Listener
                 var keyManager = HostContext.GetService<IRSAKeyManager>();
                 using (var rsa = keyManager.GetKey())
                 {
-                    return aes.CreateDecryptor(rsa.Decrypt(_session.EncryptionKey.Value, RSAEncryptionPadding.OaepSHA1), message.IV);
+                    var padding = _settings.RequireFipsCryptography ? RSAEncryptionPadding.OaepSHA256 : RSAEncryptionPadding.OaepSHA1;
+                    return aes.CreateDecryptor(rsa.Decrypt(_session.EncryptionKey.Value, padding), message.IV);
                 }
             }
             else

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -319,7 +319,7 @@ namespace GitHub.Runner.Listener
                 var keyManager = HostContext.GetService<IRSAKeyManager>();
                 using (var rsa = keyManager.GetKey())
                 {
-                    var padding = _settings.RequireFipsCryptography ? RSAEncryptionPadding.OaepSHA256 : RSAEncryptionPadding.OaepSHA1;
+                    var padding = _session.UseFipsEncryption ? RSAEncryptionPadding.OaepSHA256 : RSAEncryptionPadding.OaepSHA1;
                     return aes.CreateDecryptor(rsa.Decrypt(_session.EncryptionKey.Value, padding), message.IV);
                 }
             }

--- a/src/Sdk/DTWebApi/WebApi/TaskAgentSession.cs
+++ b/src/Sdk/DTWebApi/WebApi/TaskAgentSession.cs
@@ -65,5 +65,15 @@ namespace GitHub.DistributedTask.WebApi
             get;
             set;
         }
+
+        /// <summary>
+        /// Gets or sets whether to use FIPS compliant encryption scheme for job message key
+        /// </summary>
+        [DataMember]
+        public bool UseFipsEncryption
+        {
+            get;
+            set;
+        }
     }
 }


### PR DESCRIPTION
- Updates RSA api usage to match recommendations in https://docs.microsoft.com/en-us/dotnet/standard/security/cross-platform-cryptography#rsa, and use APIs that support fips requirements like Pss crossplatform

- Adds a runner setting to be sent by the server when upgrading to fips complaint algorithms is required

- Cleans up some dead crypto code that came in from sdk port to simplify auditing for compliant usage 