### PR TITLE
Generate SHA's for released packages and include them in package notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
               repo: '${{ github.event.repository.name }}',
               tag: 'v' + runnerVersion
             })
+            core.setFailed('Release with same tag already created: ' + release.data.html_url)
           } catch (e) {
             // We are good to create the release if release with same tag doesn't exists
             if (e.status != 404) {
@@ -110,7 +111,11 @@ jobs:
     - run: brew install coreutils #needed for shasum util
       if: ${{ matrix.os == 'macOS-latest' }}
       name: Install Dependencies for SHA Calculation (osx)
-    - run: echo "::set-output name=${{matrix.runtime}}-sha256::$(sha256sum "$(ls)" | awk '{ print $1 }')"
+    - run: |
+        file=$(ls)
+        sha=$(sha256sum $file | awk '{ print $1 }')
+        echo "Computed sha256: $sha for $file"
+        echo "::set-output name=${{matrix.runtime}}-sha256::$sha"
       shell: bash
       id: sha
       name: Compute SHA256
@@ -140,15 +145,15 @@ jobs:
           const fs = require('fs');
           const runnerVersion = fs.readFileSync('${{ github.workspace }}/src/runnerversion', 'utf8').replace(/\n$/g, '')
           var releaseNote = fs.readFileSync('${{ github.workspace }}/releaseNote.md', 'utf8').replace(/<RUNNER_VERSION>/g, runnerVersion)
-          releaseNote = releaseNote.replace(/<WIN_X64_SHA>/g, ${{needs.build.win-x64-sha}})
-          releaseNote = releaseNote.replace(/<OSX_X64_SHA>/g, ${{needs.build.osx-x64-sha}})
-          releaseNote = releaseNote.replace(/<LINUX_X64_SHA>/g, ${{needs.build.linux-x64-sha}})
-          releaseNote = releaseNote.replace(/<LINUX_ARM_SHA>/g, ${{needs.build.linux-arm-sha}})
-          releaseNote = releaseNote.replace(/<LINUX_ARM64_SHA>/g, ${{needs.build.linux-arm64-sha}})
+          releaseNote = releaseNote.replace(/<WIN_X64_SHA>/g, '${{needs.build.outputs.win-x64-sha}}')
+          releaseNote = releaseNote.replace(/<OSX_X64_SHA>/g, '${{needs.build.outputs.osx-x64-sha}}')
+          releaseNote = releaseNote.replace(/<LINUX_X64_SHA>/g, '${{needs.build.outputs.linux-x64-sha}}')
+          releaseNote = releaseNote.replace(/<LINUX_ARM_SHA>/g, '${{needs.build.outputs.linux-arm-sha}}')
+          releaseNote = releaseNote.replace(/<LINUX_ARM64_SHA>/g, '${{needs.build.outputs.linux-arm64-sha}}')
           console.log(releaseNote)
           core.setOutput('version', runnerVersion);
           core.setOutput('note', releaseNote);
-        
+    - run: echo "${{ toJSON(needs) }}"    
     # Create GitHub release
     - uses: actions/create-release@master
       id: createRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,9 +110,11 @@ jobs:
     # compute shas and set as job outputs to use in release notes
     - run: brew install coreutils #needed for shasum util
       if: ${{ matrix.os == 'macOS-latest' }}
-    - run: echo "::set-output name=${{matrix.runtime}}-sha256::$(sha256sum "$(ls _package)" | awk '{ print $1 }')"
+      name: Install Dependencies for SHA Calculation (osx)
+    - run: echo "::set-output name=${{matrix.runtime}}-sha256::$(sha256sum "_package/$(ls _package)" | awk '{ print $1 }')"
       shell: bash
       id: sha
+      name: Compute SHA256
   release:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
               repo: '${{ github.event.repository.name }}',
               tag: 'v' + runnerVersion
             })
