### PR TITLE
Problem with debugging on macOS M1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
             ],
             "cwd": "${workspaceFolder}/src",
             "console": "integratedTerminal",
-            "requireExactSource": false
+            "requireExactSource": false,
+            "targetArchitecture": "x86_64"
         },
         {
             "name": "Run",
@@ -24,7 +25,8 @@
             ],
             "cwd": "${workspaceFolder}/src",
             "console": "integratedTerminal",
-            "requireExactSource": false
+            "requireExactSource": false,
+            "targetArchitecture": "x86_64"
         },
         {
             "name": "Configure",
@@ -37,21 +39,24 @@
             ],
             "cwd": "${workspaceFolder}/src",
             "console": "integratedTerminal",
-            "requireExactSource": false
+            "requireExactSource": false,
+            "targetArchitecture": "x86_64"
         },
         {
             "name": "Debug Worker",
             "type": "coreclr",
             "request": "attach",
             "processName": "Runner.Worker",
-            "requireExactSource": false
+            "requireExactSource": false,
+            "targetArchitecture": "x86_64"
         },
         {
             "name": "Attach Debugger",
             "type": "coreclr",
             "request": "attach",
             "processId": "${command:pickProcess}",
-            "requireExactSource": false
+            "requireExactSource": false,
+            "targetArchitecture": "x86_64"
         },
     ],
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,7 @@
             "cwd": "${workspaceFolder}/src",
             "console": "integratedTerminal",
             "requireExactSource": false,
+            //"targetArchitecture": "x86_64"
         },
         {
             "name": "Run",
@@ -25,6 +26,7 @@
             "cwd": "${workspaceFolder}/src",
             "console": "integratedTerminal",
             "requireExactSource": false,
+            //"targetArchitecture": "x86_64"
         },
         {
             "name": "Configure",
@@ -38,6 +40,7 @@
             "cwd": "${workspaceFolder}/src",
             "console": "integratedTerminal",
             "requireExactSource": false,
+            //"targetArchitecture": "x86_64"
         },
         {
             "name": "Debug Worker",
@@ -45,6 +48,7 @@
             "request": "attach",
             "processName": "Runner.Worker",
             "requireExactSource": false,
+            //"targetArchitecture": "x86_64"
         },
         {
             "name": "Attach Debugger",
@@ -52,6 +56,8 @@
             "request": "attach",
             "processId": "${command:pickProcess}",
             "requireExactSource": false,
+            //"targetArchitecture": "x86_64"
         },
     ],
 }
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,7 @@
             ],
             "cwd": "${workspaceFolder}/src",
             "console": "integratedTerminal",
-            "requireExactSource": false,
-            //"targetArchitecture": "x86_64"
+            "requireExactSource": false
         },
         {
             "name": "Run",
@@ -25,8 +24,7 @@
             ],
             "cwd": "${workspaceFolder}/src",
             "console": "integratedTerminal",
-            "requireExactSource": false,
-            //"targetArchitecture": "x86_64"
+            "requireExactSource": false
         },
         {
             "name": "Configure",
@@ -39,24 +37,21 @@
             ],
             "cwd": "${workspaceFolder}/src",
             "console": "integratedTerminal",
-            "requireExactSource": false,
-            //"targetArchitecture": "x86_64"
+            "requireExactSource": false
         },
         {
             "name": "Debug Worker",
             "type": "coreclr",
             "request": "attach",
             "processName": "Runner.Worker",
-            "requireExactSource": false,
-            //"targetArchitecture": "x86_64"
+            "requireExactSource": false
         },
         {
             "name": "Attach Debugger",
             "type": "coreclr",
             "request": "attach",
             "processId": "${command:pickProcess}",
-            "requireExactSource": false,
-            //"targetArchitecture": "x86_64"
+            "requireExactSource": false
         },
     ],
 }

--- a/docs/contribute/vscode.md
+++ b/docs/contribute/vscode.md
@@ -28,7 +28,7 @@ All the configs below can be found in `.vscode/launch.json`.
     ],
     "cwd": "${workspaceFolder}/src",
     "console": "integratedTerminal",
