### PR TITLE
Add notice annotation level and support more annotation fields

### DIFF
--- a/src/Runner.Common/ExtensionManager.cs
+++ b/src/Runner.Common/ExtensionManager.cs
@@ -51,6 +51,7 @@ namespace GitHub.Runner.Common
                     Add<T>(extensions, "GitHub.Runner.Worker.RemoveMatcherCommandExtension, Runner.Worker");
                     Add<T>(extensions, "GitHub.Runner.Worker.WarningCommandExtension, Runner.Worker");
                     Add<T>(extensions, "GitHub.Runner.Worker.ErrorCommandExtension, Runner.Worker");
+                    Add<T>(extensions, "GitHub.Runner.Worker.NoticeCommandExtension, Runner.Worker");
                     Add<T>(extensions, "GitHub.Runner.Worker.DebugCommandExtension, Runner.Worker");
                     Add<T>(extensions, "GitHub.Runner.Worker.GroupCommandExtension, Runner.Worker");
                     Add<T>(extensions, "GitHub.Runner.Worker.EndGroupCommandExtension, Runner.Worker");

--- a/src/Runner.Common/JobServerQueue.cs
+++ b/src/Runner.Common/JobServerQueue.cs
@@ -544,6 +544,11 @@ namespace GitHub.Runner.Common
                         timelineRecord.WarningCount = rec.WarningCount;
                     }
 
