### PR TITLE
Use trimmed packages to speedup runner updates

### DIFF
--- a/src/Sdk/DTWebApi/WebApi/PackageMetadata.cs
+++ b/src/Sdk/DTWebApi/WebApi/PackageMetadata.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
 
@@ -110,5 +111,43 @@ namespace GitHub.DistributedTask.WebApi
             get;
             set;
         }
+
+        /// <summary>
+        /// A set of trimmed down packages:
+        /// - the package without 'externals'
+        /// - the package without 'dotnet runtime'
+        /// - the package without 'dotnet runtime' and 'externals'
+        /// </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public List<TrimmedPackageMetadata> TrimmedPackages
+        {
+            get;
+            set;
+        }
+    }
+
+    [DataContract]
+    public class TrimmedPackageMetadata
+    {
+        [DataMember(EmitDefaultValue = false)]
+        public string HashValue { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public string DownloadUrl { get; set; }
+
+        public Dictionary<string, string> TrimmedContents
+        {
+            get
+            {
+                if (m_trimmedContents == null)
+                {
+                    m_trimmedContents = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                }
+                return m_trimmedContents;
+            }
+        }
+
+        [DataMember(Name = "TrimmedContents", EmitDefaultValue = false)]
+        private Dictionary<string, string> m_trimmedContents;
     }
 }

--- a/src/Test/L0/Listener/SelfUpdaterL0.cs
+++ b/src/Test/L0/Listener/SelfUpdaterL0.cs
@@ -1,14 +1,17 @@
-﻿using GitHub.DistributedTask.WebApi;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Listener;
 using GitHub.Runner.Sdk;
 using Moq;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
