### PR TITLE
Update usage of /dev/null and ping flag in run.sh

### DIFF
--- a/src/Misc/layoutroot/run.sh
+++ b/src/Misc/layoutroot/run.sh
@@ -34,14 +34,14 @@ else
             if [ ! -x "$(command -v ping)" ]; then
                 COUNT="0"
                 while [[ $COUNT != 5000 ]]; do
-                    echo "SLEEP" >nul
+                    echo "SLEEP" > /dev/null
                     COUNT=$[$COUNT+1]
                 done
             else
-                ping -n 5 127.0.0.1 >nul
+                ping -c 5 127.0.0.1 > /dev/null
             fi
         else
-            sleep 5 >nul
+            sleep 5
         fi
         
         "$DIR"/bin/Runner.Listener run $*


### PR DESCRIPTION
- Use /dev/null instead of nul  (nul is something used in Windows and in Linux it just ended up creating a file named nul)
- Use -c instead of -n as a ping flag to specify number of packets to be sent (-n is the flag used in Windows but in Linux we need to use -c)