### PR TITLE
Add a default BuildConstants and change encoding on save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ TestResults
 TestLogs
 .DS_Store
 **/*.DotSettings.user
-
-#generated
-src/Runner.Sdk/BuildConstants.cs

--- a/src/Runner.Sdk/BuildConstants.cs
+++ b/src/Runner.Sdk/BuildConstants.cs
@@ -1,0 +1,19 @@
+namespace GitHub.Runner.Sdk
+{
+    /***
+     * WARNING: This file is automatically regenerated on layout so the runner can provide version/commit info (do not manually edit it).
+     */
+    public static class BuildConstants
+    {
+        public static class Source
+        {
+            public static readonly string CommitHash = "N/A";
+        }
+
+        public static class RunnerPackage
+        {
+            public static readonly string PackageName = "N/A";
+            public static readonly string Version = "0";
+        }
+    }
+}

--- a/src/dir.proj
+++ b/src/dir.proj
@@ -25,7 +25,7 @@
             <BuildConstants Include="}"/>
         </ItemGroup>
 
-        <WriteLinesToFile File="Runner.Sdk/BuildConstants.cs" Lines="@(BuildConstants)" Overwrite="true" Encoding="Unicode"/>
+        <WriteLinesToFile File="Runner.Sdk/BuildConstants.cs" Lines="@(BuildConstants)" Overwrite="true" />
     </Target>
 
     <ItemGroup>


### PR DESCRIPTION
- Fix the encoding so BuildConstants shows up in git correctly
- Generate a default file so the solution will compile out of the box