-using System.IO;
-using System.Collections.Generic;
-using System.Reflection;
 
 namespace GitHub.Runner.Common.Tests.Listener
 {
@@ -19,11 +22,12 @@ namespace GitHub.Runner.Common.Tests.Listener
         private Mock<IConfigurationStore> _configStore;
         private Mock<IJobDispatcher> _jobDispatcher;
         private AgentRefreshMessage _refreshMessage = new AgentRefreshMessage(1, "2.299.0");
+        private List<TrimmedPackageMetadata> _trimmedPackages = new List<TrimmedPackageMetadata>();
 
 #if !OS_WINDOWS
-        private string _packageUrl = $"https://github.com/actions/runner/releases/download/v2.285.1/actions-runner-{BuildConstants.RunnerPackage.PackageName}-2.285.1.tar.gz";
+        private string _packageUrl = null;
 #else
-        private string _packageUrl = $"https://github.com/actions/runner/releases/download/v2.285.1/actions-runner-{BuildConstants.RunnerPackage.PackageName}-2.285.1.zip";
+        private string _packageUrl = null;
 #endif
         public SelfUpdaterL0()
         {
@@ -33,10 +37,44 @@ namespace GitHub.Runner.Common.Tests.Listener
             _jobDispatcher = new Mock<IJobDispatcher>();
             _configStore.Setup(x => x.GetSettings()).Returns(new RunnerSettings() { PoolId = 1, AgentId = 1 });
 
+            Environment.SetEnvironmentVariable("_GITHUB_ACTION_EXECUTE_UPDATE_SCRIPT", "1");
+        }
+
+        private async Task FetchLatestRunner()
+        {
+            var latestVersion = "";
+            var httpClientHandler = new HttpClientHandler();
+            httpClientHandler.AllowAutoRedirect = false;
+            using (var client = new HttpClient(httpClientHandler))
+            {
+                var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://github.com/actions/runner/releases/latest"));
+                if (response.StatusCode == System.Net.HttpStatusCode.Redirect)
+                {
+                    var redirect = await response.Content.ReadAsStringAsync();
+                    Regex regex = new Regex(@"/runner/releases/tag/v(?<version>\d+\.\d+\.\d+)");
+                    var match = regex.Match(redirect);
+                    if (match.Success)
+                    {
+                        latestVersion = match.Groups["version"].Value;
+
+#if !OS_WINDOWS
+                        _packageUrl = $"https://github.com/actions/runner/releases/download/v{latestVersion}/actions-runner-{BuildConstants.RunnerPackage.PackageName}-{latestVersion}.tar.gz";
+#else
+                        _packageUrl = $"https://github.com/actions/runner/releases/download/v{latestVersion}/actions-runner-{BuildConstants.RunnerPackage.PackageName}-{latestVersion}.zip";
+#endif
+                    }
+                }
+            }
+
+            using (var client = new HttpClient())
+            {
+                var json = await client.GetStringAsync($"https://github.com/actions/runner/releases/download/v{latestVersion}/actions-runner-{BuildConstants.RunnerPackage.PackageName}-{latestVersion}-trimmedpackages.json");
+                _trimmedPackages = StringUtil.ConvertFromJson<List<TrimmedPackageMetadata>>(json);
+            }
+
             _runnerServer.Setup(x => x.GetPackageAsync("agent", BuildConstants.RunnerPackage.PackageName, "2.299.0", true, It.IsAny<CancellationToken>()))
                          .Returns(Task.FromResult(new PackageMetadata() { Platform = BuildConstants.RunnerPackage.PackageName, Version = new PackageVersion("2.299.0"), DownloadUrl = _packageUrl }));
 
-            Environment.SetEnvironmentVariable("_GITHUB_ACTION_EXECUTE_UPDATE_SCRIPT", "1");
         }
 
         [Fact]
@@ -46,9 +84,15 @@ namespace GitHub.Runner.Common.Tests.Listener
         {
             try
             {
+                await FetchLatestRunner();
+                Assert.NotNull(_packageUrl);
+                Assert.NotNull(_trimmedPackages);
                 Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", Path.GetFullPath(Path.Combine(TestUtil.GetSrcPath(), "..", "_layout", "bin")));
                 using (var hc = new TestHostContext(this))
                 {
+                    hc.GetTrace().Info(_packageUrl);
+                    hc.GetTrace().Info(StringUtil.ConvertToJson(_trimmedPackages));
+
                     //Arrange
                     var updater = new Runner.Listener.SelfUpdater();
                     hc.SetSingleton<ITerminal>(_term.Object);
@@ -101,9 +145,15 @@ namespace GitHub.Runner.Common.Tests.Listener
         {
             try
             {
+                await FetchLatestRunner();
+                Assert.NotNull(_packageUrl);
+                Assert.NotNull(_trimmedPackages);
                 Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", Path.GetFullPath(Path.Combine(TestUtil.GetSrcPath(), "..", "_layout", "bin")));
                 using (var hc = new TestHostContext(this))
                 {
+                    hc.GetTrace().Info(_packageUrl);
+                    hc.GetTrace().Info(StringUtil.ConvertToJson(_trimmedPackages));
+
                     //Arrange
                     var updater = new Runner.Listener.SelfUpdater();
                     hc.SetSingleton<ITerminal>(_term.Object);
@@ -148,9 +198,15 @@ namespace GitHub.Runner.Common.Tests.Listener
         {
             try
             {
+                await FetchLatestRunner();
+                Assert.NotNull(_packageUrl);
+                Assert.NotNull(_trimmedPackages);
                 Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", Path.GetFullPath(Path.Combine(TestUtil.GetSrcPath(), "..", "_layout", "bin")));
                 using (var hc = new TestHostContext(this))
                 {
+                    hc.GetTrace().Info(_packageUrl);
+                    hc.GetTrace().Info(StringUtil.ConvertToJson(_trimmedPackages));
+
                     //Arrange
                     var updater = new Runner.Listener.SelfUpdater();
                     hc.SetSingleton<ITerminal>(_term.Object);
@@ -197,9 +253,15 @@ namespace GitHub.Runner.Common.Tests.Listener
         {
             try
             {
+                await FetchLatestRunner();
+                Assert.NotNull(_packageUrl);
+                Assert.NotNull(_trimmedPackages);
                 Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", Path.GetFullPath(Path.Combine(TestUtil.GetSrcPath(), "..", "_layout", "bin")));
                 using (var hc = new TestHostContext(this))
                 {
+                    hc.GetTrace().Info(_packageUrl);
+                    hc.GetTrace().Info(StringUtil.ConvertToJson(_trimmedPackages));
+
                     //Arrange
                     var updater = new Runner.Listener.SelfUpdater();
                     hc.SetSingleton<ITerminal>(_term.Object);
@@ -246,9 +308,15 @@ namespace GitHub.Runner.Common.Tests.Listener
         {
             try
             {
+                await FetchLatestRunner();
+                Assert.NotNull(_packageUrl);
+                Assert.NotNull(_trimmedPackages);
                 Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", Path.GetFullPath(Path.Combine(TestUtil.GetSrcPath(), "..", "_layout", "bin")));
                 using (var hc = new TestHostContext(this))
                 {
+                    hc.GetTrace().Info(_packageUrl);
+                    hc.GetTrace().Info(StringUtil.ConvertToJson(_trimmedPackages));
+
                     //Arrange
                     var updater = new Runner.Listener.SelfUpdater();
                     hc.SetSingleton<ITerminal>(_term.Object);
@@ -315,9 +383,15 @@ namespace GitHub.Runner.Common.Tests.Listener
         {
             try
             {
+                await FetchLatestRunner();
+                Assert.NotNull(_packageUrl);
+                Assert.NotNull(_trimmedPackages);
                 Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", Path.GetFullPath(Path.Combine(TestUtil.GetSrcPath(), "..", "_layout", "bin")));
                 using (var hc = new TestHostContext(this))
                 {
+                    hc.GetTrace().Info(_packageUrl);
+                    hc.GetTrace().Info(StringUtil.ConvertToJson(_trimmedPackages));
+
                     //Arrange
                     var updater = new Runner.Listener.SelfUpdater();
                     hc.SetSingleton<ITerminal>(_term.Object);
@@ -354,10 +428,279 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                         Assert.NotEqual(2, contentHashes.Count);
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
                         hc.GetTrace().Error(ex);
                     }
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", null);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void TestSelfUpdateAsync_UseExternalsTrimmedPackage()
+        {
+            try
+            {
+                await FetchLatestRunner();
+                Assert.NotNull(_packageUrl);
+                Assert.NotNull(_trimmedPackages);
+                Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", Path.GetFullPath(Path.Combine(TestUtil.GetSrcPath(), "..", "_layout", "bin")));
+                using (var hc = new TestHostContext(this))
+                {
+                    hc.GetTrace().Info(_packageUrl);
+                    hc.GetTrace().Info(StringUtil.ConvertToJson(_trimmedPackages));
+
+                    //Arrange
+                    var updater = new Runner.Listener.SelfUpdater();
+                    hc.SetSingleton<ITerminal>(_term.Object);
+                    hc.SetSingleton<IRunnerServer>(_runnerServer.Object);
+                    hc.SetSingleton<IConfigurationStore>(_configStore.Object);
+                    hc.SetSingleton<IHttpClientHandlerFactory>(new HttpClientHandlerFactory());
+
+                    var p1 = new ProcessInvokerWrapper();  // hashfiles
+                    p1.Initialize(hc);
+                    var p2 = new ProcessInvokerWrapper();  // hashfiles
+                    p2.Initialize(hc);
+                    var p3 = new ProcessInvokerWrapper();  // un-tar
+                    p3.Initialize(hc);
+                    var p4 = new ProcessInvokerWrapper();  // node -v
+                    p4.Initialize(hc);
+                    var p5 = new ProcessInvokerWrapper();  // node -v
+                    p5.Initialize(hc);
+                    hc.EnqueueInstance<IProcessInvoker>(p1);
+                    hc.EnqueueInstance<IProcessInvoker>(p2);
+                    hc.EnqueueInstance<IProcessInvoker>(p3);
+                    hc.EnqueueInstance<IProcessInvoker>(p4);
+                    hc.EnqueueInstance<IProcessInvoker>(p5);
+                    updater.Initialize(hc);
+
+                    var trim = _trimmedPackages.Where(x => !x.TrimmedContents.ContainsKey("dotnetRuntime")).ToList();
+                    _runnerServer.Setup(x => x.GetPackageAsync("agent", BuildConstants.RunnerPackage.PackageName, "2.299.0", true, It.IsAny<CancellationToken>()))
+                         .Returns(Task.FromResult(new PackageMetadata() { Platform = BuildConstants.RunnerPackage.PackageName, Version = new PackageVersion("2.299.0"), DownloadUrl = _packageUrl, TrimmedPackages = trim }));
+
+                    _runnerServer.Setup(x => x.UpdateAgentUpdateStateAsync(1, 1, It.IsAny<string>(), It.IsAny<string>()))
+                                 .Callback((int p, int a, string s, string t) =>
+                                 {
+                                     hc.GetTrace().Info(t);
+                                 })
+                                 .Returns(Task.FromResult(new TaskAgent()));
+
+                    try
+                    {
+                        var result = await updater.SelfUpdate(_refreshMessage, _jobDispatcher.Object, true, hc.RunnerShutdownToken);
+                        Assert.True(result);
+                        Assert.True(Directory.Exists(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "bin.2.299.0")));
+                        Assert.True(Directory.Exists(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "externals.2.299.0")));
+                    }
+                    finally
+                    {
+                        IOUtil.DeleteDirectory(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "bin.2.299.0"), CancellationToken.None);
+                        IOUtil.DeleteDirectory(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "externals.2.299.0"), CancellationToken.None);
+                    }
+
+                    var traceFile = Path.GetTempFileName();
+                    File.Copy(hc.TraceFileName, traceFile, true);
+
+                    var externalsHashFile = Path.Combine(TestUtil.GetSrcPath(), $"Misc/contentHash/externals/{BuildConstants.RunnerPackage.PackageName}");
+                    var externalsHash = await File.ReadAllTextAsync(externalsHashFile);
+
+                    if (externalsHash == trim[0].TrimmedContents["externals"])
+                    {
+                        Assert.Contains("Use trimmed (externals) package", File.ReadAllText(traceFile));
+                    }
+                    else
+                    {
+                        Assert.Contains("the current runner does not carry those trimmed content (Hash mismatch)", File.ReadAllText(traceFile));
+                    }
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", null);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void TestSelfUpdateAsync_UseExternalsRuntimeTrimmedPackage()
+        {
+            try
+            {
+                await FetchLatestRunner();
+                Assert.NotNull(_packageUrl);
+                Assert.NotNull(_trimmedPackages);
+                Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", Path.GetFullPath(Path.Combine(TestUtil.GetSrcPath(), "..", "_layout", "bin")));
+                using (var hc = new TestHostContext(this))
+                {
+                    hc.GetTrace().Info(_packageUrl);
+                    hc.GetTrace().Info(StringUtil.ConvertToJson(_trimmedPackages));
+
+                    //Arrange
+                    var updater = new Runner.Listener.SelfUpdater();
+                    hc.SetSingleton<ITerminal>(_term.Object);
+                    hc.SetSingleton<IRunnerServer>(_runnerServer.Object);
+                    hc.SetSingleton<IConfigurationStore>(_configStore.Object);
+                    hc.SetSingleton<IHttpClientHandlerFactory>(new HttpClientHandlerFactory());
+
+                    var p1 = new ProcessInvokerWrapper();  // hashfiles
+                    p1.Initialize(hc);
+                    var p2 = new ProcessInvokerWrapper();  // hashfiles
+                    p2.Initialize(hc);
+                    var p3 = new ProcessInvokerWrapper();  // un-tar
+                    p3.Initialize(hc);
+                    var p4 = new ProcessInvokerWrapper();  // node -v
+                    p4.Initialize(hc);
+                    var p5 = new ProcessInvokerWrapper();  // node -v
+                    p5.Initialize(hc);
+                    var p6 = new ProcessInvokerWrapper();  // runner -v
+                    p6.Initialize(hc);
+                    hc.EnqueueInstance<IProcessInvoker>(p1);
+                    hc.EnqueueInstance<IProcessInvoker>(p2);
+                    hc.EnqueueInstance<IProcessInvoker>(p3);
+                    hc.EnqueueInstance<IProcessInvoker>(p4);
+                    hc.EnqueueInstance<IProcessInvoker>(p5);
+                    hc.EnqueueInstance<IProcessInvoker>(p6);
+                    updater.Initialize(hc);
+
+                    var trim = _trimmedPackages.Where(x => x.TrimmedContents.ContainsKey("dotnetRuntime") && x.TrimmedContents.ContainsKey("externals")).ToList();
+                    _runnerServer.Setup(x => x.GetPackageAsync("agent", BuildConstants.RunnerPackage.PackageName, "2.299.0", true, It.IsAny<CancellationToken>()))
+                         .Returns(Task.FromResult(new PackageMetadata() { Platform = BuildConstants.RunnerPackage.PackageName, Version = new PackageVersion("2.299.0"), DownloadUrl = _packageUrl, TrimmedPackages = trim }));
+
+                    _runnerServer.Setup(x => x.GetPackageAsync("agent", BuildConstants.RunnerPackage.PackageName, "2.299.0", true, It.IsAny<CancellationToken>()))
+                         .Returns(Task.FromResult(new PackageMetadata() { Platform = BuildConstants.RunnerPackage.PackageName, Version = new PackageVersion("2.299.0"), DownloadUrl = _packageUrl, TrimmedPackages = _trimmedPackages }));
+
+                    _runnerServer.Setup(x => x.UpdateAgentUpdateStateAsync(1, 1, It.IsAny<string>(), It.IsAny<string>()))
+                                 .Callback((int p, int a, string s, string t) =>
+                                 {
+                                     hc.GetTrace().Info(t);
+                                 })
+                                 .Returns(Task.FromResult(new TaskAgent()));
+
+                    try
+                    {
+                        var result = await updater.SelfUpdate(_refreshMessage, _jobDispatcher.Object, true, hc.RunnerShutdownToken);
+                        Assert.True(result);
+                        Assert.True(Directory.Exists(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "bin.2.299.0")));
+                        Assert.True(Directory.Exists(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "externals.2.299.0")));
+                    }
+                    finally
+                    {
+                        IOUtil.DeleteDirectory(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "bin.2.299.0"), CancellationToken.None);
+                        IOUtil.DeleteDirectory(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "externals.2.299.0"), CancellationToken.None);
+                    }
+
+                    var traceFile = Path.GetTempFileName();
+                    File.Copy(hc.TraceFileName, traceFile, true);
+
+                    var externalsHashFile = Path.Combine(TestUtil.GetSrcPath(), $"Misc/contentHash/externals/{BuildConstants.RunnerPackage.PackageName}");
+                    var externalsHash = await File.ReadAllTextAsync(externalsHashFile);
+
+                    var runtimeHashFile = Path.Combine(TestUtil.GetSrcPath(), $"Misc/contentHash/dotnetRuntime/{BuildConstants.RunnerPackage.PackageName}");
+                    var runtimeHash = await File.ReadAllTextAsync(runtimeHashFile);
+
+                    if (externalsHash == trim[0].TrimmedContents["externals"] &&
+                        runtimeHash == trim[0].TrimmedContents["dotnetRuntime"])
+                    {
+                        Assert.Contains("Use trimmed (runtime+externals) package", File.ReadAllText(traceFile));
+                    }
+                    else
+                    {
+                        Assert.Contains("the current runner does not carry those trimmed content (Hash mismatch)", File.ReadAllText(traceFile));
+                    }
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", null);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void TestSelfUpdateAsync_NotUseExternalsRuntimeTrimmedPackageOnHashMismatch()
+        {
+            try
+            {
+                await FetchLatestRunner();
+                Assert.NotNull(_packageUrl);
+                Assert.NotNull(_trimmedPackages);
+                Environment.SetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR", Path.GetFullPath(Path.Combine(TestUtil.GetSrcPath(), "..", "_layout", "bin")));
+                using (var hc = new TestHostContext(this))
+                {
+                    hc.GetTrace().Info(_packageUrl);
+                    hc.GetTrace().Info(StringUtil.ConvertToJson(_trimmedPackages));
+
+                    //Arrange
+                    var updater = new Runner.Listener.SelfUpdater();
+                    hc.SetSingleton<ITerminal>(_term.Object);
+                    hc.SetSingleton<IRunnerServer>(_runnerServer.Object);
+                    hc.SetSingleton<IConfigurationStore>(_configStore.Object);
+                    hc.SetSingleton<IHttpClientHandlerFactory>(new HttpClientHandlerFactory());
+
+                    var p1 = new ProcessInvokerWrapper();  // hashfiles
+                    p1.Initialize(hc);
+                    var p2 = new ProcessInvokerWrapper();  // hashfiles
+                    p2.Initialize(hc);
+                    var p3 = new ProcessInvokerWrapper();  // un-tar
+                    p3.Initialize(hc);
+                    var p4 = new ProcessInvokerWrapper();  // node -v
+                    p4.Initialize(hc);
+                    var p5 = new ProcessInvokerWrapper();  // node -v
+                    p5.Initialize(hc);
+                    var p6 = new ProcessInvokerWrapper();  // runner -v
+                    p6.Initialize(hc);
+                    hc.EnqueueInstance<IProcessInvoker>(p1);
+                    hc.EnqueueInstance<IProcessInvoker>(p2);
+                    hc.EnqueueInstance<IProcessInvoker>(p3);
+                    hc.EnqueueInstance<IProcessInvoker>(p4);
+                    hc.EnqueueInstance<IProcessInvoker>(p5);
+                    hc.EnqueueInstance<IProcessInvoker>(p6);
+                    updater.Initialize(hc);
+
+                    var trim = _trimmedPackages.ToList();
+                    foreach (var package in trim)
+                    {
+                        foreach (var hash in package.TrimmedContents.Keys)
+                        {
+                            package.TrimmedContents[hash] = "mismatch";
+                        }
+                    }
+
+                    _runnerServer.Setup(x => x.GetPackageAsync("agent", BuildConstants.RunnerPackage.PackageName, "2.299.0", true, It.IsAny<CancellationToken>()))
+                         .Returns(Task.FromResult(new PackageMetadata() { Platform = BuildConstants.RunnerPackage.PackageName, Version = new PackageVersion("2.299.0"), DownloadUrl = _packageUrl, TrimmedPackages = trim }));
+
+
+                    _runnerServer.Setup(x => x.UpdateAgentUpdateStateAsync(1, 1, It.IsAny<string>(), It.IsAny<string>()))
+                                 .Callback((int p, int a, string s, string t) =>
+                                 {
+                                     hc.GetTrace().Info(t);
+                                 })
+                                 .Returns(Task.FromResult(new TaskAgent()));
+
+                    try
+                    {
+                        var result = await updater.SelfUpdate(_refreshMessage, _jobDispatcher.Object, true, hc.RunnerShutdownToken);
+                        Assert.True(result);
+                        Assert.True(Directory.Exists(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "bin.2.299.0")));
+                        Assert.True(Directory.Exists(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "externals.2.299.0")));
+                    }
+                    finally
+                    {
+                        IOUtil.DeleteDirectory(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "bin.2.299.0"), CancellationToken.None);
+                        IOUtil.DeleteDirectory(Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "externals.2.299.0"), CancellationToken.None);
+                    }
+
+                    var traceFile = Path.GetTempFileName();
+                    File.Copy(hc.TraceFileName, traceFile, true);
+                    Assert.Contains("the current runner does not carry those trimmed content (Hash mismatch)", File.ReadAllText(traceFile));
                 }
             }
             finally

--- a/src/Test/L0/Listener/SelfUpdaterL0.cs
+++ b/src/Test/L0/Listener/SelfUpdaterL0.cs
@@ -52,6 +52,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 var p = new ProcessInvokerWrapper();
                 p.Initialize(hc);
                 hc.EnqueueInstance<IProcessInvoker>(p);
+                hc.EnqueueInstance<IProcessInvoker>(p);
+                hc.EnqueueInstance<IProcessInvoker>(p);
                 updater.Initialize(hc);
 
                 _runnerServer.Setup(x => x.UpdateAgentUpdateStateAsync(1, 1, It.IsAny<string>(), It.IsAny<string>()))

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -165,7 +165,15 @@ namespace GitHub.Runner.Common.Tests
             switch (directory)
             {
                 case WellKnownDirectory.Bin:
-                    path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+                    var overwriteBinDir = Environment.GetEnvironmentVariable("RUNNER_L0_OVERRIDEBINDIR");
+                    if (Directory.Exists(overwriteBinDir))
+                    {
+                        path = overwriteBinDir;
+                    }
+                    else
+                    {
+                        path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+                    }
                     break;
 
                 case WellKnownDirectory.Diag:


### PR DESCRIPTION
The runner update is too slow since it needs to download a relatively big package (~100MB)
However, most parts of the package are redundant cross versions most of the time.
- Externals: node 12 and node 16, we updated those once every few years)
- Dotnet Runtime: we only upgrade to the latest LTS once every 2 years.

We could make the runner only download the delta and make the update process more quick and smooth.

P95 download time cross the board (in seconds).
![image](https://user-images.githubusercontent.com/1750815/146614624-3b13eb26-f50b-42e5-90b9-bc9820fee4b0.png)
