### PR TITLE
Direct people to Feedback or Support forums

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,11 +1,17 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: 🛑 Report a bug in the runner application
+about: If you have issues with GitHub Actions, please follow the "support for GitHub Actions" link, below.
 title: ''
 labels: bug
 assignees: ''
 
 ---
+
+<!--
+👋 You're opening a bug report against the GitHub Actions **runner application**.
+
+🛑 Please stop if you're not certain that the bug you're seeing is in the runner application - if you have general problems with actions, workflows, or runners, please see the [GitHub Community Support Forum](https://github.community/c/code-to-cloud/52) which is actively monitored.  Using the forum ensures that we route your problem to the correct team.  😃
+-->
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ✅ Support for GitHub Actions
+    url: https://github.community/c/code-to-cloud/52
+    about: If you have questions about GitHub Actions or need support writing workflows, please ask in the GitHub Community Support forum.
+  - name: ✅ Feedback and suggestions for GitHub Actions
+    url: https://github.com/github/feedback/discussions/categories/actions-and-packages-feedback
+    about: If you have feedback or suggestions about GitHub Actions, please open a discussion (or add to an existing one) in the GitHub Actions Feedback.  GitHub Actions Product Managers and Engineers monitor the feedback forum.
+  - name: ‼️ GitHub Security Bug Bounty
+    url: https://bounty.github.com/
+    about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,19 +1,24 @@
 ---
-name: Feature Request
-about: Create a request to help us improve
+name: 🛑 Request a feature in the runner application 
+about: If you have feature requests for GitHub Actions, please use the "feedback and suggestions for GitHub Actions" link below.
 title: ''
 labels: enhancement
 assignees: ''
 
 ---
 
-Thank you 🙇‍♀ for wanting to create a feature in this repository. Before you do, please ensure you are filing the issue in the right place. Issues should only be opened on if the issue **relates to code in this repository**.  
+<!--
+👋 You're opening a request for an enhancement in the GitHub Actions **runner application**.
 
+🛑 Please stop if you're not certain that the feature you want is in the runner application - if you have a suggestion for improving GitHub Actions, please see the [GitHub Actions Feedback](https://github.com/github/feedback/discussions/categories/actions-and-packages-feedback) discussion forum which is actively monitored.  Using the forum ensures that we route your problem to the correct team.  😃
+
+Some additional useful links:
 * If you have found a security issue [please submit it here](https://hackerone.com/github)
 * If you have questions or issues with the service, writing workflows or actions, then please [visit the GitHub Community Forum's Actions Board](https://github.community/t5/GitHub-Actions/bd-p/actions)
-* If you are having an issue or question about GitHub Actions then please [contact customer support](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-github-actions#contacting-support)
+* If you are having an issue or have a question about GitHub Actions then please [contact customer support](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-github-actions#contacting-support)
 
 If you have a feature request that is relevant to this repository, the runner, then please include the information below:
+-->
 
 **Describe the enhancement**
 A clear and concise description of what the features or enhancement you need.


### PR DESCRIPTION
Many people open bug reports or feature requests in the `actions/runner`
repository that are more generally about GitHub Actions.  Often changes
in GitHub Actions are cross-cutting across multiple teams or feature
areas, so it's best if we direct people to the more general areas
(Actions Community Support or GitHub Feedback) so that we can get the
most eyes on the problem and give the quickest response.