### PR TITLE
Allow setting default severity to "notice"

### DIFF
--- a/src/Runner.Worker/IssueMatcher.cs
+++ b/src/Runner.Worker/IssueMatcher.cs
@@ -350,6 +350,7 @@ namespace GitHub.Runner.Worker
                 case "":
                 case "ERROR":
                 case "WARNING":
+                case "NOTICE":
                     break;
                 default:
                     throw new ArgumentException($"Matcher '{_owner}' contains unexpected default severity '{_severity}'");

--- a/src/Test/L0/Worker/IssueMatcherL0.cs
+++ b/src/Test/L0/Worker/IssueMatcherL0.cs
@@ -395,6 +395,35 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        public void Matcher_MultiplePatterns_DefaultSeverityNotice()
+        {
+            var config = JsonUtility.FromString<IssueMatchersConfig>(@"
+{
+  ""problemMatcher"": [
+    {
+      ""owner"": ""myMatcher"",
+      ""severity"": ""notice"",
+      ""pattern"": [
+        {
+          ""regexp"": ""^(.+)$"",
+          ""message"": 1
+        }
+      ]
+    }
+  ]
+}
+");
+            config.Validate();
+            var matcher = new IssueMatcher(config.Matchers[0], TimeSpan.FromSeconds(1));
+
+            var match = matcher.Match("just-a-notice");
+            Assert.Equal("notice", match.Severity);
+            Assert.Equal("just-a-notice", match.Message);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
         public void Matcher_MultiplePatterns_Loop_AccumulatesStatePerLine()
         {
             var config = JsonUtility.FromString<IssueMatchersConfig>(@"


### PR DESCRIPTION
Pull request #203 added a way to specify the default severity for a matcher. This allows us to define multiple matchers per severity, each matching only that specific severity.

However, currently the only allowed values for the default severity setting are "ERROR", "WARNING" and the empty string:

https://github.com/actions/runner/blob/dcda342eccd152fe69521d59de016ef09b70400c/src/Runner.Worker/IssueMatcher.cs#L350-L355

The empty string is interpreted in the same way as "ERROR":

https://github.com/actions/runner/blob/592ce1b230985aea359acdf6ed4ee84307bbedc1/src/Runner.Worker/Handlers/OutputManager.cs#L205-L208

As such, there is no way to add a matcher with the default severity of "notice".

This pull request addresses this by adding "notice" as one of the allowed options for the default matcher severity.