### PR TITLE
Allow absolute paths with uses:

### DIFF
--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -509,7 +509,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                     var image = uses.Value.Substring("docker://".Length);
                     result.Reference = new ContainerRegistryReference { Image = image };
                 }
-                else if (uses.Value.StartsWith("./") || uses.Value.StartsWith(".\\"))
+                else if (uses.Value.StartsWith("/") || uses.Value.StartsWith("./") || uses.Value.StartsWith(".\\"))
                 {
                     result.Reference = new RepositoryPathReference
                     {


### PR DESCRIPTION
This updates the mechanism responsible for validating the `Uses:` rule to allow actions to be provided with an absolute path along with relative paths.

We are currently replacing our old CI with GitHub Actions here at @Gympass, and we decided to include internal actions in our base runner image, which is executed by our self-hosted instances. Those images live in a folder in the root path, say `/gympass/actions`.
A workaround we found is to provide `Uses:` with a relative path to the root mountpoint, by passing several `../` before the action name. Merging this PR would allow us to provide the absolute path to our actions directory without resorting to use the hack I mentioned above.

Reviewers: I'm not sure how to write a test case for this scenario. In case this is a valid change for this application, and you intend to merge this PR, could you kindly provide instructions on how to write it?

Thank you!