### PR TITLE
Display GITHUB_TOKEN permissions

### DIFF
--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -123,16 +123,24 @@ namespace GitHub.Runner.Worker
                         }
                     }
 
-                    var tokenPermissions = jobContext.Global.Variables.Get("system.github.token.permissions") ?? "";
-                    if (!string.IsNullOrEmpty(tokenPermissions))
+                    try 
                     {
-                        context.Output($"##[group]GITHUB_TOKEN Permissions");
-                        var permissions = JsonConvert.DeserializeObject<Dictionary<string, string>>(tokenPermissions);
-                        foreach(KeyValuePair<string, string> entry in permissions)
+                        var tokenPermissions = jobContext.Global.Variables.Get("system.github.token.permissions") ?? "";
+                        if (!string.IsNullOrEmpty(tokenPermissions))
                         {
-                            context.Output($"{entry.Key}: {entry.Value}");
+                            context.Output($"##[group]GITHUB_TOKEN Permissions");
+                            var permissions = JsonConvert.DeserializeObject<Dictionary<string, string>>(tokenPermissions);
+                            foreach(KeyValuePair<string, string> entry in permissions)
+                            {
+                                context.Output($"{entry.Key}: {entry.Value}");
+                            }
+                            context.Output("##[endgroup]");
                         }
-                        context.Output("##[endgroup]");
+                    } 
+                    catch (Exception ex)
+                    {
+                        context.Output($"Fail to parse and display GITHUB_TOKEN permissions list: {ex.Message}");
+                        Trace.Error(ex);
                     }
 
                     var repoFullName = context.GetGitHubContext("repository");

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -16,7 +16,6 @@ using GitHub.Runner.Common;
 using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using Pipelines = GitHub.DistributedTask.Pipelines;
-using Newtonsoft.Json;
 
 namespace GitHub.Runner.Worker
 {
@@ -129,7 +128,7 @@ namespace GitHub.Runner.Worker
                         if (!string.IsNullOrEmpty(tokenPermissions))
                         {
                             context.Output($"##[group]GITHUB_TOKEN Permissions");
-                            var permissions = JsonConvert.DeserializeObject<Dictionary<string, string>>(tokenPermissions);
+                            var permissions = StringUtil.ConvertFromJson<Dictionary<string, string>>(tokenPermissions);
                             foreach(KeyValuePair<string, string> entry in permissions)
                             {
                                 context.Output($"{entry.Key}: {entry.Value}");

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -16,6 +16,7 @@ using GitHub.Runner.Common;
 using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using Pipelines = GitHub.DistributedTask.Pipelines;
+using Newtonsoft.Json;
 
 namespace GitHub.Runner.Worker
 {
@@ -120,6 +121,18 @@ namespace GitHub.Runner.Worker
                             context.Output($"Fail to load and print machine setup info: {ex.Message}");
                             Trace.Error(ex);
                         }
+                    }
+
+                    var tokenPermissions = jobContext.Global.Variables.Get("system.github.token.permissions") ?? "";
+                    if (!string.IsNullOrEmpty(tokenPermissions))
+                    {
+                        context.Output($"##[group]GITHUB_TOKEN Permissions");
+                        var permissions = JsonConvert.DeserializeObject<Dictionary<string, string>>(tokenPermissions);
+                        foreach(KeyValuePair<string, string> entry in permissions)
+                        {
+                            context.Output($"{entry.Key}: {entry.Value}");
+                        }
+                        context.Output("##[endgroup]");
                     }
 
                     var repoFullName = context.GetGitHubContext("repository");


### PR DESCRIPTION
Right now it's not clear what permission the GITHUB_TOKEN has.  With this change we will display the permissions in one single group in the job log.

Example run:
![image](https://user-images.githubusercontent.com/10119737/106962354-fdc8dd00-670c-11eb-9e83-0dfa95390bbc.png)
