### PR TITLE
Update error to say 'uninstall' not 'unconfigure'

### DIFF
--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -351,7 +351,7 @@ namespace GitHub.Runner.Listener.Configuration
                     throw new Exception("Unconfigure service first");
 #elif OS_OSX
                     // unconfig osx service first
-                    throw new Exception("Unconfigure service first");
+                    throw new Exception("Uninstall service first");
 #endif
                 }
 

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -346,11 +346,8 @@ namespace GitHub.Runner.Listener.Configuration
 
                     _term.WriteLine();
                     _term.WriteSuccessMessage("Runner service removed");
-#elif OS_LINUX
-                    // unconfig system D service first
-                    throw new Exception("Unconfigure service first");
-#elif OS_OSX
-                    // unconfig osx service first
+#else
+                    // unconfig systemd or osx service first
                     throw new Exception("Uninstall service first");
 #endif
                 }


### PR DESCRIPTION
When attempting to `unconfigure` a runner via `./config.sh remove` on an installed OSX service, the error currently reads `Unconfigure service first` (which is what removing the config technically is doing) but the user must run `./svc.sh uninstall` to uninstall the service before unconfiguring it.  It's petty but the exception is unclear and a bit misleading, so update it to reflect the current action that must be taken before actually removing the configuration.