### PR TITLE
Add SessionCreate so keychain can be used in macos runners

### DIFF
--- a/src/Misc/layoutbin/actions.runner.plist.template
+++ b/src/Misc/layoutbin/actions.runner.plist.template
@@ -13,7 +13,9 @@
     <key>WorkingDirectory</key>
     <string>{{RunnerRoot}}</string>
     <key>RunAtLoad</key>
-    <true/>    
+    <true/>
+    <key>SessionCreate</key>
+    <true/>
     <key>StandardOutPath</key>
     <string>{{UserHome}}/Library/Logs/{{SvcName}}/stdout.log</string>
     <key>StandardErrorPath</key>


### PR DESCRIPTION
When using a self-hosted macos runner with big sur I ran into several errors like the following

```
Failure to decode /[REDACTED PROVISIONING PROFILE]. Exit: 1: security: cert import failed: Write permissions error.
```

I found this similar issue effecting jenkins https://github.com/fastlane/fastlane/issues/9182

I have tested this by adding these changes to my plist, restarting the service and no longer have this issue.

Issues: https://github.com/actions/runner/issues/1056 https://github.com/actions/runner/issues/947 https://github.com/actions/runner/issues/349