### PR TITLE
Issue 1261: inconsistency of outputs (both canceled and cancelled are used)

### DIFF
--- a/src/Runner.Listener/JobDispatcher.cs
+++ b/src/Runner.Listener/JobDispatcher.cs
@@ -285,7 +285,7 @@ namespace GitHub.Runner.Listener
                     {
                         // at this point, the job execution might encounter some dead lock and even not able to be cancelled.
                         // no need to localize the exception string should never happen.
-                        throw new InvalidOperationException($"Job dispatch process for {jobDispatch.JobId} has encountered unexpected error, the dispatch task is not able to be canceled within 45 seconds.");
+                        throw new InvalidOperationException($"Job dispatch process for {jobDispatch.JobId} has encountered unexpected error, the dispatch task is not able to be cancelled within 45 seconds.");
                     }
                 }
                 else
@@ -363,7 +363,7 @@ namespace GitHub.Runner.Listener
                     Trace.Info($"Start renew job request {requestId} for job {message.JobId}.");
                     Task renewJobRequest = RenewJobRequestAsync(_poolId, requestId, lockToken, orchestrationId, firstJobRequestRenewed, lockRenewalTokenSource.Token);
 
-                    // wait till first renew succeed or job request is canceled
+                    // wait till first renew succeed or job request is cancelled
                     // not even start worker if the first renew fail
                     await Task.WhenAny(firstJobRequestRenewed.Task, renewJobRequest, Task.Delay(-1, jobRequestCancellationToken));
 
@@ -704,7 +704,7 @@ namespace GitHub.Runner.Listener
                 {
                     // OperationCanceledException may caused by http timeout or _lockRenewalTokenSource.Cance();
                     // Stop renew only on cancellation token fired.
-                    Trace.Info($"job renew has been canceled, stop renew job request {requestId}.");
+                    Trace.Info($"job renew has been cancelled, stop renew job request {requestId}.");
                     return;
                 }
                 catch (Exception ex)
@@ -762,7 +762,7 @@ namespace GitHub.Runner.Listener
                         }
                         catch (OperationCanceledException) when (token.IsCancellationRequested)
                         {
-                            Trace.Info($"job renew has been canceled, stop renew job request {requestId}.");
+                            Trace.Info($"job renew has been cancelled, stop renew job request {requestId}.");
                         }
                     }
                     else

--- a/src/Runner.Listener/SelfUpdater.cs
+++ b/src/Runner.Listener/SelfUpdater.cs
@@ -460,7 +460,7 @@ namespace GitHub.Runner.Listener
                     }
                     catch (OperationCanceledException) when (token.IsCancellationRequested)
                     {
-                        Trace.Info($"Runner download has been canceled.");
+                        Trace.Info($"Runner download has been cancelled.");
                         throw;
                     }
                     catch (Exception ex)

--- a/src/Runner.Plugins/Repository/v1.0/GitSourceProvider.cs
+++ b/src/Runner.Plugins/Repository/v1.0/GitSourceProvider.cs
@@ -166,7 +166,7 @@ namespace GitHub.Runner.Plugins.Repository.v1_0
             }
             else
             {
-                // delete the index.lock file left by previous canceled build or any operation cause git.exe crash last time.
+                // delete the index.lock file left by previous cancelled build or any operation cause git.exe crash last time.
                 string lockFile = Path.Combine(targetPath, ".git\\index.lock");
                 if (File.Exists(lockFile))
                 {
@@ -181,7 +181,7 @@ namespace GitHub.Runner.Plugins.Repository.v1_0
                     }
                 }
 
-                // delete the shallow.lock file left by previous canceled build or any operation cause git.exe crash last time.		
+                // delete the shallow.lock file left by previous cancelled build or any operation cause git.exe crash last time.		
                 string shallowLockFile = Path.Combine(targetPath, ".git\\shallow.lock");
                 if (File.Exists(shallowLockFile))
                 {

--- a/src/Runner.Plugins/Repository/v1.1/GitSourceProvider.cs
+++ b/src/Runner.Plugins/Repository/v1.1/GitSourceProvider.cs
@@ -150,7 +150,7 @@ namespace GitHub.Runner.Plugins.Repository.v1_1
             }
             else
             {
-                // delete the index.lock file left by previous canceled build or any operation cause git.exe crash last time.
+                // delete the index.lock file left by previous cancelled build or any operation cause git.exe crash last time.
                 string lockFile = Path.Combine(targetPath, ".git\\index.lock");
                 if (File.Exists(lockFile))
                 {
@@ -165,7 +165,7 @@ namespace GitHub.Runner.Plugins.Repository.v1_1
                     }
                 }
 