+                    if (rec.NoticeCount != null && rec.NoticeCount > 0)
+                    {
+                        timelineRecord.NoticeCount = rec.NoticeCount;
+                    }
+
                     if (rec.Issues.Count > 0)
                     {
                         timelineRecord.Issues.Clear();

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -598,8 +598,6 @@ namespace GitHub.Runner.Worker
             var hasLine = line != null;
             var hasEndLine = endLine != null;
 
-            Console.WriteLine($"hasColumnValue: {hasColumnValue}, hasLine: {hasLine}");
-
             if (!hasLine && hasColumnValue) 
             {
                 throw new Exception($"Invalid {command.Command} command value. 'column' and 'end_column' can only be set if 'line' value is provided."); 

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -537,7 +537,6 @@ namespace GitHub.Runner.Worker
             {
                 context.Debug("Enhanced Annotations not enabled on the server. The 'title', 'end_line', and 'end_column' fields are unsupported.");
             }
-
             
             Issue issue = new Issue()
             {

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -609,37 +609,37 @@ namespace GitHub.Runner.Worker
 
             if (hasEndLine && !hasStartLine)
             {
-                context.Debug($"Invalid {command.Command} command value. 'end_line' can only be set if 'line' is provided");
+                context.Debug($"Invalid {command.Command} command value. '{IssueCommandProperties.EndLine}' can only be set if '{IssueCommandProperties.Line}' is provided");
                 return false;
             }
 
             if (hasEndColumn && !hasStartColumn)
             {
-                context.Debug($"Invalid {command.Command} command value. 'end_column' can only be set if 'col' is provided");
+                context.Debug($"Invalid {command.Command} command value. '{IssueCommandProperties.EndColumn}' can only be set if '{IssueCommandProperties.Column}' is provided");
                 return false;
             }
 
             if (!hasStartLine && hasColumn) 
             {
-                context.Debug($"Invalid {command.Command} command value. 'column' and 'end_column' can only be set if 'line' value is provided.");
+                context.Debug($"Invalid {command.Command} command value. '{IssueCommandProperties.Column}' and '{IssueCommandProperties.EndColumn}' can only be set if '{IssueCommandProperties.Line}' value is provided.");
                 return false;
             }
 
             if (hasEndLine && line != endLine && hasColumn) 
             {
-                context.Debug($"Invalid {command.Command} command value. 'column' and 'end_column' cannot be set if 'line' and 'end line' are different values.");
+                context.Debug($"Invalid {command.Command} command value. '{IssueCommandProperties.Column}' and '{IssueCommandProperties.EndColumn}' cannot be set if '{IssueCommandProperties.Line}' and '{IssueCommandProperties.EndLine}' are different values.");
                 return false;
             }
 
             if (hasStartLine && hasEndLine && endLineNumber < lineNumber) 
             {
-                context.Debug($"Invalid {command.Command} command value. 'end_line' cannot be less than 'line'.");
+                context.Debug($"Invalid {command.Command} command value. '{IssueCommandProperties.EndLine}' cannot be less than '{IssueCommandProperties.Line}'.");
                 return false; 
             }
 
             if (hasStartColumn && hasEndColumn && endColumnNumber < columnNumber) 
             {
-                context.Debug($"Invalid {command.Command} command value. 'end_column' cannot be less than 'col'.");
+                context.Debug($"Invalid {command.Command} command value. '{IssueCommandProperties.EndColumn}' cannot be less than '{IssueCommandProperties.Column}'.");
                 return false; 
             }
 
@@ -650,9 +650,9 @@ namespace GitHub.Runner.Worker
         {
             public const String File = "file";
             public const String Line = "line";
-            public const String EndLine = "end_line";
+            public const String EndLine = "endLine";
             public const String Column = "col";
-            public const String EndColumn = "end_column";
+            public const String EndColumn = "endColumn";
             public const String Title = "title";
         }
 

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -596,20 +596,20 @@ namespace GitHub.Runner.Worker
             command.Properties.TryGetValue(IssueCommandProperties.Column, out string column);
             command.Properties.TryGetValue(IssueCommandProperties.EndColumn, out string endColumn);
 
-            var hasStartLine = !String.IsNullOrWhiteSpace(line);
-            var hasEndLine = !String.IsNullOrWhiteSpace(endLine);
-            var hasStartColumn = !String.IsNullOrWhiteSpace(column);
-            var hasEndColumn =  !String.IsNullOrWhiteSpace(endColumn);
+            var hasStartLine = int.TryParse(line, out int lineNumber);
+            var hasEndLine = int.TryParse(endLine, out int endLineNumber);
+            var hasStartColumn = int.TryParse(column, out int columnNumber);
+            var hasEndColumn = int.TryParse(endColumn, out int endColumnNumber);
             var hasColumn = hasStartColumn || hasEndColumn;
 
             if (hasEndLine && !hasStartLine)
             {
-                throw new Exception($"Invalid {command.Command} command value. 'end_line' can only be set of 'line' is provided");
+                throw new Exception($"Invalid {command.Command} command value. 'end_line' can only be set if 'line' is provided");
             }
 
             if (hasEndColumn && !hasStartColumn)
             {
-                throw new Exception($"Invalid {command.Command} command value. 'end_column' can only be set of 'col' is provided");
+                throw new Exception($"Invalid {command.Command} command value. 'end_column' can only be set if 'col' is provided");
             }
 
             if (!hasStartLine && hasColumn) 
@@ -621,6 +621,16 @@ namespace GitHub.Runner.Worker
             {
                 throw new Exception($"Invalid {command.Command} command value. 'column' and 'end_column' cannot be set if 'line' and 'end line' are different values."); 
             }
+
+            if (hasStartLine && hasEndLine && endLineNumber < lineNumber) 
+            {
+                throw new Exception($"Invalid {command.Command} command value. 'end_line' cannot be less than 'line'."); 
+            }
+
+            if (hasStartColumn && hasEndColumn && endColumnNumber < columnNumber) 
+            {
+                throw new Exception($"Invalid {command.Command} command value. 'end_column' cannot be less than 'col'."); 
+            }    
         }
 
         private static class IssueCommandProperties

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -498,6 +498,13 @@ namespace GitHub.Runner.Worker
         public override string Command => "error";
     }
 
+    public sealed class NoticeCommandExtension : IssueCommandExtension
+    {
+        public override IssueType Type => IssueType.Notice;
+
+        public override string Command => "notice";
+    }
+
     public abstract class IssueCommandExtension : RunnerService, IActionCommandExtension
     {
         public abstract IssueType Type { get; }
@@ -567,7 +574,10 @@ namespace GitHub.Runner.Worker
         {
             public const String File = "file";
             public const String Line = "line";
+            public const String EndLine = "end_line";
             public const String Column = "col";
+            public const String EndColumn = "end_column";
+            public const String Title = "title";
         }
 
     }

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -596,10 +596,10 @@ namespace GitHub.Runner.Worker
             command.Properties.TryGetValue(IssueCommandProperties.Column, out string column);
             command.Properties.TryGetValue(IssueCommandProperties.EndColumn, out string endColumn);
 
-            var hasStartLine = line != null;
-            var hasEndLine = endLine != null;
-            var hasStartColumn = column != null;
-            var hasEndColumn =  endColumn != null;
+            var hasStartLine = !String.IsNullOrWhiteSpace(line);
+            var hasEndLine = !String.IsNullOrWhiteSpace(endLine);
+            var hasStartColumn = !String.IsNullOrWhiteSpace(column);
+            var hasEndColumn =  !String.IsNullOrWhiteSpace(endColumn);
             var hasColumn = hasStartColumn || hasEndColumn;
 
             if (hasEndLine && !hasStartLine)

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -655,7 +655,6 @@ namespace GitHub.Runner.Worker
             public const String EndColumn = "endColumn";
             public const String Title = "title";
         }
