### PR TITLE
Fix test failure: /bin/sleep on Macos 11 (Monterey) ARM64 does not accept the "s" suffix

### DIFF
--- a/src/Test/L0/ProcessInvokerL0.cs
+++ b/src/Test/L0/ProcessInvokerL0.cs
@@ -197,7 +197,7 @@ namespace GitHub.Runner.Common.Tests
 #if OS_WINDOWS
                 execTask = processInvoker.ExecuteAsync("", "cmd.exe", $"/c \"choice /T {SecondsToRun} /D y\"", null, tokenSource.Token);
 #else
-                execTask = processInvoker.ExecuteAsync("", "bash", $"-c \"sleep {SecondsToRun}s\"", null, tokenSource.Token);
+                execTask = processInvoker.ExecuteAsync("", "bash", $"-c \"sleep {SecondsToRun}\"", null, tokenSource.Token);
 #endif
                 await Task.Delay(500);
                 tokenSource.Cancel();


### PR DESCRIPTION
This PR just removes the trailing "s", which is superfluous anyway, since `/bin/sleep <number of seconds>` is required to work by POSIX. Previous versions of Macos apparently ignored everything following a number and just treated the preceding number as seconds, but on Macos 11 (Monterey) ARM64 `/bin/sleep 10s` errors.

This fix is necessary for a failing test in my Macos ARM64 port of the runner (https://github.com/hkratz/gha-runner-osx-arm64/pull/2) and it is quite likely that this test would fail on x86-64 Macos Monterey as well.