### PR TITLE
Return 1 on service status when service is not installed

### DIFF
--- a/src/Misc/layoutbin/systemd.svc.sh.template
+++ b/src/Misc/layoutbin/systemd.svc.sh.template
@@ -124,7 +124,7 @@ function status()
         echo
         echo "not installed"
         echo
-        return
+        exit 1
     fi
 
     systemctl --no-pager status ${SVC_NAME}


### PR DESCRIPTION
This allows to easily check if the service is installed or not in configuration management tools.