### PR TITLE
Add new ANDROID_SDK_ROOT environment variable

### DIFF
--- a/src/Misc/layoutroot/env.sh
+++ b/src/Misc/layoutroot/env.sh
@@ -6,6 +6,7 @@ varCheckList=(
     'ANT_HOME' 
     'M2_HOME' 
     'ANDROID_HOME' 
+    'ANDROID_SDK_ROOT'
     'GRADLE_HOME' 
     'NVM_BIN' 
     'NVM_PATH'


### PR DESCRIPTION
`ANDROID_SDK_ROOT` is the current way of specifying the location of the SDK.
`ANDROID_HOME` is deprecated, but not everyone updated to the new format.

More info about the environment variables: https://developer.android.com/studio/command-line/variables

This change will publish the new and old environment variables. The reason is because some actions are [starting to use the new environment variable and getting broken because of that](https://github.com/ReactiveCircus/android-emulator-runner/issues/116).