### PR TITLE
Allow script to exit early as soon as runner process exits.

### DIFF
--- a/src/Misc/layoutbin/RunnerService.js
+++ b/src/Misc/layoutbin/RunnerService.js
@@ -83,7 +83,7 @@ var gracefulShutdown = function (code) {
         listener.kill('SIGINT');
 
         console.log('Sending SIGKILL to runner listener');
-        setTimeout(() => listener.kill('SIGKILL'), 30000);
+        setTimeout(() => listener.kill('SIGKILL'), 30000).unref();
     }
 }
 


### PR DESCRIPTION
`./svc.sh stop` always wait for 30s before exiting.

```
root@edc861135c46:/home/runner# time ./svc.sh stop  

/etc/systemd/system/actions.runner.bbq-beets-ting-test.edc861135c46.service
actions.runner.bbq-beets-ting-test.edc861135c46.service - GitHub Actions Runner (bbq-beets-ting-test.edc861135c46)
    Loaded: loaded (/etc/systemd/system/actions.runner.bbq-beets-ting-test.edc861135c46.service, enabled)
    Active: inactive (dead)

real	0m30.381s
user	0m1.026s
sys	0m0.146s
```

after this change:
```
root@edc861135c46:/home/runner# time ./svc.sh stop


/etc/systemd/system/actions.runner.bbq-beets-ting-test.edc861135c46.service
actions.runner.bbq-beets-ting-test.edc861135c46.service - GitHub Actions Runner (bbq-beets-ting-test.edc861135c46)
    Loaded: loaded (/etc/systemd/system/actions.runner.bbq-beets-ting-test.edc861135c46.service, enabled)
    Active: inactive (dead)

real	0m1.294s
user	0m0.969s
sys	0m0.127s

```