### PR TITLE
Show More Step Information in composite Actions

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -980,18 +980,6 @@ namespace GitHub.Runner.Worker
             context.Write(null, message);
         }
 
-        public static void WriteDetails(this IExecutionContext context, string message)
-        {
-            if (context.IsEmbedded)
-            {
-                context.Debug(message);
-            }
-            else
-            {
-                context.Output(message);
-            }
-        }
-
         // Do not add a format string overload. See comment on ExecutionContext.Write().
         public static void Command(this IExecutionContext context, string message)
         {

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -50,8 +50,8 @@ namespace GitHub.Runner.Worker.Handlers
                 var dockerFile = Path.Combine(ActionDirectory, Data.Image);
                 ArgUtil.File(dockerFile, nameof(Data.Image));
 
-                ExecutionContext.WriteDetails(ExecutionContext.IsEmbedded ? "Building docker image" : $"##[group]Building docker image");
-                ExecutionContext.WriteDetails($"Dockerfile for action: '{dockerFile}'.");
+                ExecutionContext.Output($"##[group]Building docker image");
+                ExecutionContext.Output($"Dockerfile for action: '{dockerFile}'.");
                 var imageName = $"{dockerManager.DockerInstanceLabel}:{ExecutionContext.Id.ToString("N")}";
                 var buildExitCode = await dockerManager.DockerBuild(
                     ExecutionContext,
@@ -59,7 +59,7 @@ namespace GitHub.Runner.Worker.Handlers
                     dockerFile,
                     Directory.GetParent(dockerFile).FullName,
                     imageName);
-                ExecutionContext.WriteDetails(ExecutionContext.IsEmbedded ? "" : "##[endgroup]");
+                ExecutionContext.Output("##[endgroup]");
 
                 if (buildExitCode != 0)
                 {

--- a/src/Runner.Worker/Handlers/Handler.cs
+++ b/src/Runner.Worker/Handlers/Handler.cs
@@ -82,7 +82,7 @@ namespace GitHub.Runner.Worker.Handlers
             
             if (stage == ActionRunStage.Post)
             {
-                ExecutionContext.WriteDetails($"Post job cleanup.");
+                ExecutionContext.Output($"Post job cleanup.");
                 return;
             }
 
@@ -118,30 +118,30 @@ namespace GitHub.Runner.Worker.Handlers
                 groupName = "Action details";
             }
 
-            ExecutionContext.WriteDetails(ExecutionContext.IsEmbedded ? groupName : $"##[group]{groupName}");
+            ExecutionContext.Output($"##[group]{groupName}");
 
             if (this.Inputs?.Count > 0)
             {
-                ExecutionContext.WriteDetails("with:");
+                ExecutionContext.Output("with:");
                 foreach (var input in this.Inputs)
                 {
                     if (!string.IsNullOrEmpty(input.Value))
                     {
-                        ExecutionContext.WriteDetails($"  {input.Key}: {input.Value}");
+                        ExecutionContext.Output($"  {input.Key}: {input.Value}");
                     }
                 }
             }
 
             if (this.Environment?.Count > 0)
             {
-                ExecutionContext.WriteDetails("env:");
+                ExecutionContext.Output("env:");
                 foreach (var env in this.Environment)
                 {
-                    ExecutionContext.WriteDetails($"  {env.Key}: {env.Value}");
+                    ExecutionContext.Output($"  {env.Key}: {env.Value}");
                 }
             }
 
-            ExecutionContext.WriteDetails(ExecutionContext.IsEmbedded ? "" : "##[endgroup]");
+            ExecutionContext.Output("##[endgroup]");
         }
 
         public override void Initialize(IHostContext hostContext)

--- a/src/Runner.Worker/Handlers/ScriptHandler.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandler.cs
@@ -40,7 +40,7 @@ namespace GitHub.Runner.Worker.Handlers
                     firstLine = firstLine.Substring(0, firstNewLine);
                 }
 
-                ExecutionContext.WriteDetails(ExecutionContext.IsEmbedded ? $"Run {firstLine}" : $"##[group]Run {firstLine}");
+                ExecutionContext.Output($"##[group]Run {firstLine}");
             }
             else
             {
@@ -51,7 +51,7 @@ namespace GitHub.Runner.Worker.Handlers
             foreach (var line in multiLines)
             {
                 // Bright Cyan color
-                ExecutionContext.WriteDetails($"\x1b[36;1m{line}\x1b[0m");
+                ExecutionContext.Output($"\x1b[36;1m{line}\x1b[0m");
             }
 
             string argFormat;
@@ -110,23 +110,23 @@ namespace GitHub.Runner.Worker.Handlers
 
             if (!string.IsNullOrEmpty(shellCommandPath))
             {
-                ExecutionContext.WriteDetails($"shell: {shellCommandPath} {argFormat}");
+                ExecutionContext.Output($"shell: {shellCommandPath} {argFormat}");
             }
             else
             {
-                ExecutionContext.WriteDetails($"shell: {shellCommand} {argFormat}");
+                ExecutionContext.Output($"shell: {shellCommand} {argFormat}");
             }
 
             if (this.Environment?.Count > 0)
             {
-                ExecutionContext.WriteDetails("env:");
+                ExecutionContext.Output("env:");
                 foreach (var env in this.Environment)
                 {
-                    ExecutionContext.WriteDetails($"  {env.Key}: {env.Value}");
+                    ExecutionContext.Output($"  {env.Key}: {env.Value}");
                 }
             }
 
-            ExecutionContext.WriteDetails(ExecutionContext.IsEmbedded ? "" : "##[endgroup]");
+            ExecutionContext.Output("##[endgroup]");
         }
 
         public async Task RunAsync(ActionRunStage stage)


### PR DESCRIPTION
Resolves #1272 

This PR removes step information from debug and add's it back into the main job log when running composite actions. This allows you to see more information about what step is running.

Image from a test environment of how this looks:

![image](https://user-images.githubusercontent.com/52323235/130135616-d9b7f481-7efe-41da-ba04-6bc68586e8c2.png)

Other ideas I've been toying with:

Should we put newlines in between each step for readability/visibility?
Should we highlight the composite step running messages in some way?