-
     }
 
     public sealed class GroupCommandExtension : GroupingCommandExtension

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -75,6 +75,11 @@ namespace GitHub.Runner.Worker
                 return false;
             }
 
+            if (!ActionCommandManager.EnhancedAnnotationsEnabled(context) && actionCommand.Command == "notice")
+            {
+                return false;
+            }
+
             // Serialize order
             lock (_commandSerializeLock)
             {
@@ -140,6 +145,10 @@ namespace GitHub.Runner.Worker
             }
 
             return true;
+        }
+
+        internal static bool EnhancedAnnotationsEnabled(IExecutionContext context) {
+            return context.Global.Variables.GetBoolean("DistributedTask.EnhancedAnnotations") ?? false;
         }
     }
 
@@ -565,6 +574,13 @@ namespace GitHub.Runner.Worker
                 {
                     issue.Data[property.Key] = property.Value;
                 }
+            }
+
+            if (!ActionCommandManager.EnhancedAnnotationsEnabled(context)) 
+            {
+                issue.Data.Remove(IssueCommandProperties.EndLine);
+                issue.Data.Remove(IssueCommandProperties.EndColumn);
+                issue.Data.Remove(IssueCommandProperties.Title);
             }
 
             context.AddIssue(issue);

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -516,6 +516,17 @@ namespace GitHub.Runner.Worker
                 }
 
                 _record.WarningCount++;
+            } else if (issue.Type == IssueType.Notice) {
+
+                // tracking line number for each issue in log file
+                // log UI use this to navigate from issue to log
+                if (!string.IsNullOrEmpty(logMessage))
+                {
+                    long logLineNumber = Write(ConsoleColor.White, logMessage);
+                    issue.Data["logFileLineNumber"] = logLineNumber.ToString();
+                }
+
+                _record.Issues.Add(issue);
             }
 
             _jobServerQueue.QueueTimelineRecordUpdate(_mainTimelineId, _record);

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -106,7 +106,6 @@ namespace GitHub.Runner.Worker
     {
         private const int _maxIssueCount = 10;
         private const int _throttlingDelayReportThreshold = 10 * 1000; // Don't report throttling with less than 10 seconds delay
-        private const string _noticeLogPrefix = "\u001b[31m"; //white text
 
         private readonly TimelineRecord _record = new TimelineRecord();
         private readonly Dictionary<Guid, TimelineRecord> _detailRecords = new Dictionary<Guid, TimelineRecord>();
@@ -525,7 +524,7 @@ namespace GitHub.Runner.Worker
                 // log UI use this to navigate from issue to log
                 if (!string.IsNullOrEmpty(logMessage))
                 {
-                    long logLineNumber = Write(_noticeLogPrefix, logMessage);
+                    long logLineNumber = Write(WellKnownTags.Notice, logMessage);
                     issue.Data["logFileLineNumber"] = logLineNumber.ToString();
                 }
 
@@ -1032,6 +1031,7 @@ namespace GitHub.Runner.Worker
         public static readonly string Command = "##[command]";
         public static readonly string Error = "##[error]";
         public static readonly string Warning = "##[warning]";
+        public static readonly string Notice = "##[notice]";
         public static readonly string Debug = "##[debug]";
     }
 }

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -517,7 +517,8 @@ namespace GitHub.Runner.Worker
                 }
 
                 _record.WarningCount++;
