### PR TITLE
Check if service exists before stopping it (Linux)

### DIFF
--- a/src/Misc/layoutbin/systemd.svc.sh.template
+++ b/src/Misc/layoutbin/systemd.svc.sh.template
@@ -114,7 +114,7 @@ function uninstall()
         echo "Service ${SVC_NAME} is not installed"
     fi    
     if [ -f "${CONFIG_PATH}" ]; then
-        rm "${CONFIG_PATH}" || failed "failed to delete ${CONFIG_PATH}"
+      rm "${CONFIG_PATH}" || failed "failed to delete ${CONFIG_PATH}"
     fi
     systemctl daemon-reload || failed "failed to reload daemons"
 }


### PR DESCRIPTION
Closes #1022 

If the runner was installed as a service but disabled using anything else than `svc.sh uninstall`, running `svc.sh uninstall` now will fail and it never deletes `.service` in the runner's home folder. This in turn prevents users from running `config.sh remove`, because the runner will think it's still configured as a service.

This PR changes `svc.sh uninstall` on Linux so it deletes `.service` even is the service no longer exists.