### PR TITLE
Run config remove as user instead of root

### DIFF
--- a/docs/automate.md
+++ b/docs/automate.md
@@ -11,7 +11,7 @@ export RUNNER_CFG_PAT=yourPAT
 
 ## Create running as a service
 
-**Scenario**: Run on a machine or VM (not container) which automates:
+**Scenario**: Run on a machine or VM ([not container](#why-cant-i-use-a-container)) which automates:
 
  - Resolving latest released runner
  - Download and extract latest
@@ -26,9 +26,13 @@ Run as a one-liner. NOTE: replace with yourorg/yourrepo (repo level) or just you
 curl -s https://raw.githubusercontent.com/actions/runner/automate/scripts/create-latest-svc.sh | bash -s yourorg/yourrepo
 ```
 
+### Why can't I use a container?
+
+The runner is installed as a service using `systemd` and `systemctl`. Docker does not support `systemd` for service configuration on a container.
+
 ## Uninstall running as service 
 
-**Scenario**: Run on a machine or VM (not container) which automates:
+**Scenario**: Run on a machine or VM ([not container](#why-cant-i-use-a-container)) which automates:
 
  - Stops and uninstalls the systemd (linux) or Launchd (osx) service
  - Acquires a removal token

--- a/scripts/remove-svc.sh
+++ b/scripts/remove-svc.sh
@@ -73,4 +73,4 @@ if [ "${runner_plat}" == "linux" ]; then
 fi 
 ${prefix}./svc.sh stop
 ${prefix}./svc.sh uninstall
-${prefix}./config.sh remove --token $REMOVE_TOKEN
+,/config.sh remove --token $REMOVE_TOKEN

--- a/scripts/remove-svc.sh
+++ b/scripts/remove-svc.sh
@@ -73,4 +73,4 @@ if [ "${runner_plat}" == "linux" ]; then
 fi 
 ${prefix}./svc.sh stop
 ${prefix}./svc.sh uninstall
-,/config.sh remove --token $REMOVE_TOKEN
+./config.sh remove --token $REMOVE_TOKEN


### PR DESCRIPTION
Closes https://github.com/actions/runner/issues/1079

This PR ensures that when `config.sh remove` is called as part of uninstalling the runner as a service on a Linux machine, it is run as the current user instead of `root`. Calling it as `root` fails because the `RUNNER_ALLOW_RUNASROOT` environment variable (which we need to set to `1` in order to run `config.sh` as root) is usually set not set for root. The [issue](https://github.com/actions/runner/issues/1079) does a great job of explaining it.