### PR TITLE
Add attempt number to GitHub context

### DIFF
--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -32,6 +32,7 @@ namespace GitHub.Runner.Worker
             "sha",
             "workflow",
             "workspace",
+            "attempt",
         };
 
         public IEnumerable<KeyValuePair<string, string>> GetRuntimeEnvironmentVariables()

--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -32,7 +32,7 @@ namespace GitHub.Runner.Worker
             "sha",
             "workflow",
             "workspace",
-            "attempt",
+            "run_attempt",
         };
 
         public IEnumerable<KeyValuePair<string, string>> GetRuntimeEnvironmentVariables()

--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -26,13 +26,13 @@ namespace GitHub.Runner.Worker
             "repository",
             "repository_owner",
             "retention_days",
+            "run_attempt",
             "run_id",
             "run_number",
             "server_url",
             "sha",
             "workflow",
             "workspace",
-            "run_attempt",
         };
 
         public IEnumerable<KeyValuePair<string, string>> GetRuntimeEnvironmentVariables()


### PR DESCRIPTION
As we work to support reruns on GitHub, we can expose the number of reruns for a given workflow.  Once it is exposed it will be easy to determine if a workflow run is a rerun or not.