### PR TITLE
Add boilerplate to support using kubernetes as container provider

### DIFF
--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -376,6 +376,14 @@ namespace GitHub.Runner.Common
         }
 
         /// <summary>
+        /// Register a default dynamic service.
+        /// </summary>
+        public void RegisterService(Type type, Type target)
+        {
+            _serviceTypes.TryAdd(type, target);
+        }
+
+        /// <summary>
         /// Creates a new instance of T.
         /// </summary>
         public T CreateService<T>() where T : class, IRunnerService

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -530,12 +530,12 @@ namespace GitHub.Runner.Worker
             executionContext.Output($"##[group]Pull down action image '{setupInfo.Container.Image}'");
 
             // Pull down docker image with retry up to 3 times
-            var dockerManager = HostContext.GetService<IDockerCommandManager>();
+            var containerManager = HostContext.GetService<IContainerCommandManager>();
             int retryCount = 0;
             int pullExitCode = 0;
             while (retryCount < 3)
             {
-                pullExitCode = await dockerManager.DockerPull(executionContext, setupInfo.Container.Image);
+                pullExitCode = await containerManager.DockerPull(executionContext, setupInfo.Container.Image);
                 if (pullExitCode == 0)
                 {
                     break;
@@ -574,13 +574,13 @@ namespace GitHub.Runner.Worker
             executionContext.Output($"##[group]Build container for action use: '{setupInfo.Container.Dockerfile}'.");
 
             // Build docker image with retry up to 3 times
-            var dockerManager = HostContext.GetService<IDockerCommandManager>();
+            var containerManager = HostContext.GetService<IContainerCommandManager>();
             int retryCount = 0;
             int buildExitCode = 0;
-            var imageName = $"{dockerManager.DockerInstanceLabel}:{Guid.NewGuid().ToString("N")}";
+            var imageName = $"{containerManager.DockerInstanceLabel}:{Guid.NewGuid().ToString("N")}";
             while (retryCount < 3)
             {
-                buildExitCode = await dockerManager.DockerBuild(
+                buildExitCode = await containerManager.DockerBuild(
                     executionContext,
                     setupInfo.Container.WorkingDirectory,
                     setupInfo.Container.Dockerfile,

--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -11,33 +11,9 @@ using GitHub.Runner.Sdk;
 
 namespace GitHub.Runner.Worker.Container
 {
-    [ServiceLocator(Default = typeof(DockerCommandManager))]
-    public interface IDockerCommandManager : IRunnerService
+    public class DockerCommandManager : RunnerService, IContainerCommandManager
     {
-        string DockerPath { get; }
-        string DockerInstanceLabel { get; }
-        Task<DockerVersion> DockerVersion(IExecutionContext context);
-        Task<int> DockerPull(IExecutionContext context, string image);
-        Task<int> DockerPull(IExecutionContext context, string image, string configFileDirectory);
-        Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string dockerContext, string tag);
-        Task<string> DockerCreate(IExecutionContext context, ContainerInfo container);
-        Task<int> DockerRun(IExecutionContext context, ContainerInfo container, EventHandler<ProcessDataReceivedEventArgs> stdoutDataReceived, EventHandler<ProcessDataReceivedEventArgs> stderrDataReceived);
-        Task<int> DockerStart(IExecutionContext context, string containerId);
-        Task<int> DockerLogs(IExecutionContext context, string containerId);
-        Task<List<string>> DockerPS(IExecutionContext context, string options);
-        Task<int> DockerRemove(IExecutionContext context, string containerId);
-        Task<int> DockerNetworkCreate(IExecutionContext context, string network);
-        Task<int> DockerNetworkRemove(IExecutionContext context, string network);
-        Task<int> DockerNetworkPrune(IExecutionContext context);
-        Task<int> DockerExec(IExecutionContext context, string containerId, string options, string command);
-        Task<int> DockerExec(IExecutionContext context, string containerId, string options, string command, List<string> outputs);
-        Task<List<string>> DockerInspect(IExecutionContext context, string dockerObject, string options);
-        Task<List<PortMapping>> DockerPort(IExecutionContext context, string containerId);
-        Task<int> DockerLogin(IExecutionContext context, string configFileDirectory, string registry, string username, string password);
-    }
-
-    public class DockerCommandManager : RunnerService, IDockerCommandManager
-    {
+        public string Type { get { return "docker"; } }
         public string DockerPath { get; private set; }
 
         public string DockerInstanceLabel { get; private set; }

--- a/src/Runner.Worker/Container/IContainerCommandManager.cs
+++ b/src/Runner.Worker/Container/IContainerCommandManager.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using GitHub.Runner.Common;
+using GitHub.Runner.Sdk;
+
+namespace GitHub.Runner.Worker.Container
+{
+    [ServiceLocator(Default = typeof(DockerCommandManager))]
+    public interface IContainerCommandManager : IRunnerService
+    {
+        string Type { get; }
+        string DockerPath { get; }
+        string DockerInstanceLabel { get; }
+        Task<DockerVersion> DockerVersion(IExecutionContext context);
+        Task<int> DockerPull(IExecutionContext context, string image);
+        Task<int> DockerPull(IExecutionContext context, string image, string configFileDirectory);
+        Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string dockerContext, string tag);
+        Task<string> DockerCreate(IExecutionContext context, ContainerInfo container);
+        Task<int> DockerRun(IExecutionContext context, ContainerInfo container, EventHandler<ProcessDataReceivedEventArgs> stdoutDataReceived, EventHandler<ProcessDataReceivedEventArgs> stderrDataReceived);
+        Task<int> DockerStart(IExecutionContext context, string containerId);
+        Task<int> DockerLogs(IExecutionContext context, string containerId);
+        Task<List<string>> DockerPS(IExecutionContext context, string options);
+        Task<int> DockerRemove(IExecutionContext context, string containerId);
+        Task<int> DockerNetworkCreate(IExecutionContext context, string network);
+        Task<int> DockerNetworkRemove(IExecutionContext context, string network);
+        Task<int> DockerNetworkPrune(IExecutionContext context);
+        Task<int> DockerExec(IExecutionContext context, string containerId, string options, string command);
+        Task<int> DockerExec(IExecutionContext context, string containerId, string options, string command, List<string> outputs);
+        Task<List<string>> DockerInspect(IExecutionContext context, string dockerObject, string options);
+        Task<List<PortMapping>> DockerPort(IExecutionContext context, string containerId);
+        Task<int> DockerLogin(IExecutionContext context, string configFileDirectory, string registry, string username, string password);
+    }
+}

--- a/src/Runner.Worker/Container/KubernetesCommandManager.cs
+++ b/src/Runner.Worker/Container/KubernetesCommandManager.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using GitHub.Runner.Common;
+using GitHub.Runner.Sdk;
+
+namespace GitHub.Runner.Worker.Container
+{
+    public class KubernetesCommandManager : RunnerService, IContainerCommandManager
+    {
+        public string Type { get { return "kubernetes"; } }
+        public string DockerPath { get; private set; }
+
+        public string DockerInstanceLabel { get; private set; }
+
+        public Task<DockerVersion> DockerVersion(IExecutionContext context)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerPull(IExecutionContext context, string image)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerPull(IExecutionContext context, string image, string configFileDirectory)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string dockerContext, string tag)
+        {
+           throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<string> DockerCreate(IExecutionContext context, ContainerInfo container)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerRun(IExecutionContext context, ContainerInfo container, EventHandler<ProcessDataReceivedEventArgs> stdoutDataReceived, EventHandler<ProcessDataReceivedEventArgs> stderrDataReceived)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerStart(IExecutionContext context, string containerId)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerRemove(IExecutionContext context, string containerId)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerLogs(IExecutionContext context, string containerId)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<List<string>> DockerPS(IExecutionContext context, string options)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerNetworkCreate(IExecutionContext context, string network)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerNetworkRemove(IExecutionContext context, string network)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerNetworkPrune(IExecutionContext context)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerExec(IExecutionContext context, string containerId, string options, string command)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerExec(IExecutionContext context, string containerId, string options, string command, List<string> output)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<List<string>> DockerInspect(IExecutionContext context, string dockerObject, string options)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<List<PortMapping>> DockerPort(IExecutionContext context, string containerId)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+
+        public Task<int> DockerLogin(IExecutionContext context, string configFileDirectory, string registry, string username, string password)
+        {
+            throw new NotImplementedException("Kubernetes support to be implemented");
+        }
+    }
+}

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -24,12 +24,12 @@ namespace GitHub.Runner.Worker
 
     public class ContainerOperationProvider : RunnerService, IContainerOperationProvider
     {
-        private IDockerCommandManager _dockerManager;
+        private IContainerCommandManager _containerManager;
 
         public override void Initialize(IHostContext hostContext)
         {
             base.Initialize(hostContext);
-            _dockerManager = HostContext.GetService<IDockerCommandManager>();
+            _containerManager = HostContext.GetService<IContainerCommandManager>();
         }
 
         public async Task StartContainersAsync(IExecutionContext executionContext, object data)
@@ -92,7 +92,7 @@ namespace GitHub.Runner.Worker
 
             // Check docker client/server version
             executionContext.Output("##[group]Checking docker version");
-            DockerVersion dockerVersion = await _dockerManager.DockerVersion(executionContext);
+            DockerVersion dockerVersion = await _containerManager.DockerVersion(executionContext);
             executionContext.Output("##[endgroup]");
 
             ArgUtil.NotNull(dockerVersion.ServerVersion, nameof(dockerVersion.ServerVersion));
@@ -106,26 +106,26 @@ namespace GitHub.Runner.Worker
 
             if (dockerVersion.ServerVersion < requiredDockerEngineAPIVersion)
             {
-                throw new NotSupportedException($"Min required docker engine API server version is '{requiredDockerEngineAPIVersion}', your docker ('{_dockerManager.DockerPath}') server version is '{dockerVersion.ServerVersion}'");
+                throw new NotSupportedException($"Min required docker engine API server version is '{requiredDockerEngineAPIVersion}', your docker ('{_containerManager.DockerPath}') server version is '{dockerVersion.ServerVersion}'");
             }
             if (dockerVersion.ClientVersion < requiredDockerEngineAPIVersion)
             {
-                throw new NotSupportedException($"Min required docker engine API client version is '{requiredDockerEngineAPIVersion}', your docker ('{_dockerManager.DockerPath}') client version is '{dockerVersion.ClientVersion}'");
+                throw new NotSupportedException($"Min required docker engine API client version is '{requiredDockerEngineAPIVersion}', your docker ('{_containerManager.DockerPath}') client version is '{dockerVersion.ClientVersion}'");
             }
 
             // Clean up containers left by previous runs
             executionContext.Output("##[group]Clean up resources from previous jobs");
-            var staleContainers = await _dockerManager.DockerPS(executionContext, $"--all --quiet --no-trunc --filter \"label={_dockerManager.DockerInstanceLabel}\"");
+            var staleContainers = await _containerManager.DockerPS(executionContext, $"--all --quiet --no-trunc --filter \"label={_containerManager.DockerInstanceLabel}\"");
             foreach (var staleContainer in staleContainers)
             {
-                int containerRemoveExitCode = await _dockerManager.DockerRemove(executionContext, staleContainer);
+                int containerRemoveExitCode = await _containerManager.DockerRemove(executionContext, staleContainer);
                 if (containerRemoveExitCode != 0)
                 {
                     executionContext.Warning($"Delete stale containers failed, docker rm fail with exit code {containerRemoveExitCode} for container {staleContainer}");
                 }
             }
 
-            int networkPruneExitCode = await _dockerManager.DockerNetworkPrune(executionContext);
+            int networkPruneExitCode = await _containerManager.DockerNetworkPrune(executionContext);
             if (networkPruneExitCode != 0)
             {
                 executionContext.Warning($"Delete stale container networks failed, docker network prune fail with exit code {networkPruneExitCode}");
@@ -208,7 +208,7 @@ namespace GitHub.Runner.Worker
             int pullExitCode = 0;
             while (retryCount < 3)
             {
-                pullExitCode = await _dockerManager.DockerPull(executionContext, container.ContainerImage, configLocation);
+                pullExitCode = await _containerManager.DockerPull(executionContext, container.ContainerImage, configLocation);
                 if (pullExitCode == 0)
                 {
                     break;
@@ -266,11 +266,11 @@ namespace GitHub.Runner.Worker
                 container.ContainerEntryPointArgs = "\"-f\" \"/dev/null\"";
             }
 
-            container.ContainerId = await _dockerManager.DockerCreate(executionContext, container);
+            container.ContainerId = await _containerManager.DockerCreate(executionContext, container);
             ArgUtil.NotNullOrEmpty(container.ContainerId, nameof(container.ContainerId));
 
             // Start container
-            int startExitCode = await _dockerManager.DockerStart(executionContext, container.ContainerId);
+            int startExitCode = await _containerManager.DockerStart(executionContext, container.ContainerId);
             if (startExitCode != 0)
             {
                 throw new InvalidOperationException($"Docker start fail with exit code {startExitCode}");
@@ -279,12 +279,12 @@ namespace GitHub.Runner.Worker
             try
             {
                 // Make sure container is up and running
-                var psOutputs = await _dockerManager.DockerPS(executionContext, $"--all --filter id={container.ContainerId} --filter status=running --no-trunc --format \"{{{{.ID}}}} {{{{.Status}}}}\"");
+                var psOutputs = await _containerManager.DockerPS(executionContext, $"--all --filter id={container.ContainerId} --filter status=running --no-trunc --format \"{{{{.ID}}}} {{{{.Status}}}}\"");
                 if (psOutputs.FirstOrDefault(x => !string.IsNullOrEmpty(x))?.StartsWith(container.ContainerId) != true)
                 {
                     // container is not up and running, pull docker log for this container.
-                    await _dockerManager.DockerPS(executionContext, $"--all --filter id={container.ContainerId} --no-trunc --format \"{{{{.ID}}}} {{{{.Status}}}}\"");
-                    int logsExitCode = await _dockerManager.DockerLogs(executionContext, container.ContainerId);
+                    await _containerManager.DockerPS(executionContext, $"--all --filter id={container.ContainerId} --no-trunc --format \"{{{{.ID}}}} {{{{.Status}}}}\"");
+                    int logsExitCode = await _containerManager.DockerLogs(executionContext, container.ContainerId);
                     if (logsExitCode != 0)
                     {
                         executionContext.Warning($"Docker logs fail with exit code {logsExitCode}");
@@ -309,7 +309,7 @@ namespace GitHub.Runner.Worker
                     ["ports"] = new DictionaryContextData(),
                     ["network"] = new StringContextData(container.ContainerNetwork)
                 };
-                container.AddPortMappings(await _dockerManager.DockerPort(executionContext, container.ContainerId));
+                container.AddPortMappings(await _containerManager.DockerPort(executionContext, container.ContainerId));
                 foreach (var port in container.PortMappings)
                 {
                     (service["ports"] as DictionaryContextData)[port.ContainerPort] = new StringContextData(port.HostPort);
@@ -319,7 +319,7 @@ namespace GitHub.Runner.Worker
             else
             {
                 var configEnvFormat = "--format \"{{range .Config.Env}}{{println .}}{{end}}\"";
-                var containerEnv = await _dockerManager.DockerInspect(executionContext, container.ContainerId, configEnvFormat);
+                var containerEnv = await _containerManager.DockerInspect(executionContext, container.ContainerId, configEnvFormat);
                 container.ContainerRuntimePath = DockerUtil.ParsePathFromConfigEnv(containerEnv);
                 executionContext.JobContext.Container["id"] = new StringContextData(container.ContainerId);
             }
@@ -336,7 +336,7 @@ namespace GitHub.Runner.Worker
             {
                 executionContext.Output($"Stop and remove container: {container.ContainerDisplayName}");
 
-                int rmExitCode = await _dockerManager.DockerRemove(executionContext, container.ContainerId);
+                int rmExitCode = await _containerManager.DockerRemove(executionContext, container.ContainerId);
                 if (rmExitCode != 0)
                 {
                     executionContext.Warning($"Docker rm fail with exit code {rmExitCode}");
@@ -396,7 +396,7 @@ namespace GitHub.Runner.Worker
         {
             Trace.Entering();
             ArgUtil.NotNull(executionContext, nameof(executionContext));
-            int networkExitCode = await _dockerManager.DockerNetworkCreate(executionContext, network);
+            int networkExitCode = await _containerManager.DockerNetworkCreate(executionContext, network);
             if (networkExitCode != 0)
             {
                 throw new InvalidOperationException($"Docker network create failed with exit code {networkExitCode}");
@@ -411,7 +411,7 @@ namespace GitHub.Runner.Worker
 
             executionContext.Output($"Remove container network: {network}");
 
-            int removeExitCode = await _dockerManager.DockerNetworkRemove(executionContext, network);
+            int removeExitCode = await _containerManager.DockerNetworkRemove(executionContext, network);
             if (removeExitCode != 0)
             {
                 executionContext.Warning($"Docker network rm failed with exit code {removeExitCode}");
@@ -421,7 +421,7 @@ namespace GitHub.Runner.Worker
         private async Task ContainerHealthcheck(IExecutionContext executionContext, ContainerInfo container)
         {
             string healthCheck = "--format=\"{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}\"";
-            string serviceHealth = (await _dockerManager.DockerInspect(context: executionContext, dockerObject: container.ContainerId, options: healthCheck)).FirstOrDefault();
+            string serviceHealth = (await _containerManager.DockerInspect(context: executionContext, dockerObject: container.ContainerId, options: healthCheck)).FirstOrDefault();
             if (string.IsNullOrEmpty(serviceHealth))
             {
                 // Container has no HEALTHCHECK
@@ -433,7 +433,7 @@ namespace GitHub.Runner.Worker
                 TimeSpan backoff = BackoffTimerHelper.GetExponentialBackoff(retryCount, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(32), TimeSpan.FromSeconds(2));
                 executionContext.Output($"{container.ContainerNetworkAlias} service is starting, waiting {backoff.Seconds} seconds before checking again.");
                 await Task.Delay(backoff, executionContext.CancellationToken);
-                serviceHealth = (await _dockerManager.DockerInspect(context: executionContext, dockerObject: container.ContainerId, options: healthCheck)).FirstOrDefault();
+                serviceHealth = (await _containerManager.DockerInspect(context: executionContext, dockerObject: container.ContainerId, options: healthCheck)).FirstOrDefault();
                 retryCount++;
             }
             if (string.Equals(serviceHealth, "healthy", StringComparison.OrdinalIgnoreCase))
@@ -462,7 +462,7 @@ namespace GitHub.Runner.Worker
             {
                 throw new InvalidOperationException($"Failed to create directory to store registry client credentials: {e.Message}");
             }
-            var loginExitCode = await _dockerManager.DockerLogin(
+            var loginExitCode = await _containerManager.DockerLogin(
                 executionContext,
                 configLocation,
                 container.RegistryServer,

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -37,7 +37,7 @@ namespace GitHub.Runner.Worker.Handlers
             // Update the env dictionary.
             AddInputsToEnvironment();
 
-            var dockerManager = HostContext.GetService<IDockerCommandManager>();
+            var containerManager = HostContext.GetService<IContainerCommandManager>();
 
             // container image haven't built/pull
             if (Data.Image.StartsWith("docker://", StringComparison.OrdinalIgnoreCase))
@@ -52,8 +52,8 @@ namespace GitHub.Runner.Worker.Handlers
 
                 ExecutionContext.Output($"##[group]Building docker image");
                 ExecutionContext.Output($"Dockerfile for action: '{dockerFile}'.");
-                var imageName = $"{dockerManager.DockerInstanceLabel}:{ExecutionContext.Id.ToString("N")}";
-                var buildExitCode = await dockerManager.DockerBuild(
+                var imageName = $"{containerManager.DockerInstanceLabel}:{ExecutionContext.Id.ToString("N")}";
+                var buildExitCode = await containerManager.DockerBuild(
                     ExecutionContext,
                     ExecutionContext.GetGitHubContext("workspace"),
                     dockerFile,
@@ -228,7 +228,7 @@ namespace GitHub.Runner.Worker.Handlers
             using (var stdoutManager = new OutputManager(ExecutionContext, ActionCommandManager, container))
             using (var stderrManager = new OutputManager(ExecutionContext, ActionCommandManager, container))
             {
-                var runExitCode = await dockerManager.DockerRun(ExecutionContext, container, stdoutManager.OnDataReceived, stderrManager.OnDataReceived);
+                var runExitCode = await containerManager.DockerRun(ExecutionContext, container, stdoutManager.OnDataReceived, stderrManager.OnDataReceived);
                 ExecutionContext.Debug($"Docker Action run completed with exit code {runExitCode}");
                 if (runExitCode != 0)
                 {

--- a/src/Runner.Worker/Handlers/StepHost.cs
+++ b/src/Runner.Worker/Handlers/StepHost.cs
@@ -129,10 +129,10 @@ namespace GitHub.Runner.Worker.Handlers
             // There may be more variation in which libraries are linked than just musl/glibc,
             // so determine based on known distribtutions instead
             var osReleaseIdCmd = "sh -c \"cat /etc/*release | grep ^ID\"";
-            var dockerManager = HostContext.GetService<IDockerCommandManager>();
+            var containerManager = HostContext.GetService<IContainerCommandManager>();
 
             var output = new List<string>();
-            var execExitCode = await dockerManager.DockerExec(executionContext, Container.ContainerId, string.Empty, osReleaseIdCmd, output);
+            var execExitCode = await containerManager.DockerExec(executionContext, Container.ContainerId, string.Empty, osReleaseIdCmd, output);
             string nodeExternal;
             if (execExitCode == 0)
             {
@@ -174,8 +174,8 @@ namespace GitHub.Runner.Worker.Handlers
             ArgUtil.NotNull(Container, nameof(Container));
             ArgUtil.NotNullOrEmpty(Container.ContainerId, nameof(Container.ContainerId));
 
-            var dockerManager = HostContext.GetService<IDockerCommandManager>();
-            string dockerClientPath = dockerManager.DockerPath;
+            var containerManager = HostContext.GetService<IContainerCommandManager>();
+            string dockerClientPath = containerManager.DockerPath;
 
             // Usage:  docker exec [OPTIONS] CONTAINER COMMAND [ARG...]
             IList<string> dockerCommandArgs = new List<string>();

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -26,7 +26,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         private const string TestDataFolderName = "TestData";
         private CancellationTokenSource _ecTokenSource;
         private Mock<IConfigurationStore> _configurationStore;
-        private Mock<IDockerCommandManager> _dockerManager;
+        private Mock<IContainerCommandManager> _containerManager;
         private Mock<IExecutionContext> _ec;
         private Mock<IJobServer> _jobServer;
         private Mock<IRunnerPluginManager> _pluginManager;
@@ -2149,11 +2149,11 @@ runs:
             _ec.Setup(x => x.AddIssue(It.IsAny<Issue>(), It.IsAny<string>())).Callback((Issue issue, string message) => { _hc.GetTrace().Info($"[{issue.Type}]{issue.Message ?? message}"); });
             _ec.Setup(x => x.GetGitHubContext("workspace")).Returns(Path.Combine(_workFolder, "actions", "actions"));
 
-            _dockerManager = new Mock<IDockerCommandManager>();
-            _dockerManager.Setup(x => x.DockerPull(_ec.Object, "ubuntu:16.04")).Returns(Task.FromResult(0));
-            _dockerManager.Setup(x => x.DockerPull(_ec.Object, "ubuntu:100.04")).Returns(Task.FromResult(1));
+            _containerManager = new Mock<IContainerCommandManager>();
+            _containerManager.Setup(x => x.DockerPull(_ec.Object, "ubuntu:16.04")).Returns(Task.FromResult(0));
+            _containerManager.Setup(x => x.DockerPull(_ec.Object, "ubuntu:100.04")).Returns(Task.FromResult(1));
 
-            _dockerManager.Setup(x => x.DockerBuild(_ec.Object, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(0));
+            _containerManager.Setup(x => x.DockerBuild(_ec.Object, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(0));
 
             _jobServer = new Mock<IJobServer>();
             _jobServer.Setup(x => x.ResolveActionDownloadInfoAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ActionReferenceList>(), It.IsAny<CancellationToken>()))
@@ -2180,7 +2180,7 @@ runs:
             var actionManifest = new ActionManifestManager();
             actionManifest.Initialize(_hc);
 
-            _hc.SetSingleton<IDockerCommandManager>(_dockerManager.Object);
+            _hc.SetSingleton<IContainerCommandManager>(_containerManager.Object);
             _hc.SetSingleton<IJobServer>(_jobServer.Object);
             _hc.SetSingleton<IRunnerPluginManager>(_pluginManager.Object);
             _hc.SetSingleton<IActionManifestManager>(actionManifest);

--- a/src/Test/L0/Worker/StepHostL0.cs
+++ b/src/Test/L0/Worker/StepHostL0.cs
@@ -13,7 +13,7 @@ namespace GitHub.Runner.Common.Tests.Worker
     public sealed class StepHostL0
     {
         private Mock<IExecutionContext> _ec;
-        private Mock<IDockerCommandManager> _dc;
+        private Mock<IContainerCommandManager> _dc;
         private TestHostContext CreateTestContext([CallerMemberName] String testName = "")
         {
             var hc = new TestHostContext(this, testName);
@@ -24,7 +24,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             var trace = hc.GetTrace();
             _ec.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>())).Callback((string tag, string message) => { trace.Info($"[{tag}]{message}"); });
 
-            _dc = new Mock<IDockerCommandManager>();
+            _dc = new Mock<IContainerCommandManager>();
             hc.SetSingleton(_dc.Object);
             return hc;
         }


### PR DESCRIPTION
This defines the initial base layout to support additional container providers besides using docker such as kuberentes.

Feature is not yet enabled