### PR TITLE
Cleanup Older versions on MacOS now that we recreate node versions as needed

### DIFF
--- a/src/Misc/layoutbin/update.sh.template
+++ b/src/Misc/layoutbin/update.sh.template
@@ -161,60 +161,14 @@ if [[ "$currentplatform" == 'darwin'  && restartinteractiverunner -eq 0 ]]; then
             date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner path. Path: $path, pgid: $procgroup, root: $rootfolder" >> "$telemetryfile" 2>&1
         fi
     else
-            date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner pgid. pgid: $procgroup, root: $rootfolder" >> "$logfile" 2>&1
-            date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner pgid. pgid: $procgroup, root: $rootfolder" >> "$telemetryfile" 2>&1
-    fi
-
-    if [ $attemptedtargetedfix -eq 0 ]
-    then
-
-        date "+[%F %T-%4N] DarwinRunnerUpgrade: Defaulting to old macOS service fix" >> "$logfile" 2>&1
-        date "+[%F %T-%4N] DarwinRunnerUpgrade: Defaulting to old macOS service fix" >> "$telemetryfile" 2>&1
-        if [[ ! -e "$rootfolder/externals.2.280.3/node12/bin/node" ]]
-        then
-            mkdir -p "$rootfolder/externals.2.280.3/node12/bin"
-            cp "$rootfolder/externals/node12/bin/node" "$rootfolder/externals.2.280.3/node12/bin/node"
-        fi
-
-        if [[ ! -e "$rootfolder/externals.2.280.2/node12/bin/node" ]]
-        then
-            mkdir -p "$rootfolder/externals.2.280.2/node12/bin"
-            cp "$rootfolder/externals/node12/bin/node" "$rootfolder/externals.2.280.2/node12/bin/node"
-        fi
-
-        if [[ ! -e "$rootfolder/externals.2.280.1/node12/bin/node" ]]
-        then
-            mkdir -p "$rootfolder/externals.2.280.1/node12/bin"
-            cp "$rootfolder/externals/node12/bin/node" "$rootfolder/externals.2.280.1/node12/bin/node"
-        fi
-
-        # GHES 3.2
-        if [[ ! -e "$rootfolder/externals.2.279.0/node12/bin/node" ]]
-        then
-            mkdir -p "$rootfolder/externals.2.279.0/node12/bin"
-            cp "$rootfolder/externals/node12/bin/node" "$rootfolder/externals.2.279.0/node12/bin/node"
-        fi
-
-        # GHES 3.1.2 or later
-        if [[ ! -e "$rootfolder/externals.2.278.0/node12/bin/node" ]]
-        then
-            mkdir -p "$rootfolder/externals.2.278.0/node12/bin"
-            cp "$rootfolder/externals/node12/bin/node" "$rootfolder/externals.2.278.0/node12/bin/node"
-        fi
-
-        # GHES 3.1.0
-        if [[ ! -e "$rootfolder/externals.2.276.1/node12/bin/node" ]]
-        then
-            mkdir -p "$rootfolder/externals.2.276.1/node12/bin"
-            cp "$rootfolder/externals/node12/bin/node" "$rootfolder/externals.2.276.1/node12/bin/node"
-        fi
-
-        # GHES 3.0
-        if [[ ! -e "$rootfolder/externals.2.273.5/node12/bin/node" ]]
-        then
-            mkdir -p "$rootfolder/externals.2.273.5/node12/bin"
-            cp "$rootfolder/externals/node12/bin/node" "$rootfolder/externals.2.273.5/node12/bin/node"
-        fi
+            runproc=$(ps x -o pgid,command | grep "$rootfolder/run.sh" | grep -v grep | awk '{print $1}')
+            if [[ $? -eq 0 && -n "$runproc" ]]
+                date "+[%F %T-%4N] Running as ephemeral using run.sh, no need to recreate node folder" >> "$logfile" 2>&1
+            fi
+            else
+                date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner pgid. pgid: $procgroup, root: $rootfolder" >> "$logfile" 2>&1
+                date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner pgid. pgid: $procgroup, root: $rootfolder" >> "$telemetryfile" 2>&1
+            fi
     fi
 fi
 

