### PR TITLE
Send path when resolving actions

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -610,6 +610,7 @@ namespace GitHub.Runner.Worker
                     {
                         NameWithOwner = repositoryReference.Name,
                         Ref = repositoryReference.Ref,
+                        Path = repositoryReference.Path,
                     };
                 })
                 .ToList();

--- a/src/Sdk/DTWebApi/WebApi/ActionReference.cs
+++ b/src/Sdk/DTWebApi/WebApi/ActionReference.cs
@@ -18,5 +18,12 @@ namespace GitHub.DistributedTask.WebApi
             get;
             set;
         }
+
+        [DataMember]
+        public string Path
+        {
+            get;
+            set;
+        }
     }
 }


### PR DESCRIPTION
This PR sends up the path in the resolve actions endpoint so we can properly validate policy when JIT downloading Composite Actions