### PR TITLE
Do not trim runner name from service name on unix

### DIFF
--- a/src/Runner.Listener/Configuration/ServiceControlManager.cs
+++ b/src/Runner.Listener/Configuration/ServiceControlManager.cs
@@ -60,12 +60,13 @@ namespace GitHub.Runner.Listener.Configuration
 
                 string runnerNameSubstring = settings.AgentName;
 
+#if OS_WINDOWS
                 // Only trim runner name if it's really necessary
                 if (exceededCharLength > 0)
                 {
                     runnerNameSubstring = StringUtil.SubstringPrefix(settings.AgentName, settings.AgentName.Length - exceededCharLength);
                 }
-
+#endif
                 serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgNameSubstring, runnerNameSubstring);
             }
 

--- a/src/Test/L0/ServiceControlManagerL0.cs
+++ b/src/Test/L0/ServiceControlManagerL0.cs
@@ -113,15 +113,23 @@ namespace GitHub.Runner.Common.Tests
                     out string serviceDisplayName);
 
                 // Verify name has been shortened to 80 characters
+#if OS_WINDOWS
                 Assert.Equal(80, serviceName.Length);
+#else
+                Assert.Equal(106, serviceName.Length);
+#endif
 
                 var serviceNameParts = serviceName.Split('.');
 
-                // Verify that each component has been shortened to a sensible length
                 Assert.Equal("actions", serviceNameParts[0]); // Never shortened
                 Assert.Equal("runner", serviceNameParts[1]); // Never shortened
                 Assert.Equal("myreallylongorganizationexample-myreallylongr", serviceNameParts[2]); // First 45 chars, '/' has been replaced with '-'
+#if OS_WINDOWS
+                // Verify that each component has been shortened to a sensible length
                 Assert.Equal("thisisareallyreally", serviceNameParts[3]); // Remainder of unused chars
+#else
+                Assert.Equal("thisisareallyreallylongbutstillvalidagentname", serviceNameParts[3]);
+#endif
             }
         }
 


### PR DESCRIPTION
Trimming runner name in many cases causes issues when installing multiple runners on the same machine which are just differentiated by a suffix. So far on linux without the 80 characters limitation it has been working fine

This fixes https://github.com/actions/runner/issues/730 and https://github.com/githubcustomers/Intel/issues/160