### PR TITLE
Change group description

### DIFF
--- a/src/Runner.Listener/Configuration/NativeWindowsServiceHelper.cs
+++ b/src/Runner.Listener/Configuration/NativeWindowsServiceHelper.cs
@@ -142,7 +142,7 @@ namespace GitHub.Runner.Listener.Configuration
             Trace.Entering();
             LocalGroupInfo groupInfo = new LocalGroupInfo();
             groupInfo.Name = groupName;
-            groupInfo.Comment = StringUtil.Format("Built-in group used by Team Foundation Server.");
+            groupInfo.Comment = StringUtil.Format("Built-in group used by GitHub Actions Runner.");
 
             int returnCode = NetLocalGroupAdd(null,               // computer name
                                               1,                  // 1 means include comment 


### PR DESCRIPTION
currently, when installing runner we create a security group with TFS description.
This PR changes the description so it won't be misleading.

Closes https://github.com/actions/runner/issues/1561