-    "requireExactSource": false
+    "requireExactSource": false,
 }
 ```
 
@@ -50,4 +50,3 @@ All worker processes now will wait 20 seconds before they start working on their
 This gives enough time to attach a debugger by running `Debug Worker`.
 If for some reason you have multiple workers running, run the launch config `Attach` instead.
 Select `Runner.Worker` from the running processes when VS Code prompts for it.
-

--- a/docs/contribute/vscode.md
+++ b/docs/contribute/vscode.md
@@ -12,7 +12,6 @@ Check [Quickstart](../contribute.md#quickstart-run-a-job-from-a-real-repository)
 ## Debugging
 
 Debugging the full lifecycle of a job can be tricky, because there are multiple processes involved.
-If you're using macOS with Apple M1 chip (arm64 architecture), you need to add "targetArchitecture": "x86_64" to all configs.
 All the configs below can be found in `.vscode/launch.json`.
 
 ## Debug the Listener
@@ -29,8 +28,7 @@ All the configs below can be found in `.vscode/launch.json`.
     ],
     "cwd": "${workspaceFolder}/src",
     "console": "integratedTerminal",
-    "requireExactSource": false,
-    "targetArchitecture": "x86_64"        // for debugging on macOS M1
+    "requireExactSource": false
 }
 ```
 

--- a/docs/contribute/vscode.md
+++ b/docs/contribute/vscode.md
@@ -12,6 +12,7 @@ Check [Quickstart](../contribute.md#quickstart-run-a-job-from-a-real-repository)
 ## Debugging
 
 Debugging the full lifecycle of a job can be tricky, because there are multiple processes involved.
+If you're using macOS with Apple M1 chip (arm64 architecture), you need to uncomment all "targetArchitecture": "x86_64" lines in `.vscode/launch.json`.
 All the configs below can be found in `.vscode/launch.json`.
 
 ## Debug the Listener
@@ -29,6 +30,7 @@ All the configs below can be found in `.vscode/launch.json`.
     "cwd": "${workspaceFolder}/src",
     "console": "integratedTerminal",
     "requireExactSource": false,
+    //"targetArchitecture": "x86_64"        // uncomment if you're using macOS M1
 }
 ```
 
@@ -50,3 +52,4 @@ All worker processes now will wait 20 seconds before they start working on their
 This gives enough time to attach a debugger by running `Debug Worker`.
 If for some reason you have multiple workers running, run the launch config `Attach` instead.
 Select `Runner.Worker` from the running processes when VS Code prompts for it.
+

--- a/docs/contribute/vscode.md
+++ b/docs/contribute/vscode.md
@@ -12,7 +12,7 @@ Check [Quickstart](../contribute.md#quickstart-run-a-job-from-a-real-repository)
 ## Debugging
 
 Debugging the full lifecycle of a job can be tricky, because there are multiple processes involved.
-If you're using macOS with Apple M1 chip (arm64 architecture), you need to uncomment all "targetArchitecture": "x86_64" lines in `.vscode/launch.json`.
+If you're using macOS with Apple M1 chip (arm64 architecture), you need to add "targetArchitecture": "x86_64" to all configs.
 All the configs below can be found in `.vscode/launch.json`.
 
 ## Debug the Listener
@@ -30,7 +30,7 @@ All the configs below can be found in `.vscode/launch.json`.
     "cwd": "${workspaceFolder}/src",
     "console": "integratedTerminal",
     "requireExactSource": false,
-    //"targetArchitecture": "x86_64"        // uncomment if you're using macOS M1
+    "targetArchitecture": "x86_64"        // for debugging on macOS M1
 }
 ```
 


### PR DESCRIPTION
Description: Problem with debugging actions/runner on macOS with M1 chip.

After this change, the user is able to debug the runner on macOS M1 without any problems.
Proposed changes were also tested on macOS with Intel processor, Linux and Windows, and no problems were noticed. Therefore, such configurations in the launch.json will work for all users.