### PR TITLE
Add http POST to --check.

### DIFF
--- a/docs/checks/actions.md
+++ b/docs/checks/actions.md
@@ -27,6 +27,7 @@ Make sure the runner has access to actions service for GitHub.com or GitHub Ente
 - DNS lookup for pipelines.actions.githubusercontent.com using dotnet
 - Ping pipelines.actions.githubusercontent.com using dotnet
 - Make HTTP GET to https://pipelines.actions.githubusercontent.com/_apis/health or https://myGHES.com/_services/pipelines/_apis/health using dotnet, check response headers contains `x-vss-e2eid` 
+- Make HTTP POST to https://pipelines.actions.githubusercontent.com/_apis/distributedtask/pools/1/agents or https://myGHES.com/_services/pipelines/_apis/distributedtask/pools/1/agents using dotnet, check response headers contains `x-vss-e2eid` 
 
 ## How to fix the issue?
 

--- a/docs/checks/actions.md
+++ b/docs/checks/actions.md
@@ -27,7 +27,7 @@ Make sure the runner has access to actions service for GitHub.com or GitHub Ente
 - DNS lookup for pipelines.actions.githubusercontent.com using dotnet
 - Ping pipelines.actions.githubusercontent.com using dotnet
 - Make HTTP GET to https://pipelines.actions.githubusercontent.com/_apis/health or https://myGHES.com/_services/pipelines/_apis/health using dotnet, check response headers contains `x-vss-e2eid` 
-- Make HTTP POST to https://pipelines.actions.githubusercontent.com/_apis/distributedtask/pools/1/agents or https://myGHES.com/_services/pipelines/_apis/distributedtask/pools/1/agents using dotnet, check response headers contains `x-vss-e2eid` 
+- Make HTTP POST to https://pipelines.actions.githubusercontent.com/_apis/health or https://myGHES.com/_services/pipelines/_apis/health using dotnet, check response headers contains `x-vss-e2eid` 
 
 ## How to fix the issue?
 

--- a/docs/checks/network.md
+++ b/docs/checks/network.md
@@ -10,6 +10,8 @@
 
 - Proxy try to decrypt and exam HTTPS traffic for security purpose but cause the actions-runner to fail to finish SSL handshake due to the lack of trusting proxy's CA.
 
+- Proxy try to modify the HTTPS request (like add or change some http headers) and causes the request become incompatible with the Actions Service (ASP.NetCore), Ex: [Nginx](https://github.com/dotnet/aspnetcore/issues/17081)
+
 - Firewall rules that block action runner from accessing certain hosts, ex: `*.github.com`, `*.actions.githubusercontent.com`, etc.
 
 
@@ -21,6 +23,7 @@ Use a 3rd party tool to make the same requests as the runner did would be a good
 
 - Use `nslookup` to check DNS
 - Use `ping` to check Ping
+- Use `traceroute`, `tracepath`, or `tracert` to check the network route between the runner and the Actions service 
 - Use `curl -v` to check the network stack, good for verifying default certificate/proxy settings.
 - Use `Invoke-WebRequest` from `pwsh` (`PowerShell Core`) to check the dotnet network stack, good for verifying bugs in the dotnet framework.
 

--- a/src/Runner.Listener/Checks/ActionsCheck.cs
+++ b/src/Runner.Listener/Checks/ActionsCheck.cs
@@ -39,7 +39,6 @@ namespace GitHub.Runner.Listener.Check
             string githubApiUrl = null;
             string actionsTokenServiceUrl = null;
             string actionsPipelinesServiceUrl = null;
-            string actionsPipelinesServicePostUrl = null;
             var urlBuilder = new UriBuilder(url);
             if (UrlUtil.IsHostedServer(urlBuilder))
             {
@@ -48,7 +47,6 @@ namespace GitHub.Runner.Listener.Check
                 githubApiUrl = urlBuilder.Uri.AbsoluteUri;
                 actionsTokenServiceUrl = "https://vstoken.actions.githubusercontent.com/_apis/health";
                 actionsPipelinesServiceUrl = "https://pipelines.actions.githubusercontent.com/_apis/health";
-                actionsPipelinesServicePostUrl = "https://pipelines.actions.githubusercontent.com/_apis/distributedtask/pools/1/agents";
             }
             else
             {
@@ -58,8 +56,6 @@ namespace GitHub.Runner.Listener.Check
                 actionsTokenServiceUrl = urlBuilder.Uri.AbsoluteUri;
                 urlBuilder.Path = "_services/pipelines/_apis/health";
                 actionsPipelinesServiceUrl = urlBuilder.Uri.AbsoluteUri;
-                urlBuilder.Path = "_services/pipelines/_apis/distributedtask/pools/1/agents";
-                actionsPipelinesServicePostUrl = urlBuilder.Uri.AbsoluteUri;
             }
 
             // check github api
@@ -78,7 +74,7 @@ namespace GitHub.Runner.Listener.Check
             checkTasks.Add(HostContext.CheckHttpsGetRequests(actionsPipelinesServiceUrl, pat, expectedHeader: "x-vss-e2eid"));
 
             // check HTTP POST to actions pipelines service
-            checkTasks.Add(HostContext.CheckHttpsPostRequests(actionsPipelinesServicePostUrl, pat, expectedHeader: "x-vss-e2eid"));
+            checkTasks.Add(HostContext.CheckHttpsPostRequests(actionsPipelinesServiceUrl, pat, expectedHeader: "x-vss-e2eid"));
 
             var result = true;
             while (checkTasks.Count > 0)

--- a/src/Runner.Listener/Checks/CheckUtil.cs
+++ b/src/Runner.Listener/Checks/CheckUtil.cs
@@ -117,7 +117,7 @@ namespace GitHub.Runner.Listener.Check
             return result;
         }
 