-                // delete the shallow.lock file left by previous canceled build or any operation cause git.exe crash last time.		
+                // delete the shallow.lock file left by previous cancelled build or any operation cause git.exe crash last time.		
                 string shallowLockFile = Path.Combine(targetPath, ".git\\shallow.lock");
                 if (File.Exists(shallowLockFile))
                 {

--- a/src/Runner.Sdk/Util/IOUtil.cs
+++ b/src/Runner.Sdk/Util/IOUtil.cs
@@ -108,7 +108,7 @@ namespace GitHub.Runner.Sdk
             }
 
             // Create a new token source for the parallel query. The parallel query should be
-            // canceled after the first error is encountered. Otherwise the number of exceptions
+            // cancelled after the first error is encountered. Otherwise the number of exceptions
             // could get out of control for a large directory with access denied on every file.
             using (var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
             {

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -654,7 +654,7 @@ namespace GitHub.Runner.Worker
                     actionDownloadInfos = await jobServer.ResolveActionDownloadInfoAsync(executionContext.Global.Plan.ScopeIdentifier, executionContext.Global.Plan.PlanType, executionContext.Global.Plan.PlanId, new WebApi.ActionReferenceList { Actions = actionReferences }, executionContext.CancellationToken);
                     break;
                 }
-                catch (Exception ex) when (!executionContext.CancellationToken.IsCancellationRequested) // Do not retry if the run is canceled.
+                catch (Exception ex) when (!executionContext.CancellationToken.IsCancellationRequested) // Do not retry if the run is cancelled.
                 {
                     // UnresolvableActionDownloadInfoException is a 422 client error, don't retry
                     // Some possible cases are:

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -303,7 +303,7 @@ namespace GitHub.Runner.Worker.Handlers
                     // Register job cancellation call back only if job cancellation token not been fire before each step run
                     if (!ExecutionContext.Root.CancellationToken.IsCancellationRequested)
                     {
-                        // Test the condition again. The job was canceled after the condition was originally evaluated.
+                        // Test the condition again. The job was cancelled after the condition was originally evaluated.
                         jobCancelRegister = ExecutionContext.Root.CancellationToken.Register(() =>
                         {
                             // Mark job as cancelled
@@ -403,7 +403,7 @@ namespace GitHub.Runner.Worker.Handlers
                         jobCancelRegister = null;
                     }
                 }
-                // Check failed or canceled
+                // Check failed or cancelled
                 if (step.ExecutionContext.Result == TaskResult.Failed || step.ExecutionContext.Result == TaskResult.Canceled)
                 {
                     Trace.Info($"Update job result with current composite step result '{step.ExecutionContext.Result}'.");

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -74,7 +74,7 @@ namespace GitHub.Runner.Worker
                     switch (HostContext.RunnerShutdownReason)
                     {
                         case ShutdownReason.UserCancelled:
-                            errorMessage = "The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.";
+                            errorMessage = "The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is cancelled.";
                             break;
                         case ShutdownReason.OperatingSystemShutdown:
                             errorMessage = $"Operating system is shutting down for computer '{Environment.MachineName}'";
@@ -130,9 +130,9 @@ namespace GitHub.Runner.Worker
                 }
                 catch (OperationCanceledException ex) when (jobContext.CancellationToken.IsCancellationRequested)
                 {
-                    // set the job to canceled
+                    // set the job to cancelled
                     // don't log error issue to job ExecutionContext, since server owns the job level issue
-                    Trace.Error($"Job is canceled during initialize.");
+                    Trace.Error($"Job is cancelled during initialize.");
                     Trace.Error($"Caught exception: {ex}");
                     return await CompleteJobAsync(jobServer, jobContext, message, TaskResult.Canceled);
                 }

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -74,7 +74,7 @@ namespace GitHub.Runner.Worker
                     switch (HostContext.RunnerShutdownReason)
                     {
                         case ShutdownReason.UserCancelled:
-                            errorMessage = "The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is cancelled.";
+                            errorMessage = "The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.";
                             break;
                         case ShutdownReason.OperatingSystemShutdown:
                             errorMessage = $"Operating system is shutting down for computer '{Environment.MachineName}'";

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -130,7 +130,7 @@ namespace GitHub.Runner.Worker
                         // Register job cancellation call back only if job cancellation token not been fire before each step run
                         if (!jobContext.CancellationToken.IsCancellationRequested)
                         {
-                            // Test the condition again. The job was canceled after the condition was originally evaluated.
+                            // Test the condition again. The job was cancelled after the condition was originally evaluated.
                             jobCancelRegister = jobContext.CancellationToken.Register(() =>
                             {
                                 // Mark job as cancelled


### PR DESCRIPTION
Problem was the inconsistent use of words canceled and cancelled.

Related issue: https://github.com/actions/runner/issues/1261

After this change, the word cancelled is used in all traces and logs. The problem of changing enum values still remains, because it requires major protocol changes.