-            } else if (issue.Type == IssueType.Notice) 
+            } 
+            else if (issue.Type == IssueType.Notice) 
             {
 
                 // tracking line number for each issue in log file

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -106,6 +106,7 @@ namespace GitHub.Runner.Worker
     {
         private const int _maxIssueCount = 10;
         private const int _throttlingDelayReportThreshold = 10 * 1000; // Don't report throttling with less than 10 seconds delay
+        private const string _noticeLogPrefix = "\u001b[31m"; //white text
 
         private readonly TimelineRecord _record = new TimelineRecord();
         private readonly Dictionary<Guid, TimelineRecord> _detailRecords = new Dictionary<Guid, TimelineRecord>();
@@ -516,17 +517,23 @@ namespace GitHub.Runner.Worker
                 }
 
                 _record.WarningCount++;
-            } else if (issue.Type == IssueType.Notice) {
+            } else if (issue.Type == IssueType.Notice) 
+            {
 
                 // tracking line number for each issue in log file
                 // log UI use this to navigate from issue to log
                 if (!string.IsNullOrEmpty(logMessage))
                 {
-                    long logLineNumber = Write(ConsoleColor.White, logMessage);
+                    long logLineNumber = Write(_noticeLogPrefix, logMessage);
                     issue.Data["logFileLineNumber"] = logLineNumber.ToString();
                 }
 
-                _record.Issues.Add(issue);
+                if (_record.NoticeCount < _maxIssueCount)
+                {
+                    _record.Issues.Add(issue);
+                }
+
+                _record.NoticeCount++;
             }
 
             _jobServerQueue.QueueTimelineRecordUpdate(_mainTimelineId, _record);
@@ -852,6 +859,7 @@ namespace GitHub.Runner.Worker
             _record.State = TimelineRecordState.Pending;
             _record.ErrorCount = 0;
             _record.WarningCount = 0;
+            _record.NoticeCount = 0;
 
             if (parentTimelineRecordId != null && parentTimelineRecordId.Value != Guid.Empty)
             {

--- a/src/Runner.Worker/Handlers/OutputManager.cs
+++ b/src/Runner.Worker/Handlers/OutputManager.cs
@@ -210,6 +210,10 @@ namespace GitHub.Runner.Worker.Handlers
             {
                 issueType = DTWebApi.IssueType.Warning;
             }
+            else if (string.Equals(match.Severity, "notice", StringComparison.OrdinalIgnoreCase))
+            {
+                issueType = DTWebApi.IssueType.Notice;
+            }
             else
             {
                 _executionContext.Debug($"Skipped logging an issue for the matched line because the severity '{match.Severity}' is not supported.");

--- a/src/Sdk/DTWebApi/WebApi/IssueType.cs
+++ b/src/Sdk/DTWebApi/WebApi/IssueType.cs
@@ -9,6 +9,9 @@ namespace GitHub.DistributedTask.WebApi
         Error = 1,
 
         [EnumMember]
-        Warning = 2
+        Warning = 2,
+
+        [EnumMember]
+        Notice = 3
     }
 }

