### PR TITLE
Add extra env for the Token log-in action is going to use to request ID_TOKEN

### DIFF
--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -217,6 +217,7 @@ namespace GitHub.Runner.Worker.Handlers
             if (systemConnection.Data.TryGetValue("GenerateIdTokenUrl", out var generateIdTokenUrl) && !string.IsNullOrEmpty(generateIdTokenUrl))
             {
                 Environment["ACTIONS_ID_TOKEN_REQUEST_URL"] = generateIdTokenUrl;
+                Environment["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = systemConnection.Authorization.Parameters[EndpointAuthorizationParameters.AccessToken];
             }
 
             foreach (var variable in this.Environment)

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -56,6 +56,7 @@ namespace GitHub.Runner.Worker.Handlers
             if (systemConnection.Data.TryGetValue("GenerateIdTokenUrl", out var generateIdTokenUrl) && !string.IsNullOrEmpty(generateIdTokenUrl))
             {
                 Environment["ACTIONS_ID_TOKEN_REQUEST_URL"] = generateIdTokenUrl;
+                Environment["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = systemConnection.Authorization.Parameters[EndpointAuthorizationParameters.AccessToken];
             }
 
             // Resolve the target script.


### PR DESCRIPTION
`ACTIONS_ID_TOKEN_REQUEST_TOKEN` currently just point to `ACTIONS_RUNTIME_TOKEN`.
With this extra indirection, we are able to change which token to use in the future, ex: switch to `GITHUB_TOKEN`, without breaking any existing customers.

https://github.com/github/c2c-actions-runtime/issues/1365