### PR TITLE
Better error message when a command is not found

### DIFF
--- a/src/Runner.Sdk/Util/WhichUtil.cs
+++ b/src/Runner.Sdk/Util/WhichUtil.cs
@@ -116,9 +116,9 @@ namespace GitHub.Runner.Sdk
             }
 
 #if OS_WINDOWS
-            trace?.Info($"{command}: command not found. Make sure '{command}' is installed and the path to the executable is included in the 'Path' environment variable.");
+            trace?.Info($"{command}: command not found. Make sure '{command}' is installed and its location included in the 'Path' environment variable.");
 #else
-            trace?.Info($"{command}: command not found. Make sure '{command}' is installed and included in the PATH environment variable.");
+            trace?.Info($"{command}: command not found. Make sure '{command}' is installed and its location included in the 'PATH' environment variable.");
 #endif
             if (require)
             {

--- a/src/Runner.Sdk/Util/WhichUtil.cs
+++ b/src/Runner.Sdk/Util/WhichUtil.cs
@@ -115,11 +115,15 @@ namespace GitHub.Runner.Sdk
                 }
             }
 
-            trace?.Info("Not found.");
+#if OS_WINDOWS
+            trace?.Info($"{command}: command not found. Make sure '{command}' is installed and the path to the executable is included in the 'Path' environment variable.");
+#else
+            trace?.Info($"{command}: command not found. Make sure '{command}' is installed and included in the PATH environment variable.");
+#endif
             if (require)
             {
                 throw new FileNotFoundException(
-                    message: $"File not found: '{command}'",
+                    message: $"{command}: command not found",
                     fileName: command);
             }
 


### PR DESCRIPTION
Closes https://github.com/actions/runner/issues/960

For example, `Error: File not found: 'docker'` may be hard to make sense of, so I replaced the exception message (that gets propagated to the UI log) with the Linux default for when a command is not found.

Additionally, I included some extra info in the message the runner logs to help people who hit this problem on a self-hosted runner.

I kept the exception type `FileNotFoundException`, because it describes the problem precisely.