### PR TITLE
Introduce function split() for strings

### DIFF
--- a/src/Sdk/DTExpressions2/Expressions2/ExpressionConstants.cs
+++ b/src/Sdk/DTExpressions2/Expressions2/ExpressionConstants.cs
@@ -12,6 +12,7 @@ namespace GitHub.DistributedTask.Expressions2
             AddFunction<Contains>("contains", 2, 2);
             AddFunction<EndsWith>("endsWith", 2, 2);
             AddFunction<Format>("format", 1, Byte.MaxValue);
+            AddFunction<Split>("split", 1, 2);
             AddFunction<Join>("join", 1, 2);
             AddFunction<StartsWith>("startsWith", 2, 2);
             AddFunction<ToJson>("toJson", 1, 1);

--- a/src/Sdk/DTExpressions2/Expressions2/Sdk/Functions/Split.cs
+++ b/src/Sdk/DTExpressions2/Expressions2/Sdk/Functions/Split.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text;
+
+namespace GitHub.DistributedTask.Expressions2.Sdk.Functions
+{
+    internal sealed class Split : Function
+    {
+        protected sealed override Boolean TraceFullyRealized => true;
+
+        protected sealed override Object EvaluateCore(
+            EvaluationContext context,
+            out ResultMemory resultMemory)
+        {
+            resultMemory = null;
+            var subject = Parameters[0].Evaluate(context).ConvertToString();
+            var separator = ",";
+            if (Parameters.Count > 1)
+            {
+                var separatorResult = Parameters[1].Evaluate(context);
+                if (separatorResult.IsPrimitive)
+                {
+                    separator = separatorResult.ConvertToString();
+                }
+            }
+            
+            var result = new FilteredArray();
+            var memory = new MemoryCounter(this, context.Options.MaxMemory);
+            
+            var chunks = subject.Split(separator);
+            foreach (var chunk in chunks)
+            {
+                var partialResult = EvaluationResult.CreateIntermediateResult(context, chunk);
+                var partialString = partialResult.ConvertToString();
+                memory.Add(partialString);
+                result.Add(partialString);
+            }
+
+            resultMemory = new ResultMemory { Bytes = memory.CurrentBytes };
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Introduce counterpart to [join()](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#join) function for simple arrays where JSON format would be an overkill.

Usage example with [dynamic jobs](https://github.com/cschleiden/actions-examples/blob/main/.github/workflows/dynamic-jobs.yml):
```yaml
name: Dynamic jobs
on:
  workflow_dispatch:
    inputs:
      versions:   
jobs:
  deploy:
    runs-on: ubuntu-latest
    strategy:
      matrix:
        version: ${{ split(github.event.inputs.versions, ',') }}
    name: Deploy version ${{ matrix.version }}
    steps:
      - run: echo "hello world"
```

Sample input:
```json
{
  "versions": "1,2,3"
}
```