### PR TITLE
Wait for debugger to attach in Runner.Worker process

### DIFF
--- a/src/Runner.Worker/Program.cs
+++ b/src/Runner.Worker/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using GitHub.Runner.Common;
@@ -20,7 +20,7 @@ namespace GitHub.Runner.Worker
         public static async Task<int> MainAsync(IHostContext context, string[] args)
         {
             Tracing trace = context.GetTrace(nameof(GitHub.Runner.Worker));
-            if (bool.TryParse(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_ATTACH_DEBUGGER"), out bool waitForDebugger) && waitForDebugger)
+            if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_ATTACH_DEBUGGER")))
             {
                 await WaitForDebugger(trace);
             }

--- a/src/Runner.Worker/Program.cs
+++ b/src/Runner.Worker/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using GitHub.Runner.Common;
@@ -81,10 +81,12 @@ namespace GitHub.Runner.Worker
         private static async Task WaitForDebugger(Tracing trace)
         {
             trace.Info($"Waiting for a debugger to be attached. Edit the 'GITHUB_ACTIONS_RUNNER_ATTACH_DEBUGGER' environment variable to toggle this feature.");
-            while (!Debugger.IsAttached)
+            int attemptCount = 30;
+            while (!Debugger.IsAttached && attemptCount-- > 0)
             {
-                trace.Info($"Waiting for a debugger to be attached");
+                trace.Info($"Waiting for a debugger to be attached. {attemptCount} seconds left.");
                 await Task.Delay(1000);
+                attemptCount += 1;
             }
             Debugger.Break();
         }

--- a/src/Runner.Worker/Program.cs
+++ b/src/Runner.Worker/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using GitHub.Runner.Common;
@@ -20,7 +20,7 @@ namespace GitHub.Runner.Worker
         public static async Task<int> MainAsync(IHostContext context, string[] args)
         {
             Tracing trace = context.GetTrace(nameof(GitHub.Runner.Worker));
-            if (bool.TryParse(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_ATTACH_DEBUGGER"), out _))
+            if (bool.TryParse(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_ATTACH_DEBUGGER"), out bool waitForDebugger) && waitForDebugger)
             {
                 await WaitForDebugger(trace);
             }

--- a/src/Runner.Worker/Program.cs
+++ b/src/Runner.Worker/Program.cs
@@ -1,9 +1,9 @@
-﻿using GitHub.Runner.Common.Util;
-using System;
+﻿using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using GitHub.Runner.Common;
 using GitHub.Runner.Sdk;
+using System.Diagnostics;
 
 namespace GitHub.Runner.Worker
 {
@@ -19,11 +19,16 @@ namespace GitHub.Runner.Worker
 
         public static async Task<int> MainAsync(IHostContext context, string[] args)
         {
+            Tracing trace = context.GetTrace(nameof(GitHub.Runner.Worker));
+            if (bool.TryParse(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_ATTACH_DEBUGGER"), out _))
+            {
+                await WaitForDebugger(trace);
+            }
+
             // We may want to consider registering this handler in Worker.cs, similiar to the unloading/SIGTERM handler
             //ITerminal registers a CTRL-C handler, which keeps the Runner.Worker process running
             //and lets the Runner.Listener handle gracefully the exit.
             var term = context.GetService<ITerminal>();
-            Tracing trace = context.GetTrace(nameof(GitHub.Runner.Worker));
             try
             {
                 trace.Info($"Version: {BuildConstants.RunnerPackage.Version}");
@@ -63,6 +68,25 @@ namespace GitHub.Runner.Worker
             }
 
             return 1;
+        }
+
+
+
+        /// <summary>
+        /// Runner.Worker is started by Runner.Listener in a separate process,
+        /// so the two can't be debugged in the same session.
+        /// This method halts the Runner.Worker process until a debugger is attached,
+        /// allowing a developer to debug Runner.Worker from start to finish.
+        /// </summary>
+        private static async Task WaitForDebugger(Tracing trace)
+        {
+            trace.Info($"Waiting for a debugger to be attached. Edit the 'GITHUB_ACTIONS_RUNNER_ATTACH_DEBUGGER' environment variable to toggle this feature.");
+            while (!Debugger.IsAttached)
+            {
+                trace.Info($"Waiting for a debugger to be attached");
+                await Task.Delay(1000);
+            }
+            Debugger.Break();
         }
     }
 }

--- a/src/Runner.Worker/Program.cs
+++ b/src/Runner.Worker/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using GitHub.Runner.Common;
@@ -81,10 +81,10 @@ namespace GitHub.Runner.Worker
         private static async Task WaitForDebugger(Tracing trace)
         {
             trace.Info($"Waiting for a debugger to be attached. Edit the 'GITHUB_ACTIONS_RUNNER_ATTACH_DEBUGGER' environment variable to toggle this feature.");
-            int attemptCount = 30;
-            while (!Debugger.IsAttached && attemptCount-- > 0)
+            int waitInSeconds = 20;
+            while (!Debugger.IsAttached && waitInSeconds-- > 0)
             {
-                trace.Info($"Waiting for a debugger to be attached. {attemptCount} seconds left.");
+                trace.Info($"Waiting for a debugger to be attached. {waitInSeconds} seconds left.");
                 await Task.Delay(1000);
             }
             Debugger.Break();

--- a/src/Runner.Worker/Program.cs
+++ b/src/Runner.Worker/Program.cs
@@ -86,7 +86,6 @@ namespace GitHub.Runner.Worker
             {
                 trace.Info($"Waiting for a debugger to be attached. {attemptCount} seconds left.");
                 await Task.Delay(1000);
-                attemptCount += 1;
             }
             Debugger.Break();
         }


### PR DESCRIPTION
This PR stalls the Runner.Worker process until a debugger is connected if `GITHUB_ACTIONS_RUNNER_ATTACH_DEBUGGER` environment variable is set to true.

Related to https://github.com/actions/runner/issues/1023