### PR TITLE
Set Context Name for Pre/Post Steps

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -272,7 +272,7 @@ namespace GitHub.Runner.Worker
                 return;
             }
 
-            step.ExecutionContext = Root.CreatePostChild(step.DisplayName, IntraActionState);
+            step.ExecutionContext = Root.CreatePostChild(step.DisplayName, IntraActionState, this.ScopeName);
             Root.PostJobSteps.Push(step);
         }
 
@@ -914,7 +914,7 @@ namespace GitHub.Runner.Worker
             }
         }
 
-        private IExecutionContext CreatePostChild(string displayName, Dictionary<string, string> intraActionState)
+        private IExecutionContext CreatePostChild(string displayName, Dictionary<string, string> intraActionState, string scopeName)
         {
             if (!_expandedForPostJob)
             {
@@ -924,7 +924,7 @@ namespace GitHub.Runner.Worker
             }
 
             var newGuid = Guid.NewGuid();
-            return CreateChild(newGuid, displayName, newGuid.ToString("N"), null, null, intraActionState, _childTimelineRecordOrder - Root.PostJobSteps.Count);
+            return CreateChild(newGuid, displayName, newGuid.ToString("N"), null, scopeName, intraActionState, _childTimelineRecordOrder - Root.PostJobSteps.Count);
         }
     }
 

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -272,7 +272,7 @@ namespace GitHub.Runner.Worker
                 return;
             }
 
-            step.ExecutionContext = Root.CreatePostChild(step.DisplayName, IntraActionState, this.GetFullyQualifiedContextName());
+            step.ExecutionContext = Root.CreatePostChild(step.DisplayName, IntraActionState, ContextName);
             Root.PostJobSteps.Push(step);
         }
 
@@ -914,7 +914,7 @@ namespace GitHub.Runner.Worker
             }
         }
 
-        private IExecutionContext CreatePostChild(string displayName, Dictionary<string, string> intraActionState, string scopeName)
+        private IExecutionContext CreatePostChild(string displayName, Dictionary<string, string> intraActionState, string contextName)
         {
             if (!_expandedForPostJob)
             {
@@ -924,7 +924,7 @@ namespace GitHub.Runner.Worker
             }
 
             var newGuid = Guid.NewGuid();
-            return CreateChild(newGuid, displayName, newGuid.ToString("N"), null, scopeName, intraActionState, _childTimelineRecordOrder - Root.PostJobSteps.Count);
+            return CreateChild(newGuid, displayName, newGuid.ToString("N"), null, contextName, intraActionState, _childTimelineRecordOrder - Root.PostJobSteps.Count);
         }
     }
 

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -272,7 +272,7 @@ namespace GitHub.Runner.Worker
                 return;
             }
 
-            step.ExecutionContext = Root.CreatePostChild(step.DisplayName, IntraActionState, this.ScopeName);
+            step.ExecutionContext = Root.CreatePostChild(step.DisplayName, IntraActionState, this.GetFullyQualifiedContextName());
             Root.PostJobSteps.Push(step);
         }
 

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -312,7 +312,7 @@ namespace GitHub.Runner.Worker
                         {
                             ArgUtil.NotNull(actionStep, step.DisplayName);
                             Guid stepId = Guid.NewGuid();
-                            actionStep.ExecutionContext = jobContext.CreateChild(stepId, actionStep.DisplayName, stepId.ToString("N"), null, null, intraActionStates[actionStep.Action.Id]);
+                            actionStep.ExecutionContext = jobContext.CreateChild(stepId, actionStep.DisplayName, stepId.ToString("N"), null, actionStep.Action.ContextName, intraActionStates[actionStep.Action.Id]);
                         }
                     }
 

--- a/src/Runner.Worker/Variables.cs
+++ b/src/Runner.Worker/Variables.cs
@@ -70,7 +70,7 @@ namespace GitHub.Runner.Worker
         public bool Retain_Default_Encoding => true;
 #endif
 
-        public bool? Step_Debug => GetBoolean(Constants.Variables.Actions.StepDebug);
+        public bool? Step_Debug => true;
 
         public string System_PhaseDisplayName => Get(Constants.Variables.System.PhaseDisplayName);
 


### PR DESCRIPTION
This PR sets the context name for pre/post steps to ensure composite pre/post steps are able to correctly pull the steps context as needed. Composite actions convert these into a scope name so they can properly pull the correct steps context based on the scope.