### PR TITLE
Generate refname for all build/pull container step.

### DIFF
--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -122,20 +122,20 @@ namespace GitHub.Runner.Worker
                         }
                     }
 
-                    try 
+                    try
                     {
                         var tokenPermissions = jobContext.Global.Variables.Get("system.github.token.permissions") ?? "";
                         if (!string.IsNullOrEmpty(tokenPermissions))
                         {
                             context.Output($"##[group]GITHUB_TOKEN Permissions");
                             var permissions = StringUtil.ConvertFromJson<Dictionary<string, string>>(tokenPermissions);
-                            foreach(KeyValuePair<string, string> entry in permissions)
+                            foreach (KeyValuePair<string, string> entry in permissions)
                             {
                                 context.Output($"{entry.Key}: {entry.Value}");
                             }
                             context.Output("##[endgroup]");
                         }
-                    } 
+                    }
                     catch (Exception ex)
                     {
                         context.Output($"Fail to parse and display GITHUB_TOKEN permissions list: {ex.Message}");
@@ -312,7 +312,7 @@ namespace GitHub.Runner.Worker
                             JobExtensionRunner extensionStep = step as JobExtensionRunner;
                             ArgUtil.NotNull(extensionStep, extensionStep.DisplayName);
                             Guid stepId = Guid.NewGuid();
-                            extensionStep.ExecutionContext = jobContext.CreateChild(stepId, extensionStep.DisplayName, null, null, stepId.ToString("N"), ActionRunStage.Pre);
+                            extensionStep.ExecutionContext = jobContext.CreateChild(stepId, extensionStep.DisplayName, stepId.ToString("N"), null, stepId.ToString("N"), ActionRunStage.Pre);
                         }
                         else if (step is IActionRunner actionStep)
                         {


### PR DESCRIPTION
We are getting tons of errors on the service everyday about
`Record 7a9fa351-99bd-4bcb-9bbc-90c9d6f68d94 (name: Initialize containers, type: Task) does not have a reference name.`

This is because we didn't set a `refname` for any of the container setup steps:
- `Initialize containers`
- `Pull * container`
- `Build * container`

Errors every day...
![image](https://user-images.githubusercontent.com/1750815/148873602-4db959fc-92f1-4206-aed1-17615135d3a5.png)

This will also fix https://github.com/github/c2c-actions-runtime/issues/1602