### PR TITLE
Introduce function count() for arrays & strings

### DIFF
--- a/src/Sdk/DTExpressions2/Expressions2/ExpressionConstants.cs
+++ b/src/Sdk/DTExpressions2/Expressions2/ExpressionConstants.cs
@@ -13,6 +13,7 @@ namespace GitHub.DistributedTask.Expressions2
             AddFunction<EndsWith>("endsWith", 2, 2);
             AddFunction<Format>("format", 1, Byte.MaxValue);
             AddFunction<Join>("join", 1, 2);
+            AddFunction<Count>("count", 1, 1);
             AddFunction<StartsWith>("startsWith", 2, 2);
             AddFunction<ToJson>("toJson", 1, 1);
             AddFunction<FromJson>("fromJson", 1, 1);

--- a/src/Sdk/DTExpressions2/Expressions2/Sdk/Functions/Count.cs
+++ b/src/Sdk/DTExpressions2/Expressions2/Sdk/Functions/Count.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace GitHub.DistributedTask.Expressions2.Sdk.Functions
+{
+    internal sealed class Count : Function
+    {
+        protected sealed override Boolean TraceFullyRealized => false;
+
+        protected sealed override Object EvaluateCore(
+            EvaluationContext context,
+            out ResultMemory resultMemory)
+        {
+            resultMemory = null;
+            var items = Parameters[0].Evaluate(context);
+            
+            // Array
+            if (items.TryGetCollectionInterface(out var collection) &&
+                collection is IReadOnlyArray array)
+            {
+                return array.Count;
+            }
+            // Primitive
+            else if (items.IsPrimitive)
+            {
+                return items.ConvertToString().Length;
+            }
+            // Otherwise return zero
+            else
+            {
+                return 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Usage example with [dynamic jobs](https://github.com/cschleiden/actions-examples):
```yaml
on:
  workflow_dispatch:
    inputs:
      versions:   
jobs:
  deploy:
    name: Deploy ${{ count(fromJson(github.event.inputs.versions)) }} versions
    runs-on: ubuntu-latest
    strategy:
      matrix:
        version: ${{ fromJson(github.event.inputs.versions) }}
    name: Deploy ${{ matrix.version }} version
    steps:
      - run: echo "hello world"
```