### PR TITLE
Add arch to runner context

### DIFF
--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -105,6 +105,7 @@ namespace GitHub.Runner.Worker
                 }
 
                 jobContext.SetRunnerContext("os", VarUtil.OS);
+                jobContext.SetRunnerContext("arch", VarUtil.OSArchitecture);
 
                 var runnerSettings = HostContext.GetService<IConfigurationStore>().GetSettings();
                 jobContext.SetRunnerContext("name", runnerSettings.AgentName);


### PR DESCRIPTION
Fixes #1185

Got tired of waiting, and saw "name" was just added to runner context, so did the same for "arch".