### PR TITLE
Add proxy support for container actions

### DIFF
--- a/src/Runner.Worker/Container/ContainerInfo.cs
+++ b/src/Runner.Worker/Container/ContainerInfo.cs
@@ -21,6 +21,11 @@ namespace GitHub.Runner.Worker.Container
         {
         }
 
+        public ContainerInfo(IHostContext hostContext)
+        {
+            UpdateWebProxyEnv(hostContext.WebProxy);
+        }
+
         public ContainerInfo(IHostContext hostContext, Pipelines.JobContainer container, bool isJobContainer = true, string networkAlias = null)
         {
             this.ContainerName = container.Alias;

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -70,7 +70,7 @@ namespace GitHub.Runner.Worker.Handlers
             }
 
             // run container
-            var container = new ContainerInfo()
+            var container = new ContainerInfo(HostContext)
             {
                 ContainerImage = Data.Image,
                 ContainerName = ExecutionContext.Id.ToString("N"),

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -92,6 +92,26 @@ namespace GitHub.Runner.Worker
                 var envContext = new CaseSensitiveDictionaryContextData();
 #endif
 
+                // If the HostContext needs to run through a proxy, the action needs too
+                if (!string.IsNullOrEmpty(HostContext.WebProxy.HttpProxyAddress))
+                {
+                    Trace.Info($"Setting envContext HTTP_PROXY to '{HostContext.WebProxy.HttpProxyAddress}' for all HTTP requests.");
+                    envContext["HTTP_PROXY"] = new StringContextData(HostContext.WebProxy.HttpProxyAddress);
+                    envContext["http_proxy"] = new StringContextData(HostContext.WebProxy.HttpProxyAddress);
+                }
+                if (!string.IsNullOrEmpty(HostContext.WebProxy.HttpsProxyAddress))
+                {
+                    Trace.Info($"Setting envContext HTTPS_PROXY to '{HostContext.WebProxy.HttpsProxyAddress}' for all HTTPS requests.");
+                    envContext["HTTPS_PROXY"] = new StringContextData(HostContext.WebProxy.HttpsProxyAddress);
+                    envContext["https_proxy"] = new StringContextData(HostContext.WebProxy.HttpsProxyAddress);
+                }
+                if (!String.IsNullOrEmpty(HostContext.WebProxy.NoProxyString))
+                {
+                    Trace.Info($"Setting envContext NO_PROXY to '{HostContext.WebProxy.NoProxyString}' for all requests.");
+                    envContext["NO_PROXY"] = new StringContextData(HostContext.WebProxy.NoProxyString);
+                    envContext["no_proxy"] = new StringContextData(HostContext.WebProxy.NoProxyString);
+                }
+
                 // Global env
                 foreach (var pair in step.ExecutionContext.Global.EnvironmentVariables)
                 {

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -92,26 +92,6 @@ namespace GitHub.Runner.Worker
                 var envContext = new CaseSensitiveDictionaryContextData();
 #endif
 
-                // If the HostContext needs to run through a proxy, the action needs too
-                if (!string.IsNullOrEmpty(HostContext.WebProxy.HttpProxyAddress))
-                {
-                    Trace.Info($"Setting envContext HTTP_PROXY to '{HostContext.WebProxy.HttpProxyAddress}' for all HTTP requests.");
-                    envContext["HTTP_PROXY"] = new StringContextData(HostContext.WebProxy.HttpProxyAddress);
-                    envContext["http_proxy"] = new StringContextData(HostContext.WebProxy.HttpProxyAddress);
-                }
-                if (!string.IsNullOrEmpty(HostContext.WebProxy.HttpsProxyAddress))
-                {
-                    Trace.Info($"Setting envContext HTTPS_PROXY to '{HostContext.WebProxy.HttpsProxyAddress}' for all HTTPS requests.");
-                    envContext["HTTPS_PROXY"] = new StringContextData(HostContext.WebProxy.HttpsProxyAddress);
-                    envContext["https_proxy"] = new StringContextData(HostContext.WebProxy.HttpsProxyAddress);
-                }
-                if (!String.IsNullOrEmpty(HostContext.WebProxy.NoProxyString))
-                {
-                    Trace.Info($"Setting envContext NO_PROXY to '{HostContext.WebProxy.NoProxyString}' for all requests.");
-                    envContext["NO_PROXY"] = new StringContextData(HostContext.WebProxy.NoProxyString);
-                    envContext["no_proxy"] = new StringContextData(HostContext.WebProxy.NoProxyString);
-                }
-
                 // Global env
                 foreach (var pair in step.ExecutionContext.Global.EnvironmentVariables)
                 {


### PR DESCRIPTION
Currently the proxy environment variables used by the runner are not passed on to container actions.

Manually starting the container and accessing the network works, but not when it is started by the runner.

This fixes https://github.com/actions/runner/issues/570

Not sure if this will work correctly on Windows.