### PR TITLE
Provide option to specify arguments for container jobs and services

### DIFF
--- a/src/Runner.Worker/Container/ContainerInfo.cs
+++ b/src/Runner.Worker/Container/ContainerInfo.cs
@@ -36,6 +36,7 @@ namespace GitHub.Runner.Worker.Container
             this.ContainerImage = containerImage;
             this.ContainerDisplayName = $"{container.Alias}_{Pipelines.Validation.NameValidation.Sanitize(containerImage)}_{Guid.NewGuid().ToString("N").Substring(0, 6)}";
             this.ContainerCreateOptions = container.Options;
+            this.ContainerEntryPointArgs = string.Join(" ", container.Args);
             _environmentVariables = container.Environment;
             this.IsJobContainer = isJobContainer;
             this.ContainerNetworkAlias = networkAlias;

--- a/src/Sdk/DTPipelines/Pipelines/JobContainer.cs
+++ b/src/Sdk/DTPipelines/Pipelines/JobContainer.cs
@@ -58,6 +58,15 @@ namespace GitHub.DistributedTask.Pipelines
         }
 
         /// <summary>
+        /// Gets or sets the arguments used for the container instance.
+        /// </summary>
+        public IList<String> Args
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets or sets the credentials used for pulling the container iamge.
         /// </summary>
         public ContainerRegistryCredentials Credentials

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
@@ -6,12 +6,13 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
     [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class PipelineTemplateConstants
     {
+        public const String Args = "args";
         public const String Always = "always";
         public const String BooleanStepsContext = "boolean-steps-context";
         public const String BooleanStrategyContext = "boolean-strategy-context";
         public const String CancelTimeoutMinutes = "cancel-timeout-minutes";
         public const String Cancelled = "cancelled";
-        public const String Clean= "clean";
+        public const String Clean = "clean";
         public const String Container = "container";
         public const String ContinueOnError = "continue-on-error";
         public const String Credentials = "credentials";

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -302,6 +302,17 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                         case PipelineTemplateConstants.Credentials:
                             result.Credentials = ConvertToContainerCredentials(containerPropertyPair.Value);
                             break;
+                        case PipelineTemplateConstants.Args:
+                            var args = containerPropertyPair.Value.AssertSequence($"{PipelineTemplateConstants.Container} {propertyName}");
+                            var argList = new List<String>(args.Count);
+                            foreach (var argItem in args)
+                            {
+                                var argString = argItem.AssertString($"{PipelineTemplateConstants.Container} {propertyName} {argItem.ToString()}").Value;
+                                argList.Add(argString);
+                            }
+                            result.Args = argList;
+                            break;
+
                         default:
                             propertyName.AssertUnexpectedValue($"{PipelineTemplateConstants.Container} key");
                             break;


### PR DESCRIPTION
When specifying service containers for a jobs, sometimes it is necessary to add command line arguments to the container. See this example: https://github.community/t/how-do-i-properly-override-a-service-entrypoint/17435. Here it is useful to add `--listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://0.0.0.0:2379` to the container start command line. 

These arguments are simply passed after the image name on the `docker create` command line.

Here is another example of trying to add command line arguments to postgres: https://stackoverflow.com/questions/65438055/how-to-add-config-args-to-postgres-service-container-in-github-action

The `options` field cam be used to change the entrypoint of a container, but it is not possible to change the arguments.

Please let me know what else is required to make this mergable, thank you.