-            core.setFailed('Release with same tag already created: ' + release.data.html_url)
           } catch (e) {
             // We are good to create the release if release with same tag doesn't exists
             if (e.status != 404) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
   
   build:
     needs: check
+    outputs:
+      linux-x64-sha: ${{ steps.sha.outputs.linux-x64-sha256 }}
+      linux-arm64-sha: ${{ steps.sha.outputs.linux-arm64-sha256 }}
+      linux-arm-sha: ${{ steps.sha.outputs.linux-arm-sha256 }}
+      win-x64-sha: ${{ steps.sha.outputs.win-x64-sha256 }}
+      osx-x64-sha: ${{ steps.sha.outputs.osx-x64-sha256 }}
     strategy:
       matrix:
         runtime: [ linux-x64, linux-arm64, linux-arm, win-x64, osx-x64 ]
@@ -101,7 +107,12 @@ jobs:
       with:
         name: runner-packages
         path: _package
-
+    # compute shas and set as job outputs to use in release notes
+    - run: brew install coreutils #needed for shasum util
+      if: ${{ matrix.os == 'macOS-latest' }}
+    - run: echo "::set-output name=${{matrix.runtime}}-sha256::$(sha256sum "$(ls _package)" | awk '{ print $1 }')"
+      shell: bash
+      id: sha
   release:
     needs: build
     runs-on: ubuntu-latest
@@ -126,7 +137,12 @@ jobs:
           const core = require('@actions/core')
           const fs = require('fs');
           const runnerVersion = fs.readFileSync('${{ github.workspace }}/src/runnerversion', 'utf8').replace(/\n$/g, '')
-          const releaseNote = fs.readFileSync('${{ github.workspace }}/releaseNote.md', 'utf8').replace(/<RUNNER_VERSION>/g, runnerVersion)
+          var releaseNote = fs.readFileSync('${{ github.workspace }}/releaseNote.md', 'utf8').replace(/<RUNNER_VERSION>/g, runnerVersion)
+          releaseNote = releaseNote.replace(/<WIN_X64_SHA>/g, ${{needs.build.win-x64-sha}})
+          releaseNote = releaseNote.replace(/<OSX_X64_SHA>/g, ${{needs.build.osx-x64-sha}})
+          releaseNote = releaseNote.replace(/<LINUX_X64_SHA>/g, ${{needs.build.linux-x64-sha}})
+          releaseNote = releaseNote.replace(/<LINUX_ARM_SHA>/g, ${{needs.build.linux-arm-sha}})
+          releaseNote = releaseNote.replace(/<LINUX_ARM64_SHA>/g, ${{needs.build.linux-arm64-sha}})
           console.log(releaseNote)
           core.setOutput('version', runnerVersion);
           core.setOutput('note', releaseNote);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,10 +110,11 @@ jobs:
     - run: brew install coreutils #needed for shasum util
       if: ${{ matrix.os == 'macOS-latest' }}
       name: Install Dependencies for SHA Calculation (osx)
-    - run: echo "::set-output name=${{matrix.runtime}}-sha256::$(sha256sum "_package/$(ls _package)" | awk '{ print $1 }')"
+    - run: echo "::set-output name=${{matrix.runtime}}-sha256::$(sha256sum "$(ls)" | awk '{ print $1 }')"
       shell: bash
       id: sha
       name: Compute SHA256
+      working-directory: _package
   release:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,8 +152,7 @@ jobs:
           releaseNote = releaseNote.replace(/<LINUX_ARM64_SHA>/g, '${{needs.build.outputs.linux-arm64-sha}}')
           console.log(releaseNote)
           core.setOutput('version', runnerVersion);
-          core.setOutput('note', releaseNote);
-    - run: echo "${{ toJSON(needs) }}"    
+          core.setOutput('note', releaseNote);  
     # Create GitHub release
     - uses: actions/create-release@master
       id: createRelease

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -67,3 +67,11 @@ tar xzf ./actions-runner-linux-arm-<RUNNER_VERSION>.tar.gz
 
 ## Using your self hosted runner
 For additional details about configuring, running, or shutting down the runner please check out our [product docs.](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/adding-self-hosted-runners)
+
+## SHA-256 Checksums
+The SHA-256 checksums for the packages included in this build are shown below:
+actions-runner-win-x64-<RUNNER_VERSION>.zip <!-- BEGIN SHA win-x64 --><WIN_X64_SHA><!-- END SHA win-x64 -->
+actions-runner-osx-x64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA osx-x64 --><OSX_X64_SHA><!-- END SHA osx-x64 -->
+actions-runner-linux-x64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-x64 --><LINUX_X64_SHA><!-- END SHA linux-x64 -->
+actions-runner-linux-arm64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-arm64 --><LINUX_ARM64_SHA><!-- END SHA linux-arm64 -->
+actions-runner-linux-arm64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-arm --><LINUX_ARM_SHA><!-- END SHA linux-arm -->

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -69,9 +69,11 @@ tar xzf ./actions-runner-linux-arm-<RUNNER_VERSION>.tar.gz
 For additional details about configuring, running, or shutting down the runner please check out our [product docs.](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/adding-self-hosted-runners)
 
 ## SHA-256 Checksums
+
 The SHA-256 checksums for the packages included in this build are shown below:
-actions-runner-win-x64-<RUNNER_VERSION>.zip <!-- BEGIN SHA win-x64 --><WIN_X64_SHA><!-- END SHA win-x64 -->
-actions-runner-osx-x64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA osx-x64 --><OSX_X64_SHA><!-- END SHA osx-x64 -->
-actions-runner-linux-x64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-x64 --><LINUX_X64_SHA><!-- END SHA linux-x64 -->
-actions-runner-linux-arm64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-arm64 --><LINUX_ARM64_SHA><!-- END SHA linux-arm64 -->
-actions-runner-linux-arm64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-arm --><LINUX_ARM_SHA><!-- END SHA linux-arm -->
+
+- actions-runner-win-x64-<RUNNER_VERSION>.zip <!-- BEGIN SHA win-x64 --><WIN_X64_SHA><!-- END SHA win-x64 -->
+- actions-runner-osx-x64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA osx-x64 --><OSX_X64_SHA><!-- END SHA osx-x64 -->
+- actions-runner-linux-x64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-x64 --><LINUX_X64_SHA><!-- END SHA linux-x64 -->
+- actions-runner-linux-arm64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-arm64 --><LINUX_ARM64_SHA><!-- END SHA linux-arm64 -->
+- actions-runner-linux-arm64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-arm --><LINUX_ARM_SHA><!-- END SHA linux-arm -->

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -76,4 +76,4 @@ The SHA-256 checksums for the packages included in this build are shown below:
 - actions-runner-osx-x64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA osx-x64 --><OSX_X64_SHA><!-- END SHA osx-x64 -->
 - actions-runner-linux-x64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-x64 --><LINUX_X64_SHA><!-- END SHA linux-x64 -->
 - actions-runner-linux-arm64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-arm64 --><LINUX_ARM64_SHA><!-- END SHA linux-arm64 -->
-- actions-runner-linux-arm64-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-arm --><LINUX_ARM_SHA><!-- END SHA linux-arm -->
+- actions-runner-linux-arm-<RUNNER_VERSION>.tar.gz <!-- BEGIN SHA linux-arm --><LINUX_ARM_SHA><!-- END SHA linux-arm -->


### PR DESCRIPTION
This PR updates the release process to include sha256 hashes of the runner downloads. Users can use these to verify that they have downloaded the correct runner and it has not been tampered with.

Example (fake) runner release is found [here](https://github.com/thboop/runner/releases/tag/v2.276.2)