### PR TITLE
Use default 8Mb chunking for the FileContainer uploads

### DIFF
--- a/src/Runner.Plugins/Artifact/FileContainerServer.cs
+++ b/src/Runner.Plugins/Artifact/FileContainerServer.cs
@@ -469,7 +469,7 @@ namespace GitHub.Runner.Plugins.Artifact
                         try
                         {
                             uploadTimer.Restart();
-                            using (HttpResponseMessage response = await _fileContainerHttpClient.UploadFileAsync(_containerId, itemPath, fs, _projectId, cancellationToken: token, chunkSize: 4 * 1024 * 1024))
+                            using (HttpResponseMessage response = await _fileContainerHttpClient.UploadFileAsync(_containerId, itemPath, fs, _projectId, cancellationToken: token))
                             {
                                 if (response == null || response.StatusCode != HttpStatusCode.Created)
                                 {


### PR DESCRIPTION
`FileContainer` uploads use 4Mb chunking when doing multipart uploads. This contributes to complexity on the server side when AWS S3 blob storage is used (In GitHub Enterprise Server). S3 imposes minimum chunk size constraint of 5Mb.

This PR switches FileContainer uploads to use [default chunking which is 8Mb](https://github.com/actions/runner/blob/c95d5eae3092358e0027f4d26b9962eedf2af93c/src/Sdk/WebApi/WebApi/HttpClients/FileContainerHttpClient.cs#L117). 