### PR TITLE
Fix typo in `docs/checks/sslcert.md`

### DIFF
--- a/docs/checks/sslcert.md
+++ b/docs/checks/sslcert.md
@@ -44,7 +44,7 @@ To let the runner trusts your CA certificate, you will need to:
       2. Ubuntu: http://manpages.ubuntu.com/manpages/focal/man8/update-ca-certificates.8.html
       3. Google search: "trust ca certificate on [linux distribution]"
       4. If all approaches failed, set environment variable `SSL_CERT_FILE` to the CA bundle `.pem` file we get. 
-    > To verity cert gets installed properly on Linux, you can try use `curl -v https://sitewithsslissue.com` and `pwsh -Command \"Invoke-WebRequest -Uri https://sitewithsslissue.com\"`
+    > To verify cert gets installed properly on Linux, you can try use `curl -v https://sitewithsslissue.com` and `pwsh -Command \"Invoke-WebRequest -Uri https://sitewithsslissue.com\"`
 
 ### Trust CA certificate for Git CLI
 


### PR DESCRIPTION
I think `verity` is typo of `verify`