### PR TITLE
For Main Steps, just run the step, don't check condition

### DIFF
--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -294,99 +294,110 @@ namespace GitHub.Runner.Worker.Handlers
                 // Register Callback
                 CancellationTokenRegistration? jobCancelRegister = null;
                 try
-                {
-                    // Register job cancellation call back only if job cancellation token not been fire before each step run
-                    if (!ExecutionContext.Root.CancellationToken.IsCancellationRequested)
+                {   
+                    // For main steps just run the action
+                    if (stage == ActionRunStage.Main)
                     {
-                        // Test the condition again. The job was canceled after the condition was originally evaluated.
-                        jobCancelRegister = ExecutionContext.Root.CancellationToken.Register(() =>
                         {
-                            // Mark job as cancelled
-                            ExecutionContext.Root.Result = TaskResult.Canceled;
-                            ExecutionContext.Root.JobContext.Status = ExecutionContext.Root.Result?.ToActionResult();
+                            await RunStepAsync(step);
+                        }
+                    }
+                    // We need to evaluate conditions for pre/post steps
+                    else
+                    {
+                        // Register job cancellation call back only if job cancellation token not been fire before each step run
+                        if (!ExecutionContext.Root.CancellationToken.IsCancellationRequested)
+                        {
+                            // Test the condition again. The job was canceled after the condition was originally evaluated.
+                            jobCancelRegister = ExecutionContext.Root.CancellationToken.Register(() =>
+                            {
+                                // Mark job as cancelled
+                                ExecutionContext.Root.Result = TaskResult.Canceled;
+                                ExecutionContext.Root.JobContext.Status = ExecutionContext.Root.Result?.ToActionResult();
 
-                            step.ExecutionContext.Debug($"Re-evaluate condition on job cancellation for step: '{step.DisplayName}'.");
-                            var conditionReTestTraceWriter = new ConditionTraceWriter(Trace, null); // host tracing only
-                            var conditionReTestResult = false;
-                            if (HostContext.RunnerShutdownToken.IsCancellationRequested)
-                            {
-                                step.ExecutionContext.Debug($"Skip Re-evaluate condition on runner shutdown.");
-                            }
-                            else
-                            {
-                                try
+                                step.ExecutionContext.Debug($"Re-evaluate condition on job cancellation for step: '{step.DisplayName}'.");
+                                var conditionReTestTraceWriter = new ConditionTraceWriter(Trace, null); // host tracing only
+                                var conditionReTestResult = false;
+                                if (HostContext.RunnerShutdownToken.IsCancellationRequested)
                                 {
-                                    var templateEvaluator = step.ExecutionContext.ToPipelineTemplateEvaluator(conditionReTestTraceWriter);
-                                    var condition = new BasicExpressionToken(null, null, null, step.Condition);
-                                    conditionReTestResult = templateEvaluator.EvaluateStepIf(condition, step.ExecutionContext.ExpressionValues, step.ExecutionContext.ExpressionFunctions, step.ExecutionContext.ToExpressionState());
+                                    step.ExecutionContext.Debug($"Skip Re-evaluate condition on runner shutdown.");
                                 }
-                                catch (Exception ex)
+                                else
                                 {
-                                    // Cancel the step since we get exception while re-evaluate step condition
-                                    Trace.Info("Caught exception from expression when re-test condition on job cancellation.");
-                                    step.ExecutionContext.Error(ex);
+                                    try
+                                    {
+                                        var templateEvaluator = step.ExecutionContext.ToPipelineTemplateEvaluator(conditionReTestTraceWriter);
+                                        var condition = new BasicExpressionToken(null, null, null, step.Condition);
+                                        conditionReTestResult = templateEvaluator.EvaluateStepIf(condition, step.ExecutionContext.ExpressionValues, step.ExecutionContext.ExpressionFunctions, step.ExecutionContext.ToExpressionState());
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        // Cancel the step since we get exception while re-evaluate step condition
+                                        Trace.Info("Caught exception from expression when re-test condition on job cancellation.");
+                                        step.ExecutionContext.Error(ex);
+                                    }
                                 }
-                            }
 
-                            if (!conditionReTestResult)
+                                if (!conditionReTestResult)
+                                {
+                                    // Cancel the step
+                                    Trace.Info("Cancel current running step.");
+                                    step.ExecutionContext.CancelToken();
+                                }
+                            });
+                        }
+                        else
+                        {
+                            if (ExecutionContext.Root.Result != TaskResult.Canceled)
                             {
-                                // Cancel the step
-                                Trace.Info("Cancel current running step.");
-                                step.ExecutionContext.CancelToken();
+                                // Mark job as cancelled
+                                ExecutionContext.Root.Result = TaskResult.Canceled;
+                                ExecutionContext.Root.JobContext.Status = ExecutionContext.Root.Result?.ToActionResult();
                             }
-                        });
-                    }
-                    else
-                    {
-                        if (ExecutionContext.Root.Result != TaskResult.Canceled)
-                        {
-                            // Mark job as cancelled
-                            ExecutionContext.Root.Result = TaskResult.Canceled;
-                            ExecutionContext.Root.JobContext.Status = ExecutionContext.Root.Result?.ToActionResult();
                         }
-                    }
-                    // Evaluate condition
-                    step.ExecutionContext.Debug($"Evaluating condition for step: '{step.DisplayName}'");
-                    var conditionTraceWriter = new ConditionTraceWriter(Trace, step.ExecutionContext);
-                    var conditionResult = false;
-                    var conditionEvaluateError = default(Exception);
-                    if (HostContext.RunnerShutdownToken.IsCancellationRequested)
-                    {
-                        step.ExecutionContext.Debug($"Skip evaluate condition on runner shutdown.");
-                    }
-                    else
-                    {
-                        try
+                        // Evaluate condition
+                        step.ExecutionContext.Debug($"Evaluating condition for step: '{step.DisplayName}'");
+                        var conditionTraceWriter = new ConditionTraceWriter(Trace, step.ExecutionContext);
+                        var conditionResult = false;
+                        var conditionEvaluateError = default(Exception);
+                        if (HostContext.RunnerShutdownToken.IsCancellationRequested)
                         {
-                            var templateEvaluator = step.ExecutionContext.ToPipelineTemplateEvaluator(conditionTraceWriter);
-                            var condition = new BasicExpressionToken(null, null, null, step.Condition);
-                            conditionResult = templateEvaluator.EvaluateStepIf(condition, step.ExecutionContext.ExpressionValues, step.ExecutionContext.ExpressionFunctions, step.ExecutionContext.ToExpressionState());
+                            step.ExecutionContext.Debug($"Skip evaluate condition on runner shutdown.");
                         }
-                        catch (Exception ex)
+                        else
                         {
-                            Trace.Info("Caught exception from expression.");
-                            Trace.Error(ex);
-                            conditionEvaluateError = ex;
+                            try
+                            {
+                                var templateEvaluator = step.ExecutionContext.ToPipelineTemplateEvaluator(conditionTraceWriter);
+                                var condition = new BasicExpressionToken(null, null, null, step.Condition);
+                                conditionResult = templateEvaluator.EvaluateStepIf(condition, step.ExecutionContext.ExpressionValues, step.ExecutionContext.ExpressionFunctions, step.ExecutionContext.ToExpressionState());
+                            }
+                            catch (Exception ex)
+                            {
+                                Trace.Info("Caught exception from expression.");
+                                Trace.Error(ex);
+                                conditionEvaluateError = ex;
+                            }
                         }
-                    }
-                    if (!conditionResult && conditionEvaluateError == null)
-                    {
-                        // Condition is false
-                        Trace.Info("Skipping step due to condition evaluation.");
-                        step.ExecutionContext.Result = TaskResult.Skipped;
-                        continue;
-                    }
-                    else if (conditionEvaluateError != null)
-                    {
-                        // Condition error
-                        step.ExecutionContext.Error(conditionEvaluateError);
-                        step.ExecutionContext.Result = TaskResult.Failed;
-                        ExecutionContext.Result = TaskResult.Failed;
-                        break;
-                    }
-                    else
-                    {
-                        await RunStepAsync(step);
+                        if (!conditionResult && conditionEvaluateError == null)
+                        {
+                            // Condition is false
+                            Trace.Info("Skipping step due to condition evaluation.");
+                            step.ExecutionContext.Result = TaskResult.Skipped;
+                            continue;
+                        }
+                        else if (conditionEvaluateError != null)
+                        {
+                            // Condition error
+                            step.ExecutionContext.Error(conditionEvaluateError);
+                            step.ExecutionContext.Result = TaskResult.Failed;
+                            ExecutionContext.Result = TaskResult.Failed;
+                            break;
+                        }
+                        else
+                        {
+                            await RunStepAsync(step);
+                        }
                     }
                 }
                 finally

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -298,9 +298,7 @@ namespace GitHub.Runner.Worker.Handlers
                     // For main steps just run the action
                     if (stage == ActionRunStage.Main)
                     {
-                        {
-                            await RunStepAsync(step);
-                        }
+                        await RunStepAsync(step);
                     }
                     // We need to evaluate conditions for pre/post steps
                     else

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -294,7 +294,7 @@ namespace GitHub.Runner.Worker.Handlers
                 // Register Callback
                 CancellationTokenRegistration? jobCancelRegister = null;
                 try
-                {   
+                {
                     // For main steps just run the action
                     if (stage == ActionRunStage.Main)
                     {


### PR DESCRIPTION
Resolves #1271 

We made a change to evaluate conditions for pre/post steps for composite actions. We also evalute these conditions for main steps, but it always defaults to `success`. This works well for those pre/post steps, as the default is `always()`. However, for the main steps, if you try to run a composite step on `failure` or `cancelled`, success() will always evaluate to false, thus not running the step. This change restores the old functionality, always running main steps if the parent's `if` condition succeeded.