### PR TITLE
Issue 1528: use OS specific path separator

### DIFF
--- a/src/Sdk/Common/Common/ClientStorage/VssFileStorage.cs
+++ b/src/Sdk/Common/Common/ClientStorage/VssFileStorage.cs
@@ -24,7 +24,11 @@ namespace GitHub.Services.Common.ClientStorage
         private readonly VssFileStorageReader m_reader;
         private readonly IVssClientStorageWriter m_writer;
 
+#if OS_WINDOWS
         private const char c_defaultPathSeparator = '\\';
+#else
+        private const char c_defaultPathSeparator = '/';
+#endif
         private const bool c_defaultIgnoreCaseInPaths = false;
 
         /// <summary>
@@ -192,7 +196,7 @@ namespace GitHub.Services.Common.ClientStorage
                 // Windows Impersonation is being used.
 
                 // Check to see if we can find the user's local application data directory.
-                string subDir = "GitHub\\ActionsService";
+                string subDir = $"GitHub{c_defaultPathSeparator}ActionsService";
                 string path = Environment.GetEnvironmentVariable("localappdata");
                 SafeGetFolderPath(Environment.SpecialFolder.LocalApplicationData);
                 if (string.IsNullOrEmpty(path))

--- a/src/Sdk/Common/Common/ClientStorage/VssFileStorage.cs
+++ b/src/Sdk/Common/Common/ClientStorage/VssFileStorage.cs
@@ -23,12 +23,7 @@ namespace GitHub.Services.Common.ClientStorage
         private readonly string m_filePath;
         private readonly VssFileStorageReader m_reader;
         private readonly IVssClientStorageWriter m_writer;
-
-#if OS_WINDOWS
         private const char c_defaultPathSeparator = '\\';
-#else
-        private const char c_defaultPathSeparator = '/';
-#endif
         private const bool c_defaultIgnoreCaseInPaths = false;
 
         /// <summary>
@@ -196,7 +191,7 @@ namespace GitHub.Services.Common.ClientStorage
                 // Windows Impersonation is being used.
 
                 // Check to see if we can find the user's local application data directory.
-                string subDir = $"GitHub{c_defaultPathSeparator}ActionsService";
+                string subDir = Path.Combine("GitHub", "ActionsService");
                 string path = Environment.GetEnvironmentVariable("localappdata");
                 SafeGetFolderPath(Environment.SpecialFolder.LocalApplicationData);
                 if (string.IsNullOrEmpty(path))


### PR DESCRIPTION
Description: Problem was usage of \\ as path separator on non-Windows platforms.

Closes #1528, closes #1810 

After this change, VssFileStorage uses path separator based on OS.