--- a/src/Sdk/DTWebApi/WebApi/TimelineRecord.cs
+++ b/src/Sdk/DTWebApi/WebApi/TimelineRecord.cs
@@ -38,6 +38,7 @@ namespace GitHub.DistributedTask.WebApi
             this.RefName = recordToBeCloned.RefName;
             this.ErrorCount = recordToBeCloned.ErrorCount;
             this.WarningCount = recordToBeCloned.WarningCount;
+            this.NoticeCount = recordToBeCloned.NoticeCount;
             this.AgentPlatform = recordToBeCloned.AgentPlatform;
 
             if (recordToBeCloned.Log != null)
@@ -217,6 +218,13 @@ namespace GitHub.DistributedTask.WebApi
 
         [DataMember(Order = 50)]
         public Int32? WarningCount
+        {
+            get;
+            set;
+        }
+
+        [DataMember(Order = 60)]
+        public Int32? NoticeCount
         {
             get;
             set;

--- a/src/Sdk/DTWebApi/WebApi/TimelineRecord.cs
+++ b/src/Sdk/DTWebApi/WebApi/TimelineRecord.cs
@@ -223,7 +223,7 @@ namespace GitHub.DistributedTask.WebApi
             set;
         }
 
-        [DataMember(Order = 60)]
+        [DataMember(Order = 55)]
         public Int32? NoticeCount
         {
             get;

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -36,7 +36,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                    {
                        hc.GetTrace().Info($"{issue.Type} {issue.Message} {message ?? string.Empty}");
                    });
-
+                
                 _commandManager.EnablePluginInternalCommand();
 
                 Assert.True(_commandManager.TryProcessCommand(_ec.Object, "##[internal-set-repo-path repoFullName=actions/runner;workspaceRepo=true]somepath", null));
@@ -175,7 +175,6 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var ec = new Runner.Worker.ExecutionContext();
                 ec.Initialize(hc);
                 ec.InitializeJob(jobRequest, System.Threading.CancellationToken.None);
-
                 ec.Complete();
 
                 Assert.True(ec.EchoOnActionCommand);
@@ -285,6 +284,10 @@ namespace GitHub.Runner.Common.Tests.Worker
             _ec = new Mock<IExecutionContext>();
             _ec.SetupAllProperties();
             _ec.Setup(x => x.Global).Returns(new GlobalContext());
+            _ec.Object.Global.Variables = new Variables(
+                hostContext,
+                new Dictionary<string, VariableValue>()
+            );
 
             // Command manager
             _commandManager = new ActionCommandManager();

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -207,39 +207,62 @@ namespace GitHub.Runner.Common.Tests.Worker
                 
                 // Columns when lines are different
                 ActionCommand.TryParseV2("::warning line=1,endLine=2,col=1,endColumn=2::this is a warning", registeredCommands, out command);
-                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
+                Assert.Equal("1", command.Properties["col"]);
+                IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object);
+                Assert.False(command.Properties.ContainsKey("col"));
             
                 // No lines with columns
                 ActionCommand.TryParseV2("::warning col=1,endColumn=2::this is a warning", registeredCommands, out command);
-                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
+                Assert.Equal("1", command.Properties["col"]);
+                Assert.Equal("2", command.Properties["endColumn"]);
+                IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object);
+                Assert.False(command.Properties.ContainsKey("col"));
+                Assert.False(command.Properties.ContainsKey("endColumn"));
 
                 // No line with endLine
                 ActionCommand.TryParseV2("::warning endLine=1::this is a warning", registeredCommands, out command);
-                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
+                Assert.Equal("1", command.Properties["endLine"]);
+                IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object);
+                Assert.Equal(command.Properties["endLine"], command.Properties["line"]);
 
                 // No column with endColumn
-                ActionCommand.TryParseV2("::warning endColumn=2::this is a warning", registeredCommands, out command);
-                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
+                ActionCommand.TryParseV2("::warning line=1,endColumn=2::this is a warning", registeredCommands, out command);
+                Assert.Equal("2", command.Properties["endColumn"]);
+                IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object);
+                Assert.Equal(command.Properties["endColumn"], command.Properties["col"]);
 
                 // Empty Strings
                 ActionCommand.TryParseV2("::warning line=,endLine=3::this is a warning", registeredCommands, out command);
