### PR TITLE
Ephemeral runner deletes local .runner,.credentials files after completion

### DIFF
--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -22,6 +22,7 @@ namespace GitHub.Runner.Listener.Configuration
         bool IsConfigured();
         Task ConfigureAsync(CommandSettings command);
         Task UnconfigureAsync(CommandSettings command);
+        void DeleteLocalRunnerConfig();
         RunnerSettings LoadSettings();
     }
 
@@ -329,6 +330,24 @@ namespace GitHub.Runner.Listener.Configuration
 #endif
         }
 
+        // Delete only the .runner file
+        public void DeleteLocalRunnerConfig()
+        {
+            bool isConfigured = _store.IsConfigured();
+
+            //delete settings config file
+            var currentAction = "Removing .runner";
+            if (isConfigured)
+            {
+                _store.DeleteSettings();
+                _term.WriteSuccessMessage("Removed .runner");
+            }
+            else
+            {
+                _term.WriteLine("Does not exist. Skipping " + currentAction);
+            }
+        }
+
         public async Task UnconfigureAsync(CommandSettings command)
         {
             string currentAction = string.Empty;
@@ -416,17 +435,7 @@ namespace GitHub.Runner.Listener.Configuration
                     _term.WriteLine("Does not exist. Skipping " + currentAction);
                 }
 
-                //delete settings config file
-                currentAction = "Removing .runner";
-                if (isConfigured)
-                {
-                    _store.DeleteSettings();
-                    _term.WriteSuccessMessage("Removed .runner");
-                }
-                else
-                {
-                    _term.WriteLine("Does not exist. Skipping " + currentAction);
-                }
+                DeleteLocalRunnerConfig();
             }
             catch (Exception)
             {

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -330,13 +330,27 @@ namespace GitHub.Runner.Listener.Configuration
 #endif
         }
 
-        // Delete only the .runner file
+        // Delete .runner and .credentials files
         public void DeleteLocalRunnerConfig()
         {
             bool isConfigured = _store.IsConfigured();
+            bool hasCredentials = _store.HasCredentials();
+            //delete credential config files
+            var currentAction = "Removing .credentials";
+            if (hasCredentials)
+            {
+                _store.DeleteCredential();
+                var keyManager = HostContext.GetService<IRSAKeyManager>();
+                keyManager.DeleteKey();
+                _term.WriteSuccessMessage("Removed .credentials");
+            }
+            else
+            {
+                _term.WriteLine("Does not exist. Skipping " + currentAction);
+            }
 
             //delete settings config file
-            var currentAction = "Removing .runner";
+            currentAction = "Removing .runner";
             if (isConfigured)
             {
                 _store.DeleteSettings();
@@ -419,20 +433,6 @@ namespace GitHub.Runner.Listener.Configuration
                 else
                 {
                     _term.WriteLine("Cannot connect to server, because config files are missing. Skipping removing runner from the server.");
-                }
-
-                //delete credential config files
-                currentAction = "Removing .credentials";
-                if (hasCredentials)
-                {
-                    _store.DeleteCredential();
-                    var keyManager = HostContext.GetService<IRSAKeyManager>();
-                    keyManager.DeleteKey();
-                    _term.WriteSuccessMessage("Removed .credentials");
-                }
-                else
-                {
-                    _term.WriteLine("Does not exist. Skipping " + currentAction);
                 }
 
                 DeleteLocalRunnerConfig();

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -214,7 +214,7 @@ namespace GitHub.Runner.Listener
                     var startupTypeAsString = command.GetStartupType();
                     if (string.IsNullOrEmpty(startupTypeAsString) && configuredAsService)
                     {
-                        // We need try our best to make the startup type accurate 
+                        // We need try our best to make the startup type accurate
                         // The problem is coming from runner autoupgrade, which result an old version service host binary but a newer version runner binary
                         // At that time the servicehost won't pass --startuptype to Runner.Listener while the runner is actually running as service.
                         // We will guess the startup type only when the runner is configured as service and the guess will based on whether STDOUT/STDERR/STDIN been redirect or not
@@ -478,6 +478,12 @@ namespace GitHub.Runner.Listener
                     }
 
                     messageQueueLoopTokenSource.Dispose();
+
+                    if (settings.Ephemeral)
+                    {
+                        var configManager = HostContext.GetService<IConfigurationManager>();
+                        configManager.DeleteLocalRunnerConfig();
+                    }
                 }
             }
             catch (TaskAgentAccessTokenExpiredException)

--- a/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
+++ b/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
@@ -161,7 +161,8 @@ namespace GitHub.Runner.Common.Tests.Listener.Configuration
                        "--work", _expectedWorkFolder,
                        "--auth", _expectedAuthType,
                        "--token", _expectedToken,
-                       "--labels", userLabels
+                       "--labels", userLabels,
+                       "--ephemeral",
                     });
                 trace.Info("Constructed.");
                 _store.Setup(x => x.IsConfigured()).Returns(false);
@@ -179,6 +180,7 @@ namespace GitHub.Runner.Common.Tests.Listener.Configuration
                 Assert.True(s.AgentName.Equals(_expectedAgentName));
                 Assert.True(s.PoolId.Equals(_secondRunnerGroupId));
                 Assert.True(s.WorkFolder.Equals(_expectedWorkFolder));
+                Assert.True(s.Ephemeral.Equals(true));
 
                 // validate GetAgentPoolsAsync gets called twice with automation pool type
                 _runnerServer.Verify(x => x.GetAgentPoolsAsync(It.IsAny<string>(), It.Is<TaskAgentPoolType>(p => p == TaskAgentPoolType.Automation)), Times.Exactly(2));

--- a/src/Test/L0/Listener/RunnerL0.cs
+++ b/src/Test/L0/Listener/RunnerL0.cs
@@ -149,6 +149,9 @@ namespace GitHub.Runner.Common.Tests.Listener
                     _messageListener.Verify(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()), Times.Once());
                     _messageListener.Verify(x => x.DeleteSessionAsync(), Times.Once());
                     _messageListener.Verify(x => x.DeleteMessageAsync(It.IsAny<TaskAgentMessage>()), Times.AtLeastOnce());
+
+                    // verify that we didn't try to delete local settings file (since we're not ephemeral)
+                    _configurationManager.Verify(x => x.DeleteLocalRunnerConfig(), Times.Never());
                 }
             }
         }
@@ -312,6 +315,9 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _messageListener.Verify(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()), Times.Once());
                 _messageListener.Verify(x => x.DeleteSessionAsync(), Times.Once());
                 _messageListener.Verify(x => x.DeleteMessageAsync(It.IsAny<TaskAgentMessage>()), Times.AtLeastOnce());
+
+                // verify that we did try to delete local settings file (since we're ephemeral)
+                _configurationManager.Verify(x => x.DeleteLocalRunnerConfig(), Times.Once());
             }
         }
 


### PR DESCRIPTION
Currently the `--ephemeral` flag means we "clean up" _remote_ state by de-registering the runner with the actions service after completion. However it doesn't clean up _local_ state (namely the `.runner` registration config file as well as the `.credentials` file), leading to confusion in the form of  https://github.com/actions/runner/issues/1337.
