### PR TITLE
Composite Code Cleanup

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -247,7 +247,9 @@ namespace GitHub.Runner.Worker
                                 {
                                     _cachedEmbeddedPreSteps[parentStepId] = new List<Pipelines.ActionStep>();
                                 }
-                                _cachedEmbeddedPreSteps[parentStepId].Add(action);
+                                var clonedAction = action.Clone() as Pipelines.ActionStep;
+                                clonedAction.Condition = definition.Data.Execution.InitCondition;
+                                _cachedEmbeddedPreSteps[parentStepId].Add(clonedAction);
                             }
                         }
 
@@ -258,7 +260,9 @@ namespace GitHub.Runner.Worker
                                 // If we haven't done so already, add the parent to the post steps
                                 _cachedEmbeddedPostSteps[parentStepId] = new Stack<Pipelines.ActionStep>();
                             }
-                            _cachedEmbeddedPostSteps[parentStepId].Push(action);
+                            var clonedAction = action.Clone() as Pipelines.ActionStep;
+                            clonedAction.Condition = definition.Data.Execution.CleanupCondition;
+                            _cachedEmbeddedPostSteps[parentStepId].Push(clonedAction);
                         }
                     }
                 }

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -247,6 +247,7 @@ namespace GitHub.Runner.Worker
                                 {
                                     _cachedEmbeddedPreSteps[parentStepId] = new List<Pipelines.ActionStep>();
                                 }
+                                // Clone action so we can modify the condition without affecting the original
                                 var clonedAction = action.Clone() as Pipelines.ActionStep;
                                 clonedAction.Condition = definition.Data.Execution.InitCondition;
                                 _cachedEmbeddedPreSteps[parentStepId].Add(clonedAction);
@@ -260,6 +261,7 @@ namespace GitHub.Runner.Worker
                                 // If we haven't done so already, add the parent to the post steps
                                 _cachedEmbeddedPostSteps[parentStepId] = new Stack<Pipelines.ActionStep>();
                             }
+                            // Clone action so we can modify the condition without affecting the original
                             var clonedAction = action.Clone() as Pipelines.ActionStep;
                             clonedAction.Condition = definition.Data.Execution.CleanupCondition;
                             _cachedEmbeddedPostSteps[parentStepId].Push(clonedAction);

--- a/src/Runner.Worker/ActionRunner.cs
+++ b/src/Runner.Worker/ActionRunner.cs
@@ -82,12 +82,6 @@ namespace GitHub.Runner.Worker
             ActionExecutionData handlerData = definition.Data?.Execution;
             ArgUtil.NotNull(handlerData, nameof(handlerData));
 
-            if (handlerData.HasPre &&
-                Action.Reference is Pipelines.RepositoryPathReference repoAction &&
-                string.Equals(repoAction.RepositoryType, Pipelines.PipelineConstants.SelfAlias, StringComparison.OrdinalIgnoreCase))
-            {
-                ExecutionContext.Warning($"`pre` execution is not supported for local action from '{repoAction.Path}'");
-            }
             List<JobExtensionRunner> localActionContainerSetupSteps = null;
             // Handle Composite Local Actions
             // Need to download and expand the tree of referenced actions
@@ -108,6 +102,13 @@ namespace GitHub.Runner.Worker
 
                 // Save container setup steps so we can reference them later
                 localActionContainerSetupSteps = prepareResult.ContainerSetupSteps;
+            }
+
+            if (handlerData.HasPre &&
+                Action.Reference is Pipelines.RepositoryPathReference repoAction &&
+                string.Equals(repoAction.RepositoryType, Pipelines.PipelineConstants.SelfAlias, StringComparison.OrdinalIgnoreCase))
+            {
+                ExecutionContext.Warning($"`pre` execution is not supported for local action from '{repoAction.Path}'");
             }
 
             // The action has post cleanup defined.