--- a/src/Misc/layoutbin/update.sh.template
+++ b/src/Misc/layoutbin/update.sh.template
@@ -161,10 +161,10 @@ if [[ "$currentplatform" == 'darwin'  && restartinteractiverunner -eq 0 ]]; then
             date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner path. Path: $path, pgid: $procgroup, root: $rootfolder" >> "$telemetryfile" 2>&1
         fi
     else
-            runproc=$(ps x -o pgid,command | grep "$rootfolder/run.sh" | grep -v grep | awk '{print $1}')
+            runproc=$(ps x -o pgid,command | grep "run.sh" | grep -v grep | awk '{print $1}')
             if [[ $? -eq 0 && -n "$runproc" ]]
+            then
                 date "+[%F %T-%4N] Running as ephemeral using run.sh, no need to recreate node folder" >> "$logfile" 2>&1
-            fi
             else
                 date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner pgid. pgid: $procgroup, root: $rootfolder" >> "$logfile" 2>&1
                 date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner pgid. pgid: $procgroup, root: $rootfolder" >> "$telemetryfile" 2>&1

--- a/src/Misc/layoutbin/update.sh.template
+++ b/src/Misc/layoutbin/update.sh.template
@@ -161,14 +161,14 @@ if [[ "$currentplatform" == 'darwin'  && restartinteractiverunner -eq 0 ]]; then
             date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner path. Path: $path, pgid: $procgroup, root: $rootfolder" >> "$telemetryfile" 2>&1
         fi
     else
-            runproc=$(ps x -o pgid,command | grep "run.sh" | grep -v grep | awk '{print $1}')
-            if [[ $? -eq 0 && -n "$runproc" ]]
-            then
-                date "+[%F %T-%4N] Running as ephemeral using run.sh, no need to recreate node folder" >> "$logfile" 2>&1
-            else
-                date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner pgid. pgid: $procgroup, root: $rootfolder" >> "$logfile" 2>&1
-                date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner pgid. pgid: $procgroup, root: $rootfolder" >> "$telemetryfile" 2>&1
-            fi
+        runproc=$(ps x -o pgid,command | grep "run.sh" | grep -v grep | awk '{print $1}')
+        if [[ $? -eq 0 && -n "$runproc" ]]
+        then
+            date "+[%F %T-%4N] Running as ephemeral using run.sh, no need to recreate node folder" >> "$logfile" 2>&1
+        else
+            date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner pgid. pgid: $procgroup, root: $rootfolder" >> "$logfile" 2>&1
+            date "+[%F %T-%4N] DarwinRunnerUpgrade: Failed to find runner pgid. pgid: $procgroup, root: $rootfolder" >> "$telemetryfile" 2>&1
+        fi
     fi
 fi
 

--- a/src/Runner.Listener/SelfUpdater.cs
+++ b/src/Runner.Listener/SelfUpdater.cs
@@ -75,11 +75,9 @@ namespace GitHub.Runner.Listener
                 Trace.Info($"All running job has exited.");
 
                 // We need to keep runner backup around for macOS until we fixed https://github.com/actions/runner/issues/743
-#if !OS_OSX
                 // delete runner backup
                 DeletePreviousVersionRunnerBackup(token);
                 Trace.Info($"Delete old version runner backup.");
-#endif
                 // generate update script from template
                 await UpdateRunnerUpdateStateAsync("Generate and execute update script.");
 


### PR DESCRIPTION
Follow up to https://github.com/actions/runner/pull/1381

We originally kept a bunch of older versions of mac runners, as OSX's gatekeeper would prevent us from spawning new processes if we deleted the original process on disk. Now, we find out what version was running and dynamically recreate it, so we only need to keep one older version. This PR now readds the behavior that deletes old runner versions on upgrade, and adds telemetry for upgrading ephemeral runners as they don't use node so they don't need to recreate old versions.