### PR TITLE
Add secret source to start job step

### DIFF
--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -141,10 +141,11 @@ namespace GitHub.Runner.Worker
                         context.Output($"Fail to parse and display GITHUB_TOKEN permissions list: {ex.Message}");
                         Trace.Error(ex);
                     }
-                    
-                    var secretSource = context.GetGitHubContext("secret_source");
-                    ArgUtil.NotNull(secretSource, nameof(secretSource));
-                    context.Output($"Secret source: {secretSource}");
+
+                    if (!string.IsNullOrEmpty(context.GetGitHubContext("secret_source")))
+                    {
+                        context.Output($"Secret source: {context.GetGitHubContext("secret_source")}");
+                    }
 
                     var repoFullName = context.GetGitHubContext("repository");
                     ArgUtil.NotNull(repoFullName, nameof(repoFullName));

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -142,16 +142,9 @@ namespace GitHub.Runner.Worker
                         Trace.Error(ex);
                     }
                     
-                    try 
-                    {
-                        var secretSource = jobContext.Global.Variables.Get("system.secretSource");
-                        context.Output($"Using secrets from: {secretSource}");
-                    } 
-                    catch (Exception ex)
-                    {
-                        context.Output($"Fail to parse and display secretSource: {ex.Message}");
-                        Trace.Error(ex);
-                    }
+                    var secretSource = context.GetGitHubContext("secret_source");
+                    ArgUtil.NotNull(secretSource, nameof(secretSource));
+                    context.Output($"Secret source: {secretSource}");
 
                     var repoFullName = context.GetGitHubContext("repository");
                     ArgUtil.NotNull(repoFullName, nameof(repoFullName));

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -142,9 +142,10 @@ namespace GitHub.Runner.Worker
                         Trace.Error(ex);
                     }
 
-                    if (!string.IsNullOrEmpty(context.GetGitHubContext("secret_source")))
+                    var secretSource = context.GetGitHubContext("secret_source");
+                    if (!string.IsNullOrEmpty(secretSource))
                     {
-                        context.Output($"Secret source: {context.GetGitHubContext("secret_source")}");
+                        context.Output($"Secret source: {secretSource}");
                     }
 
                     var repoFullName = context.GetGitHubContext("repository");

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -141,6 +141,17 @@ namespace GitHub.Runner.Worker
                         context.Output($"Fail to parse and display GITHUB_TOKEN permissions list: {ex.Message}");
                         Trace.Error(ex);
                     }
+                    
+                    try 
+                    {
+                        var secretSource = jobContext.Global.Variables.Get("system.secretSource");
+                        context.Output($"Using secrets from: {secretSource}");
+                    } 
+                    catch (Exception ex)
+                    {
+                        context.Output($"Fail to parse and display secretSource: {ex.Message}");
+                        Trace.Error(ex);
+                    }
 
                     var repoFullName = context.GetGitHubContext("repository");
                     ArgUtil.NotNull(repoFullName, nameof(repoFullName));

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -102,6 +102,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             _message = new Pipelines.AgentJobRequestMessage(plan, timeline, jobId, "test", "test", null, null, null, new Dictionary<string, VariableValue>(), new List<MaskHint>(), new Pipelines.JobResources(), new Pipelines.ContextData.DictionaryContextData(), new Pipelines.WorkspaceOptions(), steps, null, null, null, null);
             GitHubContext github = new GitHubContext();
             github["repository"] = new Pipelines.ContextData.StringContextData("actions/runner");
+            github["secret_source"] = new Pipelines.ContextData.StringContextData("Actions");
             _message.ContextData.Add("github", github);
 
             hc.SetSingleton(_actionManager.Object);


### PR DESCRIPTION
Display secret source for actions runs (Actions/Dependabot/None). This will help users determine which secrets are being used.

![image](https://user-images.githubusercontent.com/60276246/142073246-7a6e26c0-db23-4cf9-8ec3-aabdfa55004e.png)
