### PR TITLE
Don't try to login to ghcr.io with GHES tokens

### DIFF
--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -117,6 +117,7 @@ namespace GitHub.Runner.Listener.Configuration
                 try
                 {
                     // Determine the service deployment type based on connection data. (Hosted/OnPremises)
+                    // Hosted usually means github.com or localhost, while OnPremises means GHES or GHAE
                     runnerSettings.IsHostedServer = runnerSettings.GitHubUrl == null || UrlUtil.IsHostedServer(new UriBuilder(runnerSettings.GitHubUrl));
 
                     // Warn if the Actions server url and GHES server url has different Host

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -494,8 +494,8 @@ namespace GitHub.Runner.Worker
         private void UpdateRegistryAuthForGitHubToken(IExecutionContext executionContext, ContainerInfo container)
         {
             var registryIsTokenCompatible = container.RegistryServer.Equals("ghcr.io", StringComparison.OrdinalIgnoreCase) || container.RegistryServer.Equals("containers.pkg.github.com", StringComparison.OrdinalIgnoreCase);
-            var isTokenFromGithubDotcom = HostContext.GetService<IConfigurationStore>().GetSettings().IsHostedServer;
-            if (!registryIsTokenCompatible || !isTokenFromGithubDotcom)
+            var isFallbackTokenFromHostedGithub = HostContext.GetService<IConfigurationStore>().GetSettings().IsHostedServer;
+            if (!registryIsTokenCompatible || !isFallbackTokenFromHostedGithub)
             {
                 return;
             }

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -494,7 +494,8 @@ namespace GitHub.Runner.Worker
         private void UpdateRegistryAuthForGitHubToken(IExecutionContext executionContext, ContainerInfo container)
         {
             var registryIsTokenCompatible = container.RegistryServer.Equals("ghcr.io", StringComparison.OrdinalIgnoreCase) || container.RegistryServer.Equals("containers.pkg.github.com", StringComparison.OrdinalIgnoreCase);
-            if (!registryIsTokenCompatible)
+            var isTokenFromGithubDotcom = HostContext.GetService<IConfigurationStore>().GetSettings().IsHostedServer;
+            if (!registryIsTokenCompatible || !isTokenFromGithubDotcom)
             {
                 return;
             }


### PR DESCRIPTION
Fixes https://github.com/actions/runner/issues/1199

This PR prevents the usage of tokens from a GHES instance when authenticating against ghcr.io. Instead of failing the job due to a failure to authenticate, the runner can now access public images in an unauthenticated session.