### PR TITLE
Add masks for multiline secrets from `::add-mask::`

### DIFF
--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -383,10 +383,10 @@ namespace GitHub.Runner.Worker
                 Trace.Info($"Add new secret mask with length of {command.Data.Length}");
 
                 // Also add each individual line. Typically individual lines are processed from STDOUT of child processes.
-                var split = command.Data.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                var split = command.Data.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                 foreach (var item in split)
                 {
-                    HostContext.SecretMasker.AddValue(item.Trim());
+                    HostContext.SecretMasker.AddValue(item);
                 }
             }
         }

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -381,6 +381,13 @@ namespace GitHub.Runner.Worker
 
                 HostContext.SecretMasker.AddValue(command.Data);
                 Trace.Info($"Add new secret mask with length of {command.Data.Length}");
+
+                // Also add each individual line. Typically individual lines are processed from STDOUT of child processes.
+                var split = command.Data.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var item in split)
+                {
+                    HostContext.SecretMasker.AddValue(item.Trim());
+                }
             }
         }
     }

--- a/src/Runner.Worker/Worker.cs
+++ b/src/Runner.Worker/Worker.cs
@@ -22,12 +22,13 @@ namespace GitHub.Runner.Worker
     {
         private readonly TimeSpan _workerStartTimeout = TimeSpan.FromSeconds(30);
         private ManualResetEvent _completedCommand = new ManualResetEvent(false);
-        
+
         // Do not mask the values of these secrets
-        private static HashSet<String> SecretVariableMaskWhitelist = new HashSet<String>(StringComparer.OrdinalIgnoreCase){ 
+        private static HashSet<String> SecretVariableMaskWhitelist = new HashSet<String>(StringComparer.OrdinalIgnoreCase)
+        {
             Constants.Variables.Actions.StepDebug,
             Constants.Variables.Actions.RunnerDebug
-            };
+        };
 
         public async Task<int> RunAsync(string pipeIn, string pipeOut)
         {
@@ -138,10 +139,10 @@ namespace GitHub.Runner.Worker
                     HostContext.SecretMasker.AddValue(value);
 
                     // Also add each individual line. Typically individual lines are processed from STDOUT of child processes.
-                    var split = value.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                    var split = value.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                     foreach (var item in split)
                     {
-                        HostContext.SecretMasker.AddValue(item.Trim());
+                        HostContext.SecretMasker.AddValue(item);
                     }
                 }
             }

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -122,14 +122,14 @@ namespace GitHub.Runner.Common.Tests.Worker
             {
                 _ec.Object.Global.EnvironmentVariables = new Dictionary<string, string>();
                 var expressionValues = new DictionaryContextData
-            {
-                ["env"] =
+                {
+                    ["env"] =
 #if OS_WINDOWS
                         new DictionaryContextData{ { Constants.Variables.Actions.AllowUnsupportedStopCommandTokens, new StringContextData(allowUnsupportedStopCommandTokens) }}
 #else
-                        new CaseSensitiveDictionaryContextData{ { Constants.Variables.Actions.AllowUnsupportedStopCommandTokens, new StringContextData(allowUnsupportedStopCommandTokens) }}
+                        new CaseSensitiveDictionaryContextData { { Constants.Variables.Actions.AllowUnsupportedStopCommandTokens, new StringContextData(allowUnsupportedStopCommandTokens) } }
 #endif
-            };
+                };
                 _ec.Setup(x => x.ExpressionValues).Returns(expressionValues);
                 _ec.Setup(x => x.JobTelemetry).Returns(new List<JobTelemetry>());
 
@@ -426,13 +426,20 @@ namespace GitHub.Runner.Common.Tests.Worker
             using (TestHostContext hc = CreateTestContext())
             {
                 // Act
-                _commandManager.TryProcessCommand(_ec.Object, $"::add-mask::abc%0Ddef%0Aghi", null);
+                _commandManager.TryProcessCommand(_ec.Object, $"::add-mask::abc%0Ddef%0Aghi%0D%0Ajkl", null);
+                _commandManager.TryProcessCommand(_ec.Object, $"::add-mask:: %0D  %0A   %0D%0A    %0D", null);
 
                 // Assert
                 Assert.Equal("***", hc.SecretMasker.MaskSecrets("abc"));
                 Assert.Equal("***", hc.SecretMasker.MaskSecrets("def"));
                 Assert.Equal("***", hc.SecretMasker.MaskSecrets("ghi"));
-                Assert.Equal("***", hc.SecretMasker.MaskSecrets("abc\rdef\nghi"));
+                Assert.Equal("***", hc.SecretMasker.MaskSecrets("jkl"));
+                Assert.Equal("***", hc.SecretMasker.MaskSecrets("abc\rdef\nghi\r\njkl"));
+                Assert.Equal("", hc.SecretMasker.MaskSecrets(""));
+                Assert.Equal(" ", hc.SecretMasker.MaskSecrets(" "));
+                Assert.Equal("  ", hc.SecretMasker.MaskSecrets("  "));
+                Assert.Equal("   ", hc.SecretMasker.MaskSecrets("   "));
+                Assert.Equal("    ", hc.SecretMasker.MaskSecrets("    "));
             }
         }
 

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -418,6 +418,24 @@ namespace GitHub.Runner.Common.Tests.Worker
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void AddMaskWithMultilineValue()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // Act
+                _commandManager.TryProcessCommand(_ec.Object, $"::add-mask::abc%0Ddef%0Aghi", null);
+
+                // Assert
+                Assert.Equal("***", hc.SecretMasker.MaskSecrets("abc"));
+                Assert.Equal("***", hc.SecretMasker.MaskSecrets("def"));
+                Assert.Equal("***", hc.SecretMasker.MaskSecrets("ghi"));
+                Assert.Equal("***", hc.SecretMasker.MaskSecrets("abc\rdef\nghi"));
+            }
+        }
+
         private TestHostContext CreateTestContext([CallerMemberName] string testName = "")
         {
             var hostContext = new TestHostContext(this, testName);
@@ -431,6 +449,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 new InternalPluginSetRepoPathCommandExtension(),
                 new SetEnvCommandExtension(),
                 new WarningCommandExtension(),
+                new AddMaskCommandExtension(),
             };
             foreach (var command in commands)
             {


### PR DESCRIPTION
When the runner gets a secret coming from the service as part of the job message, if the secret has multiline, the runner will break the multiline and add a secret masker to each line. 

However, we don't have the same logic when an action or step tries to register a new secret masker with `::add-mask::`.

We should copy the logic and do the same thing with `::add-mask::`