### PR TITLE
mask secrets with double-quotes when passed to docker command line

### DIFF
--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -84,6 +84,7 @@ namespace GitHub.Runner.Common
             this.SecretMasker.AddValueEncoder(ValueEncoders.Base64StringEscape);
             this.SecretMasker.AddValueEncoder(ValueEncoders.Base64StringEscapeShift1);
             this.SecretMasker.AddValueEncoder(ValueEncoders.Base64StringEscapeShift2);
+            this.SecretMasker.AddValueEncoder(ValueEncoders.CommandLineArgumentEscape);
             this.SecretMasker.AddValueEncoder(ValueEncoders.ExpressionStringEscape);
             this.SecretMasker.AddValueEncoder(ValueEncoders.JsonStringEscape);
             this.SecretMasker.AddValueEncoder(ValueEncoders.UriDataEscape);

--- a/src/Sdk/DTLogging/Logging/ValueEncoders.cs
+++ b/src/Sdk/DTLogging/Logging/ValueEncoders.cs
@@ -37,6 +37,12 @@ namespace GitHub.DistributedTask.Logging
             return Base64StringEscapeShift(value, 2);
         }
 
+        // Used when we pass environment variables to docker to escape " with \"
+        public static String CommandLineArgumentEscape(String value)
+        {
+            return value.Replace("\"", "\\\"");
+        }
+
         public static String ExpressionStringEscape(String value)
         {
             return Expressions2.Sdk.ExpressionUtility.StringEscape(value);


### PR DESCRIPTION
Small bug fix when passing secrets to the job container

Repro steps:
- Create a secret like `MY_SECRET={"my-token": "my multiline\nsecret value"}`
- Run the following workflow:

```yaml
name: CI
on:
  push:
jobs:
  build:
    runs-on: ubuntu-latest
    container:
      image: alpine:latest
      env:
        MY_SECRET: ${{ secrets.MY_SECRET }}
    steps:
      - run: echo hello world
```