### PR TITLE
Allow auth token env var for pulling internal/org based actions

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1135,10 +1135,21 @@ namespace GitHub.Runner.Worker
             {
                 return null;
             }
+            var authToken = Environment.GetEnvironmentVariable("_GITHUB_ACTION_TOKEN");
 
-            var base64EncodingToken = Convert.ToBase64String(Encoding.UTF8.GetBytes($"x-access-token:{token}"));
-            HostContext.SecretMasker.AddValue(base64EncodingToken);
-            return new AuthenticationHeaderValue("Basic", base64EncodingToken);
+            if (!string.IsNullOrEmpty(authToken))
+            {
+                HostContext.SecretMasker.AddValue(authToken);
+                var base64EncodingToken = Convert.ToBase64String(Encoding.UTF8.GetBytes($"PAT:{authToken}"));
+                HostContext.SecretMasker.AddValue(base64EncodingToken);
+                return new AuthenticationHeaderValue("Basic", base64EncodingToken);
+            }
+            else
+            {
+                var base64EncodingToken = Convert.ToBase64String(Encoding.UTF8.GetBytes($"x-access-token:{token}"));
+                HostContext.SecretMasker.AddValue(base64EncodingToken);
+                return new AuthenticationHeaderValue("Basic", base64EncodingToken);
+            }
         }
 
         // todo: Remove when feature flag DistributedTask.NewActionMetadata is removed


### PR DESCRIPTION
Follow similar logic used for GHES, to allow non GHES to pass an auth token for pulling private/internal/org actions