### PR TITLE
Makes the user keychains available to the service

### DIFF
--- a/src/Misc/layoutbin/actions.runner.plist.template
+++ b/src/Misc/layoutbin/actions.runner.plist.template
@@ -25,5 +25,7 @@
     </dict>
     <key>ProcessType</key>
     <string>Interactive</string>
+    <key>SessionCreate</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Without creating a session, the service is not able to access the keychains for the user specified under `UserName`. This causes any workflow that deals with code signing to fail as the only keychain loaded with be the system one. This should fix #350