-                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
+                IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object);
+                Assert.Equal(command.Properties["line"], command.Properties["endLine"]);
 
                 // Nonsensical line values
                 ActionCommand.TryParseV2("::warning line=4,endLine=3::this is a warning", registeredCommands, out command);
-                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
+                IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object);
+                Assert.False(command.Properties.ContainsKey("line"));
+                Assert.False(command.Properties.ContainsKey("endLine"));
 
                 /// Nonsensical column values
                 ActionCommand.TryParseV2("::warning line=1,endLine=1,col=3,endColumn=2::this is a warning", registeredCommands, out command);
-                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
+                IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object);
+                Assert.False(command.Properties.ContainsKey("col"));
+                Assert.False(command.Properties.ContainsKey("endColumn"));
 
                 // Valid
                 ActionCommand.TryParseV2("::warning line=1,endLine=1,col=1,endColumn=2::this is a warning", registeredCommands, out command);
-                Assert.True(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
+                IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object);
+                Assert.Equal("1", command.Properties["line"]);
+                Assert.Equal("1", command.Properties["endLine"]);
+                Assert.Equal("1", command.Properties["col"]);
+                Assert.Equal("2", command.Properties["endColumn"]);
 
                 // Backwards compatibility
                 ActionCommand.TryParseV2("::warning line=1,col=1,file=test.txt::this is a warning", registeredCommands, out command);
-                Assert.True(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
+                IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object);
+                Assert.Equal("1", command.Properties["line"]);
+                Assert.False(command.Properties.ContainsKey("endLine"));
+                Assert.Equal("1", command.Properties["col"]);
+                Assert.False(command.Properties.ContainsKey("endColumn"));
             }
         }
 

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -206,34 +206,36 @@ namespace GitHub.Runner.Common.Tests.Worker
                 ActionCommand command;
                 
                 ActionCommand.TryParseV2("::warning line=1,end_line=2,col=1,end_column=2::this is a warning", registeredCommands, out command);
-                Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
+                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
             
                 // No lines with columns
                 ActionCommand.TryParseV2("::warning col=1,end_column=2::this is a warning", registeredCommands, out command);
-                Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
+                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
                 // No line with endLine
                 ActionCommand.TryParseV2("::warning end_line=1::this is a warning", registeredCommands, out command);
-                Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
+                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
                 // No column with end_column
                 ActionCommand.TryParseV2("::warning end_column=2::this is a warning", registeredCommands, out command);
-                Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
+                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
                 // Empty Strings
                 ActionCommand.TryParseV2("::warning line=,end_line=3::this is a warning", registeredCommands, out command);
-                Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
+                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
                 // Nonsensical line values
                 ActionCommand.TryParseV2("::warning line=4,end_line=3::this is a warning", registeredCommands, out command);
-                Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
+                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
                 /// Nonsensical column values
                 ActionCommand.TryParseV2("::warning line=1,end_line=1,col=3,end_column=2::this is a warning", registeredCommands, out command);
-                Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
+                Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
                 // Valid
                 ActionCommand.TryParseV2("::warning line=1,end_line=1,col=1,end_column=2::this is a warning", registeredCommands, out command);
+                Assert.True(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
+
             }
         }
 

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -216,9 +216,12 @@ namespace GitHub.Runner.Common.Tests.Worker
                 ActionCommand.TryParseV2("::warning end_line=1::this is a warning", registeredCommands, out command);
                 Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
 
-
                 // No column with end_column
                 ActionCommand.TryParseV2("::warning end_column=2::this is a warning", registeredCommands, out command);
+                Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
+
+                // Empty Strings
+                ActionCommand.TryParseV2("::warning line=,end_line=3::this is a warning", registeredCommands, out command);
                 Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
 
                 // Valid

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -205,37 +205,41 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var registeredCommands = new HashSet<string>(new string[1]{ "warning" });
                 ActionCommand command;
                 
