### PR TITLE
Self update fix when running under impersonation

### DIFF
--- a/src/Misc/layoutroot/run.cmd
+++ b/src/Misc/layoutroot/run.cmd
@@ -24,10 +24,10 @@ if /i "%~1" equ "localRun" (
   rem ********************************************************************************
   "%~dp0bin\Runner.Listener.exe" run %*
 
-  rem Return code 4 means the run once runner received an update message.
+  rem Return codes 3 and 4 mean the runner received an update message.
   rem Sleep 5 seconds to wait for the update process finish and run the runner again.
-  if ERRORLEVEL 4 (
+  if ERRORLEVEL 3 (
     timeout /t 5 /nobreak > NUL
-    "%~dp0bin\Runner.Listener.exe" run %*
+    "%~dp0run.cmd"
   )
 )

--- a/src/Misc/layoutroot/run.cmd
+++ b/src/Misc/layoutroot/run.cmd
@@ -28,6 +28,6 @@ if /i "%~1" equ "localRun" (
   rem Sleep 5 seconds to wait for the update process finish and run the runner again.
   if ERRORLEVEL 3 (
     timeout /t 5 /nobreak > NUL
-    "%~dp0run.cmd"
+    "%~dp0run.cmd" %*
   )
 )

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -396,7 +396,14 @@ namespace GitHub.Runner.Listener
                                     autoUpdateInProgress = true;
                                     var runnerUpdateMessage = JsonUtility.FromString<AgentRefreshMessage>(message.Body);
                                     var selfUpdater = HostContext.GetService<ISelfUpdater>();
-                                    selfUpdateTask = selfUpdater.SelfUpdate(runnerUpdateMessage, jobDispatcher, !runOnce && HostContext.StartupType != StartupType.Service, HostContext.RunnerShutdownToken);
+
+#if OS_WINDOWS
+                                    var restartInteractiveRunner = false;
+#else
+                                    var restartInteractiveRunner = !runOnce;
+#endif
+
+                                    selfUpdateTask = selfUpdater.SelfUpdate(runnerUpdateMessage, jobDispatcher, restartInteractiveRunner, HostContext.RunnerShutdownToken);
                                     Trace.Info("Refresh message received, kick-off selfupdate background process.");
                                 }
                                 else


### PR DESCRIPTION
Closes #1123 by reusing the existing ephemeral runner update process for static runners. The user profile remains properly loaded since ephemeral runners use the original `run.cmd` script to restart the process rather than starting a new process from the update script.
