### PR TITLE
Allow to optionally skip self-update

### DIFF
--- a/src/Runner.Listener/SelfUpdater.cs
+++ b/src/Runner.Listener/SelfUpdater.cs
@@ -59,6 +59,12 @@ namespace GitHub.Runner.Listener
                     return false;
                 }
 
+                if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_SKIP_SELF_UPDATE")))
+                {
+                    Trace.Info($"An update is available, but it was chosen to skip the self-update.");
+                    return false;
+                }
+
                 Trace.Info($"An update is available.");
 
                 // Print console line that warn user not shutdown runner.


### PR DESCRIPTION
When using infrastructure as code, containers and recipes, pinning versions for reproducibility is a good practice. Usually docker container images contain static tools and binaries and the docker image
is tagged with a specific version.

Constructing a docker image of a runner with a specific runner version and then self-updating itself doesn't seem that natural, instead the docker image should use whatever that binary was built/tagged to.

Additionally to this - this concept doesn't play well when using ephemeral runners and kuberentes (e.g. https://github.com/actions-runner-controller/actions-runner-controller). First of all, we need to pay the price of downloading/self-updating every single ephemeral pod for every single
job which causes delays in execution. Secondly this doesn't work well and containers may get stuck

Related issues that will be solved with this:
- https://github.com/actions/runner/issues/1396
- https://github.com/actions/runner/issues/246
- https://github.com/actions/runner/issues/485
- https://github.com/actions/runner/issues/422
- https://github.com/actions/runner/issues/442

This will optionally skip self update logic if runner the environment variable `GITHUB_ACTIONS_SKIP_SELF_UPDATE` is set to a truly value