### PR TITLE
Ignore certain scenarios so they are not counted as infra failures

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -594,14 +594,8 @@ namespace GitHub.Runner.Worker
                     actionDownloadInfos = await jobServer.ResolveActionDownloadInfoAsync(executionContext.Global.Plan.ScopeIdentifier, executionContext.Global.Plan.PlanType, executionContext.Global.Plan.PlanId, new WebApi.ActionReferenceList { Actions = actionReferences }, executionContext.CancellationToken);
                     break;
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (!executionContext.CancellationToken.IsCancellationRequested) // Do not retry if the run is canceled.
                 {
-                    // Action download was canceled, due to fail fast strategy. There is no point in retrying anymore as the run is canceled.
-                    if (ex.Message != null && string.Equals(ex.Message, "A task was canceled.", StringComparison.OrdinalIgnoreCase))
-                    {
-                        throw;
-                    }
-
                     if (attempt < 3)
                     {
                         executionContext.Output($"Failed to resolve action download info. Error: {ex.Message}");

--- a/src/Sdk/DTWebApi/WebApi/Exceptions.cs
+++ b/src/Sdk/DTWebApi/WebApi/Exceptions.cs
@@ -2460,6 +2460,25 @@ namespace GitHub.DistributedTask.WebApi
     }
 
     [Serializable]
+    public class UnresolvableActionDownloadInfoException : DistributedTaskException
+    {
+        public UnresolvableActionDownloadInfoException(String message)
+            : base(message)
+        {
+        }
+
+        public UnresolvableActionDownloadInfoException(String message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected UnresolvableActionDownloadInfoException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
     public sealed class FailedToResolveActionDownloadInfoException : DistributedTaskException
     {
         public FailedToResolveActionDownloadInfoException(String message)


### PR DESCRIPTION
Closes https://github.com/github/c2c-actions-runtime/issues/1050

There are some cases that should not be counted as infrastructure failures:
1. Repo is rate-limited
2. Action lives in a non-public repo
3. Job is canceled due to fail fast strategy

This PR will ignore all `422` response code (Server maps `UnresolvableActionDownloadInfoException` to status code `422`), those scenarios should be considered user error.

We should also stop retry if the job is canceled.

