### PR TITLE
Added env to fix execution errors

### DIFF
--- a/src/Misc/layoutbin/actions.runner.service.template
+++ b/src/Misc/layoutbin/actions.runner.service.template
@@ -3,7 +3,7 @@ Description={{Description}}
 After=network.target
 
 [Service]
-ExecStart={{RunnerRoot}}/runsvc.sh
+ExecStart=/usr/bin/env bash {{RunnerRoot}}/runsvc.sh
 User={{User}}
 WorkingDirectory={{RunnerRoot}}
 KillMode=process


### PR DESCRIPTION
When we run the runner as service the following error is getting generated since svc.sh is not executable. Using `/usr/bin/env bash` will make it working and it will also work across all the linux distros. 
https://man7.org/linux/man-pages/man1/env.1.html

**Before:**
![Screenshot 2021-07-04 at 4 46 01 PM](https://user-images.githubusercontent.com/8397274/124382955-9d53c100-dce7-11eb-8649-b68ca5163425.png)

**After:**
![Screenshot 2021-07-04 at 4 49 23 PM](https://user-images.githubusercontent.com/8397274/124382995-d429d700-dce7-11eb-857f-d3608380e596.png)
