### PR TITLE
Update dependency check for dotnet 6.

### DIFF
--- a/docs/start/envlinux.md
+++ b/docs/start/envlinux.md
@@ -23,8 +23,8 @@ You might see something like this which indicate a dependency's missing.
 ./config.sh
     libunwind.so.8 => not found
     libunwind-x86_64.so.8 => not found
-Dependencies is missing for Dotnet Core 3.0
-Execute ./bin/installdependencies.sh to install any missing Dotnet Core 3.0 dependencies.
+Dependencies is missing for Dotnet Core 6.0
+Execute ./bin/installdependencies.sh to install any missing Dotnet Core 6.0 dependencies.
 ```
 You can easily correct the problem by executing `./bin/installdependencies.sh`.  
 The `installdependencies.sh` script should install all required dependencies on all supported Linux versions  

--- a/src/Misc/layoutroot/config.sh
+++ b/src/Misc/layoutroot/config.sh
@@ -8,7 +8,7 @@ if [ $user_id -eq 0 -a -z "$RUNNER_ALLOW_RUNASROOT" ]; then
     exit 1
 fi
 
-# Check dotnet core 3.0 dependencies for Linux
+# Check dotnet Core 6.0 dependencies for Linux
 if [[ (`uname` == "Linux") ]]
 then
     command -v ldd > /dev/null
@@ -18,25 +18,25 @@ then
         exit 1
     fi
 
-    message="Execute sudo ./bin/installdependencies.sh to install any missing Dotnet Core 3.0 dependencies."
+    message="Execute sudo ./bin/installdependencies.sh to install any missing Dotnet Core 6.0 dependencies."
 
     ldd ./bin/libcoreclr.so | grep 'not found'
     if [ $? -eq 0 ]; then
-        echo "Dependencies is missing for Dotnet Core 3.0"
+        echo "Dependencies is missing for Dotnet Core 6.0"
         echo $message
         exit 1
     fi
 
-    ldd ./bin/System.Security.Cryptography.Native.OpenSsl.so | grep 'not found'
+    ldd ./bin/libSystem.Security.Cryptography.Native.OpenSsl.so | grep 'not found'
     if [ $? -eq 0 ]; then
-        echo "Dependencies is missing for Dotnet Core 3.0"
+        echo "Dependencies is missing for Dotnet Core 6.0"
         echo $message
         exit 1
     fi
 
-    ldd ./bin/System.IO.Compression.Native.so | grep 'not found'
+    ldd ./bin/libSystem.IO.Compression.Native.so | grep 'not found'
     if [ $? -eq 0 ]; then
-        echo "Dependencies is missing for Dotnet Core 3.0"
+        echo "Dependencies is missing for Dotnet Core 6.0"
         echo $message
         exit 1
     fi
@@ -54,7 +54,7 @@ then
     libpath=${LD_LIBRARY_PATH:-}
     $LDCONFIG_COMMAND -NXv ${libpath//:/ } 2>&1 | grep libicu >/dev/null 2>&1
     if [ $? -ne 0 ]; then
-        echo "Libicu's dependencies is missing for Dotnet Core 3.0"
+        echo "Libicu's dependencies is missing for Dotnet Core 6.0"
         echo $message
         exit 1
     fi


### PR DESCRIPTION
Dotnet renames its native lib from `System.*.so` to `libSystem.*.so` since dotnet 5, we need to change our script to check the right files, otherwise, you will get annoying output like 
```
ldd: ./bin/System.Security.Cryptography.Native.OpenSsl.so: No such file or directory
ldd: ./bin/System.IO.Compression.Native.so: No such file or directory
```