### PR TITLE
fix: Do not merge missing default value into Action inputs

### DIFF
--- a/src/Runner.Worker/ActionManifestManager.cs
+++ b/src/Runner.Worker/ActionManifestManager.cs
@@ -532,7 +532,7 @@ namespace GitHub.Runner.Worker
 
                 if (!hasDefault)
                 {
-                    actionDefinition.Inputs.Add(inputName, new StringToken(null, null, null, string.Empty));
+                    actionDefinition.Inputs.Add(inputName, new NullToken(null, null, null));
                 }
             }
         }

--- a/src/Runner.Worker/ActionRunner.cs
+++ b/src/Runner.Worker/ActionRunner.cs
@@ -194,7 +194,7 @@ namespace GitHub.Runner.Worker
                 {
                     string key = input.Key.AssertString("action input name").Value;
                     validInputs.Add(key);
-                    if (!inputs.ContainsKey(key))
+                    if (!inputs.ContainsKey(key) && !(input.Value is NullToken))
                     {
                         inputs[key] = manifestManager.EvaluateDefaultInput(ExecutionContext, key, input.Value);
                     }

--- a/src/Test/L0/Worker/ActionManifestManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManifestManagerL0.cs
@@ -45,7 +45,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
 
                 Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
@@ -89,7 +89,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
 
                 Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
@@ -135,7 +135,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
 
                 Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
@@ -181,7 +181,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
 
                 Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
@@ -227,7 +227,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
 
                 Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
@@ -272,7 +272,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
 
                 Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
@@ -310,7 +310,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
 
                 Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
@@ -353,7 +353,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
 
                 Assert.Equal(ActionExecutionType.Container, result.Execution.ExecutionType);
 
@@ -396,7 +396,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
                 Assert.Equal(1, result.Deprecated.Count);
 
                 Assert.True(result.Deprecated.ContainsKey("greeting"));
@@ -438,7 +438,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
                 Assert.Equal(1, result.Deprecated.Count);
 
                 Assert.True(result.Deprecated.ContainsKey("greeting"));
@@ -482,7 +482,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
                 Assert.Equal(1, result.Deprecated.Count);
 
                 Assert.True(result.Deprecated.ContainsKey("greeting"));
@@ -526,7 +526,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                //Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
                 Assert.Equal(1, result.Deprecated.Count);
 
                 Assert.True(result.Deprecated.ContainsKey("greeting"));
@@ -570,7 +570,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
                 Assert.Equal(1, result.Deprecated.Count);
 
                 Assert.True(result.Deprecated.ContainsKey("greeting"));
@@ -614,7 +614,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("greeting", result.Inputs[0].Key.AssertString("key").Value);
                 Assert.Equal("Hello", result.Inputs[0].Value.AssertString("value").Value);
                 Assert.Equal("entryPoint", result.Inputs[1].Key.AssertString("key").Value);
-                Assert.Equal("", result.Inputs[1].Value.AssertString("value").Value);
+                Assert.Equal("", result.Inputs[1].Value.AssertNull("value").ToString());
 
                 Assert.Equal(ActionExecutionType.Plugin, result.Execution.ExecutionType);
 


### PR DESCRIPTION
Closes #924 

At present, an Input without a default value is given a default value of an empty string, meaning there's no way for Action authors to differentiate between "no value was provided" and "an empty string was provided". As described in #924, this introduces a number of challenges for Action authors and has been acknowledged as a (low priority) bug.

The change in this Pull Request is very simple: do not set a default string value when no default is provided -- using a `NullToken` instead of a `StringToken`. As a consequence, the `INPUT_*` environment variables will now only contain a value when an input _or default_ is provided.

## Backwards Compatibility

The GitHub Actions toolkit package `core` provides a `getInput` method which checks for the presence of the environment variable and uses a default empty string if the environment variable is not found, therefore this change would not break the behaviour of the toolkit. However, it _would_ enable the introduction of `hasInput` as described in my Pull Request [feat: Check if action run hasInput #849](https://github.com/actions/toolkit/pull/849).

```ts
const val: string = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || ''
```
https://github.com/actions/toolkit/blob/45647689407e7fb224e06d066dde6aefa67a365f/packages/core/src/core.ts#L80-L101

I've performed various tests of this against my own actions (like [actions-assert](https://github.com/pr-mpt/actions-assert)) and experienced no issues, so I'm fairly confident in saying it works without issue.

## Previously

### `action.yml`

```yaml
inputs:
  example:
    description: "Example of an optional input with no default"
```

```yaml
- uses: ./
- run: printenv INPUT_EXAMPLE
```

```console
$ printenv INPUT_EXAMPLE
''
```

## With this change

### `action.yml`

```yaml
inputs:
  example:
    description: "Example of an optional input with no default"
```

```yaml
- uses: ./
- run: printenv INPUT_EXAMPLE
```

```console
$ printenv INPUT_EXAMPLE

```