### PR TITLE
Use Net.WebClient instead of Invoke-WebRequest

### DIFF
--- a/releaseNote.md
+++ b/releaseNote.md
@@ -25,8 +25,10 @@ The following snipped needs to be run on `powershell`:
 ``` powershell
 # Create a folder under the drive root
 mkdir \actions-runner ; cd \actions-runner
+
 # Download the latest runner package
-Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/v<RUNNER_VERSION>/actions-runner-win-x64-<RUNNER_VERSION>.zip -OutFile actions-runner-win-x64-<RUNNER_VERSION>.zip
+(New-Object Net.WebClient).DownloadFile("https://github.com/actions/runner/releases/download/v<RUNNER_VERSION>/actions-runner-win-x64-<RUNNER_VERSION>.zip", "$PWD\actions-runner-win-x64-<RUNNER_VERSION>.zip")
+
 # Extract the installer
 Add-Type -AssemblyName System.IO.Compression.FileSystem ;
 [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD\actions-runner-win-x64-<RUNNER_VERSION>.zip", "$PWD")


### PR DESCRIPTION
Description: The problem was recommending the use of the Invoke-WebRequest command to download the project on a Windows operating system. The solution is to recommend a much faster command that uses Net.WebClient object. 

Related Issue: https://github.com/actions/runner/issues/1550

After this change download performance was definitely improved for me too.