-                ActionCommand.TryParseV2("::warning line=1,end_line=2,col=1,end_column=2::this is a warning", registeredCommands, out command);
+                // Columns when lines are different
+                ActionCommand.TryParseV2("::warning line=1,endLine=2,col=1,endColumn=2::this is a warning", registeredCommands, out command);
                 Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
             
                 // No lines with columns
-                ActionCommand.TryParseV2("::warning col=1,end_column=2::this is a warning", registeredCommands, out command);
+                ActionCommand.TryParseV2("::warning col=1,endColumn=2::this is a warning", registeredCommands, out command);
                 Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
                 // No line with endLine
-                ActionCommand.TryParseV2("::warning end_line=1::this is a warning", registeredCommands, out command);
+                ActionCommand.TryParseV2("::warning endLine=1::this is a warning", registeredCommands, out command);
                 Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
-                // No column with end_column
-                ActionCommand.TryParseV2("::warning end_column=2::this is a warning", registeredCommands, out command);
+                // No column with endColumn
+                ActionCommand.TryParseV2("::warning endColumn=2::this is a warning", registeredCommands, out command);
                 Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
                 // Empty Strings
-                ActionCommand.TryParseV2("::warning line=,end_line=3::this is a warning", registeredCommands, out command);
+                ActionCommand.TryParseV2("::warning line=,endLine=3::this is a warning", registeredCommands, out command);
                 Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
                 // Nonsensical line values
-                ActionCommand.TryParseV2("::warning line=4,end_line=3::this is a warning", registeredCommands, out command);
+                ActionCommand.TryParseV2("::warning line=4,endLine=3::this is a warning", registeredCommands, out command);
                 Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
                 /// Nonsensical column values
-                ActionCommand.TryParseV2("::warning line=1,end_line=1,col=3,end_column=2::this is a warning", registeredCommands, out command);
+                ActionCommand.TryParseV2("::warning line=1,endLine=1,col=3,endColumn=2::this is a warning", registeredCommands, out command);
                 Assert.False(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
                 // Valid
-                ActionCommand.TryParseV2("::warning line=1,end_line=1,col=1,end_column=2::this is a warning", registeredCommands, out command);
+                ActionCommand.TryParseV2("::warning line=1,endLine=1,col=1,endColumn=2::this is a warning", registeredCommands, out command);
                 Assert.True(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
 
+                // Backwards compatibility
+                ActionCommand.TryParseV2("::warning line=1,col=1,file=test.txt::this is a warning", registeredCommands, out command);
+                Assert.True(IssueCommandExtension.ValidateLinesAndColumns(command, _ec.Object));
             }
         }
 

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -224,6 +224,14 @@ namespace GitHub.Runner.Common.Tests.Worker
                 ActionCommand.TryParseV2("::warning line=,end_line=3::this is a warning", registeredCommands, out command);
                 Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
 
+                // Nonsensical line values
+                ActionCommand.TryParseV2("::warning line=4,end_line=3::this is a warning", registeredCommands, out command);
+                Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
+
+                /// Nonsensical column values
+                ActionCommand.TryParseV2("::warning line=1,end_line=1,col=3,end_column=2::this is a warning", registeredCommands, out command);
+                Assert.Throws<Exception>(() => IssueCommandExtension.ValidateLinesAndColumns(command));
+
                 // Valid
                 ActionCommand.TryParseV2("::warning line=1,end_line=1,col=1,end_column=2::this is a warning", registeredCommands, out command);
             }

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -175,6 +175,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var ec = new Runner.Worker.ExecutionContext();
                 ec.Initialize(hc);
                 ec.InitializeJob(jobRequest, System.Threading.CancellationToken.None);
+
                 ec.Complete();
 
                 Assert.True(ec.EchoOnActionCommand);


### PR DESCRIPTION
This PR does the following:

* Creates a new `notice` command to map to the `notice` annotation level. 
* Adds support for `title`, `endColumn`, `endLine`