### PR TITLE
Fix unconfiguring of runner after group changes

### DIFF
--- a/src/Runner.Common/RunnerServer.cs
+++ b/src/Runner.Common/RunnerServer.cs
@@ -257,7 +257,7 @@ namespace GitHub.Runner.Common
         public Task<List<TaskAgent>> GetAgentsAsync(string agentName)
         {
             CheckConnection(RunnerConnectionType.Generic);
-            return _genericTaskAgentClient.GetAgentsAsync(0, agentName, false); // search in all all agentPools
+            return _genericTaskAgentClient.GetAgentsAsync(-1, agentName, false); // search in all all agentPools
         }
 
         public Task<TaskAgent> ReplaceAgentAsync(int agentPoolId, TaskAgent agent)

--- a/src/Runner.Common/RunnerServer.cs
+++ b/src/Runner.Common/RunnerServer.cs
@@ -273,7 +273,7 @@ namespace GitHub.Runner.Common
 
         public Task DeleteAgentAsync(int agentId)
         {
-            return DeleteAgentAsync(agentId); // agentPool is ignored server side
+            return DeleteAgentAsync(0, agentId); // agentPool is ignored server side
         }
 
         //-----------------------------------------------------------------

--- a/src/Runner.Common/RunnerServer.cs
+++ b/src/Runner.Common/RunnerServer.cs
@@ -29,8 +29,10 @@ namespace GitHub.Runner.Common
         // Configuration
         Task<TaskAgent> AddAgentAsync(Int32 agentPoolId, TaskAgent agent);
         Task DeleteAgentAsync(int agentPoolId, int agentId);
+        Task DeleteAgentAsync(int agentId);
         Task<List<TaskAgentPool>> GetAgentPoolsAsync(string agentPoolName = null, TaskAgentPoolType poolType = TaskAgentPoolType.Automation);
         Task<List<TaskAgent>> GetAgentsAsync(int agentPoolId, string agentName = null);
+        Task<List<TaskAgent>> GetAgentsAsync(string agentName);
         Task<TaskAgent> ReplaceAgentAsync(int agentPoolId, TaskAgent agent);
 
         // messagequeue
@@ -252,6 +254,12 @@ namespace GitHub.Runner.Common
             return _genericTaskAgentClient.GetAgentsAsync(agentPoolId, agentName, false);
         }
 
+        public Task<List<TaskAgent>> GetAgentsAsync(string agentName)
+        {
+            CheckConnection(RunnerConnectionType.Generic);
+            return _genericTaskAgentClient.GetAgentsAsync(0, agentName, false); // search in all all agentPools
+        }
+
         public Task<TaskAgent> ReplaceAgentAsync(int agentPoolId, TaskAgent agent)
         {
             CheckConnection(RunnerConnectionType.Generic);
@@ -262,6 +270,12 @@ namespace GitHub.Runner.Common
         {
             CheckConnection(RunnerConnectionType.Generic);
             return _genericTaskAgentClient.DeleteAgentAsync(agentPoolId, agentId);
+        }
+
+        public Task DeleteAgentAsync(int agentId)
+        {
+            CheckConnection(RunnerConnectionType.Generic);
+            return _genericTaskAgentClient.DeleteAgentAsync(-1, agentId); // agentPool is ignored server side
         }
 
         //-----------------------------------------------------------------

--- a/src/Runner.Common/RunnerServer.cs
+++ b/src/Runner.Common/RunnerServer.cs
@@ -256,8 +256,7 @@ namespace GitHub.Runner.Common
 
         public Task<List<TaskAgent>> GetAgentsAsync(string agentName)
         {
-            CheckConnection(RunnerConnectionType.Generic);
-            return _genericTaskAgentClient.GetAgentsAsync(-1, agentName, false); // search in all all agentPools
+            return GetAgentsAsync(0, agentName); // search in all all agentPools
         }
 
         public Task<TaskAgent> ReplaceAgentAsync(int agentPoolId, TaskAgent agent)
@@ -274,8 +273,7 @@ namespace GitHub.Runner.Common
 
         public Task DeleteAgentAsync(int agentId)
         {
-            CheckConnection(RunnerConnectionType.Generic);
-            return _genericTaskAgentClient.DeleteAgentAsync(-1, agentId); // agentPool is ignored server side
+            return DeleteAgentAsync(agentId); // agentPool is ignored server side
         }
 
         //-----------------------------------------------------------------

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -415,7 +415,7 @@ namespace GitHub.Runner.Listener.Configuration
                     // Determine the service deployment type based on connection data. (Hosted/OnPremises)
                     await _runnerServer.ConnectAsync(new Uri(settings.ServerUrl), creds);
 
-                    var agents = await _runnerServer.GetAgentsAsync(settings.PoolId, settings.AgentName);
+                    var agents = await _runnerServer.GetAgentsAsync(settings.AgentName);
                     Trace.Verbose("Returns {0} agents", agents.Count);
                     TaskAgent agent = agents.FirstOrDefault();
                     if (agent == null)
@@ -424,7 +424,7 @@ namespace GitHub.Runner.Listener.Configuration
                     }
                     else
                     {
-                        await _runnerServer.DeleteAgentAsync(settings.PoolId, settings.AgentId);
+                        await _runnerServer.DeleteAgentAsync(settings.AgentId);
 
                         _term.WriteLine();
                         _term.WriteSuccessMessage("Runner removed successfully");


### PR DESCRIPTION
Fixes https://github.com/actions/runner/issues/1254

Runner names and IDs are unique within a ServiceHost
They don't need to be included when unconfiguring the runner.