### PR TITLE
Update run.sh

### DIFF
--- a/src/Misc/layoutroot/run.sh
+++ b/src/Misc/layoutroot/run.sh
@@ -26,10 +26,10 @@ if [[ "$1" == "localRun" ]]; then
 else
     "$DIR"/bin/Runner.Listener run $*
 
-# Return code 4 means the run once runner received an update message.
-# Sleep 5 seconds to wait for the update process finish and run the runner again.
+# Return code 3 means the run once runner received an update message.
+# Sleep 5 seconds to wait for the update process finish
     returnCode=$?
-    if [[ $returnCode == 4 ]]; then
+    if [[ $returnCode == 3 ]]; then
         if [ ! -x "$(command -v sleep)" ]; then
             if [ ! -x "$(command -v ping)" ]; then
                 COUNT="0"
@@ -43,8 +43,6 @@ else
         else
             sleep 5 >nul
         fi
-        
-        "$DIR"/bin/Runner.Listener run $*
     else
         exit $returnCode
     fi


### PR DESCRIPTION
Fix runner update script, in fact the behavior is:

```
Runner update in progress, do not shutdown runner.
Downloading 2.276.1 runner
Waiting for current job finish running.
Generate and execute update script.
Runner will exit shortly for update, should back online within 10 seconds.
+ returnCode=3
+ [[ 3 == 4 ]]
+ exit 3
```