### PR TITLE
Make TimeoutException retry-able

### DIFF
--- a/src/Sdk/Common/Common/VssHttpRetryMessageHandler.cs
+++ b/src/Sdk/Common/Common/VssHttpRetryMessageHandler.cs
@@ -125,7 +125,10 @@ namespace GitHub.Services.Common
                 }
                 catch (TimeoutException)
                 {
-                    throw;
+                    // Let's consider runner TimeoutException as 'retry-able'. The lower layer (i.e. VssHttpMessageHandler)
+                    // special-cases TimeoutException from OperationCanceledException (caused by cancellation requests)
+                    // so we won't be accidentally stalling the runner on e.g. a Ctrl-Z operation.
+                    canRetry = true;
                 }
 
                 if (attempt < maxAttempts && canRetry)


### PR DESCRIPTION
This PR fixes an issue where `TimeoutException`s are being readily thrown by `VssHttpMessageHandler`, but the exception itself is not caught anywhere in the stack, so it bubbles all the way up to the runner process crashing. This is done by modifying the handler to make `TimeoutException` use the retry mechanism, so at least the runner can gracefully recover from a timeout, and properly fail if timeouts are exhausted.