--- a/src/Runner.Worker/ConditionTraceWriter.cs
+++ b/src/Runner.Worker/ConditionTraceWriter.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Text;
+using GitHub.DistributedTask.Pipelines;
+using GitHub.Runner.Common;
+using GitHub.Runner.Sdk;
+using ObjectTemplating = GitHub.DistributedTask.ObjectTemplating;
+
+namespace GitHub.Runner.Worker
+{
+    public sealed class ConditionTraceWriter : ObjectTemplating::ITraceWriter
+    {
+        private readonly IExecutionContext _executionContext;
+        private readonly Tracing _trace;
+        private readonly StringBuilder _traceBuilder = new StringBuilder();
+
+        public string Trace => _traceBuilder.ToString();
+
+        public ConditionTraceWriter(Tracing trace, IExecutionContext executionContext)
+        {
+            ArgUtil.NotNull(trace, nameof(trace));
+            _trace = trace;
+            _executionContext = executionContext;
+        }
+
+        public void Error(string format, params Object[] args)
+        {
+            var message = StringUtil.Format(format, args);
+            _trace.Error(message);
+            _executionContext?.Debug(message);
+        }
+
+        public void Info(string format, params Object[] args)
+        {
+            var message = StringUtil.Format(format, args);
+            _trace.Info(message);
+            _executionContext?.Debug(message);
+            _traceBuilder.AppendLine(message);
+        }
+
+        public void Verbose(string format, params Object[] args)
+        {
+            var message = StringUtil.Format(format, args);
+            _trace.Verbose(message);
+            _executionContext?.Debug(message);
+        }
+    }
+}

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -277,48 +277,112 @@ namespace GitHub.Runner.Worker.Handlers
                     step.ExecutionContext.Complete(TaskResult.Failed);
                 }
 
-                // Evaluate condition
-                step.ExecutionContext.Debug($"Evaluating condition for step: '{step.DisplayName}'");
-                var conditionTraceWriter = new ConditionTraceWriter(Trace, step.ExecutionContext);
-                var conditionResult = false;
-                var conditionEvaluateError = default(Exception);
-                if (HostContext.RunnerShutdownToken.IsCancellationRequested)
+                // Register Callback
+                CancellationTokenRegistration? jobCancelRegister = null;
+                var jobContext = ExecutionContext.Root;
+                try
                 {
-                    step.ExecutionContext.Debug($"Skip evaluate condition on runner shutdown.");
-                }
-                else
-                {
-                    try
+                    // Register job cancellation call back only if job cancellation token not been fire before each step run
+                    if (!jobContext.CancellationToken.IsCancellationRequested)
                     {
-                        var templateEvaluator = step.ExecutionContext.ToPipelineTemplateEvaluator(conditionTraceWriter);
-                        var condition = new BasicExpressionToken(null, null, null, step.Condition);
-                        conditionResult = templateEvaluator.EvaluateStepIf(condition, step.ExecutionContext.ExpressionValues, step.ExecutionContext.ExpressionFunctions, step.ExecutionContext.ToExpressionState());
+                        // Test the condition again. The job was canceled after the condition was originally evaluated.
+                        jobCancelRegister = jobContext.CancellationToken.Register(() =>
+                        {
+                            // Mark job as cancelled
+                            jobContext.Result = TaskResult.Canceled;
+                            jobContext.JobContext.Status = jobContext.Result?.ToActionResult();
+
+                            step.ExecutionContext.Debug($"Re-evaluate condition on job cancellation for step: '{step.DisplayName}'.");
+                            var conditionReTestTraceWriter = new ConditionTraceWriter(Trace, null); // host tracing only
+                            var conditionReTestResult = false;
+                            if (HostContext.RunnerShutdownToken.IsCancellationRequested)
+                            {
+                                step.ExecutionContext.Debug($"Skip Re-evaluate condition on runner shutdown.");
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    var templateEvaluator = step.ExecutionContext.ToPipelineTemplateEvaluator(conditionReTestTraceWriter);
+                                    var condition = new BasicExpressionToken(null, null, null, step.Condition);
+                                    conditionReTestResult = templateEvaluator.EvaluateStepIf(condition, step.ExecutionContext.ExpressionValues, step.ExecutionContext.ExpressionFunctions, step.ExecutionContext.ToExpressionState());
+                                }
+                                catch (Exception ex)
+                                {
+                                    // Cancel the step since we get exception while re-evaluate step condition
+                                    Trace.Info("Caught exception from expression when re-test condition on job cancellation.");
+                                    step.ExecutionContext.Error(ex);
+                                }
+                            }
+
+                            if (!conditionReTestResult)
+                            {
+                                // Cancel the step
+                                Trace.Info("Cancel current running step.");
+                                step.ExecutionContext.CancelToken();
+                            }
+                        });
                     }
