### PR TITLE
Prefer higher libicu versions in installDependencies.sh

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -104,7 +104,7 @@ then
         fi
 
         # libicu version prefer: libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
-        apt_get_with_fallbacks libicu66 libicu63 libicu60 libicu57 libicu55 libicu52
+        apt_get_with_fallbacks libicu72 libicu71 libicu70 libicu69 libicu68 libicu67 libicu66 libicu65 libicu63 libicu60 libicu57 libicu55 libicu52
         if [ $? -ne 0 ]
         then
             echo "'$apt_get' failed with exit code '$?'"

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -94,7 +94,6 @@ then
             fi
         }
 
-        # libssl version prefer: libssl1.1 -> libssl1.0.2 -> libssl1.0.0
         apt_get_with_fallbacks libssl1.1$ libssl1.0.2$ libssl1.0.0$
         if [ $? -ne 0 ]
         then
@@ -103,7 +102,6 @@ then
             exit 1
         fi
 
-        # libicu version prefer: libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
         apt_get_with_fallbacks libicu72 libicu71 libicu70 libicu69 libicu68 libicu67 libicu66 libicu65 libicu63 libicu60 libicu57 libicu55 libicu52
         if [ $? -ne 0 ]
         then


### PR DESCRIPTION
This PR fixes https://github.com/actions/runner/issues/1204

This PR allows us to use higher (>libicu66) versions. On some Oss, libicu67 is the lowest available version.

I got the list of dotnet compatible `libicu` versions from [here](https://linux-packages.com/ubuntu-groovy-gorilla/package/dotnet-runtime-deps-31)
Snippet from the dotnet runtime dependencies:
```
Maintainer: .NET Core Team 
Architecture: amd64
Version: 3.1.15-1

Depends: 
libgcc1, 
libssl1.0.0 | libssl1.0.2 | libssl1.1, 
libicu | libicu72 | libicu71 | libicu70 | libicu69 | libicu68 | libicu67 | libicu66 | libicu65 | libicu63 | libicu60 | libicu57 | libicu55 | libicu52
```
