### PR TITLE
More resilient `VssConnection` client retries in `JobServer`

### DIFF
--- a/src/Runner.Listener/JobDispatcher.cs
+++ b/src/Runner.Listener/JobDispatcher.cs
@@ -510,9 +510,8 @@ namespace GitHub.Runner.Listener
 
                                     var jobServer = HostContext.GetService<IJobServer>();
                                     VssCredentials jobServerCredential = VssUtil.GetVssCredential(systemConnection);
-                                    VssConnection jobConnection = VssUtil.CreateConnection(systemConnection.Url, jobServerCredential);
-                                    await jobServer.ConnectAsync(jobConnection);
 
+                                    await jobServer.ConnectAsync(systemConnection.Url, jobServerCredential);
                                     await LogWorkerProcessUnhandledException(jobServer, message, detailInfo);
 
                                     // Go ahead to finish the job with result 'Failed' if the STDERR from worker is System.IO.IOException, since it typically means we are running out of disk space.
@@ -791,9 +790,8 @@ namespace GitHub.Runner.Listener
 
                 var jobServer = HostContext.GetService<IJobServer>();
                 VssCredentials jobServerCredential = VssUtil.GetVssCredential(systemConnection);
-                VssConnection jobConnection = VssUtil.CreateConnection(systemConnection.Url, jobServerCredential);
 
-                await jobServer.ConnectAsync(jobConnection);
+                await jobServer.ConnectAsync(systemConnection.Url, jobServerCredential);
 
                 var timeline = await jobServer.GetTimelineAsync(message.Plan.ScopeIdentifier, message.Plan.PlanType, message.Plan.PlanId, message.Timeline.Id, CancellationToken.None);
 

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -48,8 +48,8 @@ namespace GitHub.Runner.Worker
             Trace.Info($"Creating job server with URL: {jobServerUrl}");
             // jobServerQueue is the throttling reporter.
             _jobServerQueue = HostContext.GetService<IJobServerQueue>();
-            VssConnection jobConnection = VssUtil.CreateConnection(jobServerUrl, jobServerCredential, new DelegatingHandler[] { new ThrottlingReportHandler(_jobServerQueue) });
-            await jobServer.ConnectAsync(jobConnection);
+            
+            await jobServer.ConnectAsync(jobServerUrl, jobServerCredential, new DelegatingHandler[] { new ThrottlingReportHandler(_jobServerQueue) });
 
             _jobServerQueue.Start(message);
             HostContext.WritePerfCounter($"WorkerJobServerQueueStarted_{message.RequestId.ToString()}");


### PR DESCRIPTION
Re-create `VssConnection` object with each retry for resiliency. This follows an existing pattern that's used in `RunnerServer` that has been working well so far.