-                    catch (Exception ex)
+                    else
                     {
-                        Trace.Info("Caught exception from expression.");
-                        Trace.Error(ex);
-                        conditionEvaluateError = ex;
+                        if (jobContext.Result != TaskResult.Canceled)
+                        {
+                            // Mark job as cancelled
+                            jobContext.Result = TaskResult.Canceled;
+                            jobContext.JobContext.Status = jobContext.Result?.ToActionResult();
+                        }
+                    }
+                    // Evaluate condition
+                    step.ExecutionContext.Debug($"Evaluating condition for step: '{step.DisplayName}'");
+                    var conditionTraceWriter = new ConditionTraceWriter(Trace, step.ExecutionContext);
+                    var conditionResult = false;
+                    var conditionEvaluateError = default(Exception);
+                    if (HostContext.RunnerShutdownToken.IsCancellationRequested)
+                    {
+                        step.ExecutionContext.Debug($"Skip evaluate condition on runner shutdown.");
+                    }
+                    else
+                    {
+                        try
+                        {
+                            var templateEvaluator = step.ExecutionContext.ToPipelineTemplateEvaluator(conditionTraceWriter);
+                            var condition = new BasicExpressionToken(null, null, null, step.Condition);
+                            conditionResult = templateEvaluator.EvaluateStepIf(condition, step.ExecutionContext.ExpressionValues, step.ExecutionContext.ExpressionFunctions, step.ExecutionContext.ToExpressionState());
+                        }
+                        catch (Exception ex)
+                        {
+                            Trace.Info("Caught exception from expression.");
+                            Trace.Error(ex);
+                            conditionEvaluateError = ex;
+                        }
+                    }
+                    if (!conditionResult && conditionEvaluateError == null)
+                    {
+                        // Condition is false
+                        Trace.Info("Skipping step due to condition evaluation.");
+                        step.ExecutionContext.Result = TaskResult.Skipped;
+                        continue;
+                    }
+                    else if (conditionEvaluateError != null)
+                    {
+                        // Condition error
+                        step.ExecutionContext.Error(conditionEvaluateError);
+                        step.ExecutionContext.Result = TaskResult.Failed;
+                        ExecutionContext.Result = TaskResult.Failed;
+                        break;
+                    }
+                    else
+                    {
+                        await RunStepAsync(step);
                     }
                 }
-                if (!conditionResult && conditionEvaluateError == null)
+                finally
                 {
-                    // Condition is false
-                    Trace.Info("Skipping step due to condition evaluation.");
-                    step.ExecutionContext.Result = TaskResult.Skipped;
-                    continue;
-                }
-                else if (conditionEvaluateError != null)
-                {
-                    // Condition error
-                    step.ExecutionContext.Error(conditionEvaluateError);
-                    step.ExecutionContext.Result = TaskResult.Failed;
-                    ExecutionContext.Result = TaskResult.Failed;
-                    break;
-                }
-                else
-                {
-                    await RunStepAsync(step);
+                    if (jobCancelRegister != null)
+                    {
+                        jobCancelRegister?.Dispose();
+                        jobCancelRegister = null;
+                    }
                 }
 
                 // Check failed or canceled

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -279,18 +279,17 @@ namespace GitHub.Runner.Worker.Handlers
 
                 // Register Callback
                 CancellationTokenRegistration? jobCancelRegister = null;