-        public static async Task<CheckResult> CheckHttpsRequests(this IHostContext hostContext, string url, string pat, string expectedHeader)
+        public static async Task<CheckResult> CheckHttpsGetRequests(this IHostContext hostContext, string url, string pat, string expectedHeader)
         {
             var result = new CheckResult();
             try
@@ -182,6 +182,67 @@ namespace GitHub.Runner.Listener.Check
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****                                                                                                       ****");
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****     Https request 'GET' to {url} failed with error: {ex}");
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****                                                                                                       ****");
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
+            }
+
+            return result;
+        }
+
+        public static async Task<CheckResult> CheckHttpsPostRequests(this IHostContext hostContext, string url, string pat, string expectedHeader)
+        {
+            var result = new CheckResult();
+            try
+            {
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****                                                                                                       ****");
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****     Send HTTPS POST Request to {url} ");
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****                                                                                                       ****");
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
+                using (var _ = new HttpEventSourceListener(result.Logs))
+                using (var httpClientHandler = hostContext.CreateHttpClientHandler())
+                using (var httpClient = new HttpClient(httpClientHandler))
+                {
+                    httpClient.DefaultRequestHeaders.UserAgent.AddRange(hostContext.UserAgents);
+                    if (!string.IsNullOrEmpty(pat))
+                    {
+                        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("token", pat);
+                    }
+
+                    // Send empty JSON '{}' to service
+                    var response = await httpClient.PostAsJsonAsync<Dictionary<string, string>>(url, new Dictionary<string, string>());
+
+                    result.Logs.Add($"{DateTime.UtcNow.ToString("O")} Http status code: {response.StatusCode}");
+                    result.Logs.Add($"{DateTime.UtcNow.ToString("O")} Http response headers: {response.Headers}");
+
+                    var responseContent = await response.Content.ReadAsStringAsync();
+                    result.Logs.Add($"{DateTime.UtcNow.ToString("O")} Http response body: {responseContent}");
+                    if (response.Headers.Contains(expectedHeader))
+                    {
+                        result.Pass = true;
+                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
+                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} Http request 'POST' to {url} has expected HTTP response header");
+                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
+                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ");
+                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ");
+                    }
+                    else
+                    {
+                        result.Pass = false;
+                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
+                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} Http request 'POST' to {url} doesn't have expected HTTP Header.");
+                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
+                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ");
+                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                result.Pass = false;
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****                                                                                                       ****");
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****     Https request 'POST' to {url} failed with error: {ex}");
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****                                                                                                       ****");
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
             }
@@ -289,18 +350,23 @@ namespace GitHub.Runner.Listener.Check
         private readonly Dictionary<string, HashSet<string>> _ignoredEvent = new Dictionary<string, HashSet<string>>
         {
             {
-                "Private.InternalDiagnostics.System.Net.Http",
+                "Microsoft-System-Net-Http",
                 new HashSet<string>
                 {
                     "Info",
-                    "Associate"
+                    "Associate",
+                    "Enter",
+                    "Exit"
                 }
             },
             {
-                "Private.InternalDiagnostics.System.Net.Security",
+                "Microsoft-System-Net-Security",
                 new HashSet<string>
                 {
+                    "Enter",
+                    "Exit",
                     "Info",
+                    "DumpBuffer",
                     "SslStreamCtor",
                     "SecureChannelCtor",
                     "NoDelegateNoClientCert",
@@ -324,8 +390,8 @@ namespace GitHub.Runner.Listener.Check
         {
             base.OnEventSourceCreated(eventSource);
 
-            if (eventSource.Name == "Private.InternalDiagnostics.System.Net.Http" ||
-                eventSource.Name == "Private.InternalDiagnostics.System.Net.Security")
+            if (eventSource.Name == "Microsoft-System-Net-Http" ||
+                eventSource.Name == "Microsoft-System-Net-Security")
             {
                 EnableEvents(eventSource, EventLevel.Verbose, EventKeywords.All);
             }

--- a/src/Runner.Listener/Checks/CheckUtil.cs
+++ b/src/Runner.Listener/Checks/CheckUtil.cs
@@ -124,7 +124,7 @@ namespace GitHub.Runner.Listener.Check
             {
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****                                                                                                       ****");
-                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****     Send HTTPS Request to {url} ");
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****     Send HTTPS Request (GET) to {url} ");
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****                                                                                                       ****");
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
                 using (var _ = new HttpEventSourceListener(result.Logs))
@@ -159,7 +159,7 @@ namespace GitHub.Runner.Listener.Check
                         {
                             result.Pass = false;
                             result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
-                            result.Logs.Add($"{DateTime.UtcNow.ToString("O")} Http request 'GET' to {url} succeed but doesn't have expected HTTP Header.");
+                            result.Logs.Add($"{DateTime.UtcNow.ToString("O")} Http request 'GET' to {url} succeed but doesn't have expected HTTP response Header '{expectedHeader}'.");
                             result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
                             result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ");
                             result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ");
@@ -196,7 +196,7 @@ namespace GitHub.Runner.Listener.Check
             {
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****                                                                                                       ****");
-                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****     Send HTTPS POST Request to {url} ");
+                result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****     Send HTTPS Request (POST) to {url} ");
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ****                                                                                                       ****");
                 result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
                 using (var _ = new HttpEventSourceListener(result.Logs))
@@ -230,7 +230,7 @@ namespace GitHub.Runner.Listener.Check
                     {
                         result.Pass = false;
                         result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
-                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} Http request 'POST' to {url} doesn't have expected HTTP Header.");
+                        result.Logs.Add($"{DateTime.UtcNow.ToString("O")} Http request 'POST' to {url} doesn't have expected HTTP response Header '{expectedHeader}'.");
                         result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ***************************************************************************************************************");
                         result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ");
                         result.Logs.Add($"{DateTime.UtcNow.ToString("O")} ");

--- a/src/Runner.Listener/Checks/InternetCheck.cs
+++ b/src/Runner.Listener/Checks/InternetCheck.cs
@@ -40,7 +40,7 @@ namespace GitHub.Runner.Listener.Check
             checkTasks.Add(CheckUtil.CheckPing("https://api.github.com"));
 
             // We don't need to pass a PAT since it might be a token for GHES.
-            checkTasks.Add(HostContext.CheckHttpsRequests("https://api.github.com", pat: null, expectedHeader: "X-GitHub-Request-Id"));
+            checkTasks.Add(HostContext.CheckHttpsGetRequests("https://api.github.com", pat: null, expectedHeader: "X-GitHub-Request-Id"));
 
             var result = true;
             while (checkTasks.Count > 0)


### PR DESCRIPTION
As part of investigation for https://github.com/github/c2c-actions/issues/2231
We learned that Nginx may change the HTTP request header and cause an issue with a runner HTTP request to the Actions server written in ASP.netcore.

Add an HTTP POST test to `--check` and update the documentation.