### PR TITLE
Count actions resolve failures as infra failures

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -919,6 +919,12 @@ namespace GitHub.Runner.Worker
         }
 
         // Do not add a format string overload. See comment on ExecutionContext.Write().
+        public static void InfrastructureError(this IExecutionContext context, string message)
+        {
+            context.AddIssue(new Issue() { Type = IssueType.Error, Message = message, IsInfrastructureIssue = true});
+        }
+
+        // Do not add a format string overload. See comment on ExecutionContext.Write().
         public static void Warning(this IExecutionContext context, string message)
         {
             context.AddIssue(new Issue() { Type = IssueType.Warning, Message = message });

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -335,6 +335,14 @@ namespace GitHub.Runner.Worker
                     context.Result = TaskResult.Canceled;
                     throw;
                 }
+                catch (FailedToResolveActionDownloadInfoException ex) 
+                {
+                    // Log the error and fail the JobExtension Initialization.
+                    Trace.Error($"Caught exception from JobExtenion Initialization: {ex}");
+                    context.InfrastructureError(ex.Message);
+                    context.Result = TaskResult.Failed;
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     // Log the error and fail the JobExtension Initialization.

--- a/src/Sdk/DTWebApi/WebApi/Exceptions.cs
+++ b/src/Sdk/DTWebApi/WebApi/Exceptions.cs
@@ -2458,4 +2458,23 @@ namespace GitHub.DistributedTask.WebApi
         {
         }
     }
+
+    [Serializable]
+    public sealed class FailedToResolveActionDownloadInfoException : DistributedTaskException
+    {
+        public FailedToResolveActionDownloadInfoException(String message)
+            : base(message)
+        {
+        }
+
+        public FailedToResolveActionDownloadInfoException(String message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        private FailedToResolveActionDownloadInfoException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
 }

--- a/src/Sdk/DTWebApi/WebApi/Issue.cs
+++ b/src/Sdk/DTWebApi/WebApi/Issue.cs
@@ -17,6 +17,7 @@ namespace GitHub.DistributedTask.WebApi
             this.Type = issueToBeCloned.Type;
             this.Category = issueToBeCloned.Category;
             this.Message = issueToBeCloned.Message;
+            this.IsInfrastructureIssue = issueToBeCloned.IsInfrastructureIssue;
 
             if (issueToBeCloned.m_data != null)
             {
@@ -43,6 +44,13 @@ namespace GitHub.DistributedTask.WebApi
 
         [DataMember(Order = 3)]
         public String Message
+        {
+            get;
+            set;
+        }
+
+        [DataMember(Order = 4)]
+        public bool? IsInfrastructureIssue
         {
             get;
             set;


### PR DESCRIPTION
Closes https://github.com/github/c2c-actions-runtime/issues/986

During job run we may fail to resolve actions download info, and this stack is fully controlled by GitHub actions so it should be counted as infrastructure failure instead of user failure.