-                var jobContext = ExecutionContext.Root;
                 try
                 {
                     // Register job cancellation call back only if job cancellation token not been fire before each step run
-                    if (!jobContext.CancellationToken.IsCancellationRequested)
+                    if (!ExecutionContext.Root.CancellationToken.IsCancellationRequested)
                     {
                         // Test the condition again. The job was canceled after the condition was originally evaluated.
-                        jobCancelRegister = jobContext.CancellationToken.Register(() =>
+                        jobCancelRegister = ExecutionContext.Root.CancellationToken.Register(() =>
                         {
                             // Mark job as cancelled
-                            jobContext.Result = TaskResult.Canceled;
-                            jobContext.JobContext.Status = jobContext.Result?.ToActionResult();
+                            ExecutionContext.Root.Result = TaskResult.Canceled;
+                            ExecutionContext.Root.JobContext.Status = ExecutionContext.Root.Result?.ToActionResult();
 
                             step.ExecutionContext.Debug($"Re-evaluate condition on job cancellation for step: '{step.DisplayName}'.");
                             var conditionReTestTraceWriter = new ConditionTraceWriter(Trace, null); // host tracing only
@@ -325,11 +324,11 @@ namespace GitHub.Runner.Worker.Handlers
                     }
                     else
                     {
-                        if (jobContext.Result != TaskResult.Canceled)
+                        if (ExecutionContext.Root.Result != TaskResult.Canceled)
                         {
                             // Mark job as cancelled
-                            jobContext.Result = TaskResult.Canceled;
-                            jobContext.JobContext.Status = jobContext.Result?.ToActionResult();
+                            ExecutionContext.Root.Result = TaskResult.Canceled;
+                            ExecutionContext.Root.JobContext.Status = ExecutionContext.Root.Result?.ToActionResult();
                         }
                     }
                     // Evaluate condition

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -354,43 +354,43 @@ namespace GitHub.Runner.Worker
 
             executionContext.Complete(result, resultCode: resultCode);
         }
+    }
 
-        private sealed class ConditionTraceWriter : ObjectTemplating::ITraceWriter
+    public sealed class ConditionTraceWriter : ObjectTemplating::ITraceWriter
+    {
+        private readonly IExecutionContext _executionContext;
+        private readonly Tracing _trace;
+        private readonly StringBuilder _traceBuilder = new StringBuilder();
+
+        public string Trace => _traceBuilder.ToString();
+
+        public ConditionTraceWriter(Tracing trace, IExecutionContext executionContext)
         {
-            private readonly IExecutionContext _executionContext;
-            private readonly Tracing _trace;
-            private readonly StringBuilder _traceBuilder = new StringBuilder();
+            ArgUtil.NotNull(trace, nameof(trace));
+            _trace = trace;
+            _executionContext = executionContext;
+        }
 
-            public string Trace => _traceBuilder.ToString();
+        public void Error(string format, params Object[] args)
+        {
+            var message = StringUtil.Format(format, args);
+            _trace.Error(message);
+            _executionContext?.Debug(message);
+        }
 
-            public ConditionTraceWriter(Tracing trace, IExecutionContext executionContext)
-            {
-                ArgUtil.NotNull(trace, nameof(trace));
-                _trace = trace;
-                _executionContext = executionContext;
-            }
+        public void Info(string format, params Object[] args)
+        {
+            var message = StringUtil.Format(format, args);
+            _trace.Info(message);
+            _executionContext?.Debug(message);
+            _traceBuilder.AppendLine(message);
+        }
 
-            public void Error(string format, params Object[] args)
-            {
-                var message = StringUtil.Format(format, args);
-                _trace.Error(message);
-                _executionContext?.Debug(message);
-            }
-
-            public void Info(string format, params Object[] args)
-            {
-                var message = StringUtil.Format(format, args);
-                _trace.Info(message);
-                _executionContext?.Debug(message);
-                _traceBuilder.AppendLine(message);
-            }
-
-            public void Verbose(string format, params Object[] args)
-            {
-                var message = StringUtil.Format(format, args);
-                _trace.Verbose(message);
-                _executionContext?.Debug(message);
-            }
+        public void Verbose(string format, params Object[] args)
+        {
+            var message = StringUtil.Format(format, args);
+            _trace.Verbose(message);
+            _executionContext?.Debug(message);
         }
     }
 }

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -355,42 +355,4 @@ namespace GitHub.Runner.Worker
             executionContext.Complete(result, resultCode: resultCode);
         }
     }
-
-    public sealed class ConditionTraceWriter : ObjectTemplating::ITraceWriter
-    {
-        private readonly IExecutionContext _executionContext;
-        private readonly Tracing _trace;
-        private readonly StringBuilder _traceBuilder = new StringBuilder();
-
-        public string Trace => _traceBuilder.ToString();
-
-        public ConditionTraceWriter(Tracing trace, IExecutionContext executionContext)
-        {
-            ArgUtil.NotNull(trace, nameof(trace));
-            _trace = trace;
-            _executionContext = executionContext;
-        }
-
-        public void Error(string format, params Object[] args)
-        {
-            var message = StringUtil.Format(format, args);
-            _trace.Error(message);
-            _executionContext?.Debug(message);
-        }
-
-        public void Info(string format, params Object[] args)
-        {
-            var message = StringUtil.Format(format, args);
-            _trace.Info(message);
-            _executionContext?.Debug(message);
-            _traceBuilder.AppendLine(message);
-        }
-
-        public void Verbose(string format, params Object[] args)
-        {
-            var message = StringUtil.Format(format, args);
-            _trace.Verbose(message);
-            _executionContext?.Debug(message);
-        }
-    }
 }


### PR DESCRIPTION
This pr fixes some minor bugs associated with composite actions and prepares the feature for release

Technical changes
- Correctly sets the condition for pre and post steps, and ensures that these conditions are evaluated when pre/post steps are ran
- When a composite action fails, we update the Job status early so we can evaluate the next composite step correctly
- Fixes an issue where we modify an existing collection crashing the for loop