### PR TITLE
Introduce GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY=1 to skip SSL cert verification for the runner.

### DIFF
--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -193,6 +193,11 @@ namespace GitHub.Runner.Common
                 _trace.Info($"No proxy settings were found based on environmental variables (http_proxy/https_proxy/HTTP_PROXY/HTTPS_PROXY)");
             }
 
+            if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY")))
+            {
+                _trace.Warning($"Runner is running under insecure mode: HTTPS server certifcate validation has been turned off by GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY environment variable.");
+            }
+
             var credFile = GetConfigFile(WellKnownConfigFile.Credentials);
             if (File.Exists(credFile))
             {
@@ -350,7 +355,7 @@ namespace GitHub.Runner.Common
                         GetDirectory(WellKnownDirectory.Root),
                         ".setup_info");
                     break;
-                
+
                 case WellKnownConfigFile.Telemetry:
                     path = Path.Combine(
                         GetDirectory(WellKnownDirectory.Diag),

--- a/src/Runner.Common/HttpClientHandlerFactory.cs
+++ b/src/Runner.Common/HttpClientHandlerFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using GitHub.Runner.Sdk;
 
@@ -13,7 +14,14 @@ namespace GitHub.Runner.Common
     {
         public HttpClientHandler CreateClientHandler(RunnerWebProxy webProxy)
         {
-            return new HttpClientHandler() { Proxy = webProxy };
+            var client = new HttpClientHandler() { Proxy = webProxy };
+
+            if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY")))
+            {
+                client.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+            }
+
+            return client;
         }
     }
 }

--- a/src/Runner.Sdk/Util/VssUtil.cs
+++ b/src/Runner.Sdk/Util/VssUtil.cs
@@ -27,6 +27,11 @@ namespace GitHub.Runner.Sdk
 
             VssClientHttpRequestSettings.Default.UserAgent = headerValues;
             VssHttpMessageHandler.DefaultWebProxy = proxy;
+
+            if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY")))
+            {
+                VssClientHttpRequestSettings.Default.ServerCertificateValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+            }
         }
 
         public static VssConnection CreateConnection(Uri serverUri, VssCredentials credentials, IEnumerable<DelegatingHandler> additionalDelegatingHandler = null, TimeSpan? timeout = null)


### PR DESCRIPTION
Allow customers to turn off SSL validation when the runner connects to the service.

`export GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY=1` before configuring and running the runner.

Use cases
- Behind proxy that tries to decrypt SSL traffic for audit
- Self-signed cert for GHES is not compatible with a certain OS, ex macOS

https://github.com/github/c2c-actions-runtime/issues/1484

close: https://github.com/actions/runner/issues/286