### PR TITLE
Wait for job record updated before running steps.

### DIFF
--- a/src/Runner.Common/JobServerQueue.cs
+++ b/src/Runner.Common/JobServerQueue.cs
@@ -15,6 +15,7 @@ namespace GitHub.Runner.Common
     [ServiceLocator(Default = typeof(JobServerQueue))]
     public interface IJobServerQueue : IRunnerService, IThrottlingReporter
     {
+        TaskCompletionSource<int> JobRecordUpdated { get; }
         event EventHandler<ThrottlingEventArgs> JobServerQueueThrottling;
         Task ShutdownAsync();
         void Start(Pipelines.AgentJobRequestMessage jobRequest);
@@ -62,7 +63,10 @@ namespace GitHub.Runner.Common
         private IJobServer _jobServer;
         private Task[] _allDequeueTasks;
         private readonly TaskCompletionSource<int> _jobCompletionSource = new TaskCompletionSource<int>();
+        private readonly TaskCompletionSource<int> _jobRecordUpdated = new TaskCompletionSource<int>();
         private bool _queueInProcess = false;
+
+        public TaskCompletionSource<int> JobRecordUpdated => _jobRecordUpdated;
 
         public event EventHandler<ThrottlingEventArgs> JobServerQueueThrottling;
 
@@ -287,11 +291,11 @@ namespace GitHub.Runner.Common
                                 {
                                     await _jobServer.AppendTimelineRecordFeedAsync(_scopeIdentifier, _hubName, _planId, _jobTimelineId, _jobTimelineRecordId, stepRecordId, batch.Select(logLine => logLine.Line).ToList(), batch[0].LineNumber.Value, default(CancellationToken));
                                 }
-                                else 
+                                else
                                 {
                                     await _jobServer.AppendTimelineRecordFeedAsync(_scopeIdentifier, _hubName, _planId, _jobTimelineId, _jobTimelineRecordId, stepRecordId, batch.Select(logLine => logLine.Line).ToList(), default(CancellationToken));
                                 }
-                                
+
                                 if (_firstConsoleOutputs)
                                 {
                                     HostContext.WritePerfCounter($"WorkerJobServerQueueAppendFirstConsoleOutput_{_planId.ToString()}");
@@ -454,6 +458,14 @@ namespace GitHub.Runner.Common
                             if (_bufferedRetryRecords.Remove(update.TimelineId))
                             {
                                 Trace.Verbose("Cleanup buffered timeline record for timeline: {0}.", update.TimelineId);
+                            }
+
+                            if (!_jobRecordUpdated.Task.IsCompleted &&
+                                update.PendingRecords.Any(x => x.Id == _jobTimelineRecordId && x.State != null))
+                            {
+                                // We have changed the state of the job
+                                Trace.Info("Job timeline record has been updated for the first time.");
+                                _jobRecordUpdated.TrySetResult(0);
                             }
                         }
                         catch (Exception ex)

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -145,10 +145,15 @@ namespace GitHub.Runner.Worker
                 Trace.Verbose($"Job steps: '{string.Join(", ", jobSteps.Select(x => x.DisplayName))}'");
                 HostContext.WritePerfCounter($"WorkerJobInitialized_{message.RequestId.ToString()}");
 
-                // We want to let the job is marked as in-progress before running any customer's steps as much as we can.
-                // Timeline record update background process runs every 500ms, so delay 1000ms is enough for most of the cases
-                Trace.Info($"Waiting for job to be marked as started.");
-                await Task.WhenAny(_jobServerQueue.JobRecordUpdated.Task, Task.Delay(1000));
+                if (systemConnection.Data.TryGetValue("GenerateIdTokenUrl", out var generateIdTokenUrl) &&
+                    !string.IsNullOrEmpty(generateIdTokenUrl))
+                {
+                    // Server won't issue ID_TOKEN for non-inprogress job.
+                    // If the job is trying to use OIDC feature, we want the job to be marked as in-progress before running any customer's steps as much as we can.
+                    // Timeline record update background process runs every 500ms, so delay 1000ms is enough for most of the cases
+                    Trace.Info($"Waiting for job to be marked as started.");
+                    await Task.WhenAny(_jobServerQueue.JobRecordUpdated.Task, Task.Delay(1000));
+                }
 
                 // Run all job steps
                 Trace.Info("Run all job steps.");

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -145,6 +145,11 @@ namespace GitHub.Runner.Worker
                 Trace.Verbose($"Job steps: '{string.Join(", ", jobSteps.Select(x => x.DisplayName))}'");
                 HostContext.WritePerfCounter($"WorkerJobInitialized_{message.RequestId.ToString()}");
 
+                // We want to let the job is marked as in-progress before running any customer's steps as much as we can.
+                // Timeline record update background process runs every 500ms, so delay 1000ms is enough for most of the cases
+                Trace.Info($"Waiting for job to be marked as started.");
+                await Task.WhenAny(_jobServerQueue.JobRecordUpdated.Task, Task.Delay(1000));
+
                 // Run all job steps
                 Trace.Info("Run all job steps.");
                 var stepsRunner = HostContext.GetService<IStepsRunner>();


### PR DESCRIPTION
When requesting an OIDC Id_Token, the service requires the job is in the `in-progress` state.

Since timeline records update is an async background task. you might run into a race condition that we haven't marked the job as `in-progress` when you request an ID_Token.

This is normally happening to the workflow that tries to fetch Id_Token as the first step and also doesn't download any actions.

![image](https://user-images.githubusercontent.com/1750815/132750270-4b82f06f-89ee-4943-b197-9c948f42b3c1.png)
