### PR TITLE
Use GITHUB_TOKEN for ghcr.io containers if credentials are not provided

### DIFF
--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -493,7 +493,7 @@ namespace GitHub.Runner.Worker
 
         private void UpdateRegistryAuthForGitHubToken(IExecutionContext executionContext, ContainerInfo container)
         {
-            var registryIsTokenCompatible = container.RegistryServer.Equals("ghcr.io", StringComparison.OrdinalIgnoreCase);
+            var registryIsTokenCompatible = container.RegistryServer.Equals("ghcr.io", StringComparison.OrdinalIgnoreCase) || container.RegistryServer.Equals("containers.pkg.github.com", StringComparison.OrdinalIgnoreCase);
             if (!registryIsTokenCompatible)
             {
                 return;


### PR DESCRIPTION
This PR allows us to use the GITHUB_TOKEN for job containers hosted in ghcr.io without providing credentials. Example:

```yaml
name: ghcr.io test
on:
  workflow_dispatch:
jobs:
  push:
    runs-on:
      - self-hosted
      - Linux
      - X64
    
    # Use private GHCR image as build container
    container:
      image: ghcr.io/owner/repo

    steps:
      - uses: actions/checkout@v2

      - name: Run Action
        run: |
          echo 'Hello, World!'
```

I just tested it here https://github.com/sweethaven-village/ghtoken_test/runs/1920493095?check_suite_focus=true Let me know if you want access.

I used some existing code, but removed the repo check because we want to use containers in any repo in the same org and eventually in other orgs too, as long as the GITHUB_TOKEN has access to them of course.