### PR TITLE
Pass `jobId` to the actionsDownloadInfo controller

### DIFF
--- a/src/Runner.Common/JobServer.cs
+++ b/src/Runner.Common/JobServer.cs
@@ -42,7 +42,7 @@ namespace GitHub.Runner.Common
             int attemptCount = totalAttempts;
             var configurationStore = HostContext.GetService<IConfigurationStore>();
             var runnerSettings = configurationStore.GetSettings();
- 
+
             while (!_connection.HasAuthenticated && attemptCount-- > 0)
             {
                 try

--- a/src/Runner.Common/JobServer.cs
+++ b/src/Runner.Common/JobServer.cs
@@ -41,8 +41,8 @@ namespace GitHub.Runner.Common
             int totalAttempts = 5;
             int attemptCount = totalAttempts;
             var configurationStore = HostContext.GetService<IConfigurationStore>();
-            var runnerSettings = configurationStore.GetSettings(); 
-            
+            var runnerSettings = configurationStore.GetSettings();
+
             while (!_connection.HasAuthenticated && attemptCount-- > 0)
             {
                 try

--- a/src/Runner.Common/JobServer.cs
+++ b/src/Runner.Common/JobServer.cs
@@ -41,7 +41,7 @@ namespace GitHub.Runner.Common
             int totalAttempts = 5;
             int attemptCount = totalAttempts;
             var configurationStore = HostContext.GetService<IConfigurationStore>();
-            var runnerSettings = configurationStore.GetSettings();
+            var runnerSettings = configurationStore.GetSettings(); 
             
             while (!_connection.HasAuthenticated && attemptCount-- > 0)
             {

--- a/src/Runner.Common/JobServer.cs
+++ b/src/Runner.Common/JobServer.cs
@@ -42,7 +42,7 @@ namespace GitHub.Runner.Common
             int attemptCount = totalAttempts;
             var configurationStore = HostContext.GetService<IConfigurationStore>();
             var runnerSettings = configurationStore.GetSettings();
-
+            
             while (!_connection.HasAuthenticated && attemptCount-- > 0)
             {
                 try

--- a/src/Runner.Common/JobServer.cs
+++ b/src/Runner.Common/JobServer.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.DistributedTask.WebApi;
+using GitHub.DistributedTask.WebApi;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -26,7 +26,7 @@ namespace GitHub.Runner.Common
         Task<List<TimelineRecord>> UpdateTimelineRecordsAsync(Guid scopeIdentifier, string hubName, Guid planId, Guid timelineId, IEnumerable<TimelineRecord> records, CancellationToken cancellationToken);
         Task RaisePlanEventAsync<T>(Guid scopeIdentifier, string hubName, Guid planId, T eventData, CancellationToken cancellationToken) where T : JobEvent;
         Task<Timeline> GetTimelineAsync(Guid scopeIdentifier, string hubName, Guid planId, Guid timelineId, CancellationToken cancellationToken);
-        Task<ActionDownloadInfoCollection> ResolveActionDownloadInfoAsync(Guid scopeIdentifier, string hubName, Guid planId, ActionReferenceList actions, CancellationToken cancellationToken);
+        Task<ActionDownloadInfoCollection> ResolveActionDownloadInfoAsync(Guid scopeIdentifier, string hubName, Guid planId, Guid jobId, ActionReferenceList actions, CancellationToken cancellationToken);
     }
 
     public sealed class JobServer : RunnerService, IJobServer
@@ -186,10 +186,10 @@ namespace GitHub.Runner.Common
         //-----------------------------------------------------------------
         // Action download info
         //-----------------------------------------------------------------
-        public Task<ActionDownloadInfoCollection> ResolveActionDownloadInfoAsync(Guid scopeIdentifier, string hubName, Guid planId, ActionReferenceList actions, CancellationToken cancellationToken)
+        public Task<ActionDownloadInfoCollection> ResolveActionDownloadInfoAsync(Guid scopeIdentifier, string hubName, Guid planId, Guid jobId, ActionReferenceList actions, CancellationToken cancellationToken)
         {
             CheckConnection();
-            return _taskClient.ResolveActionDownloadInfoAsync(scopeIdentifier, hubName, planId, actions, cancellationToken: cancellationToken);
+            return _taskClient.ResolveActionDownloadInfoAsync(scopeIdentifier, hubName, planId, jobId, actions, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -619,7 +619,7 @@ namespace GitHub.Runner.Worker
         private async Task<IDictionary<string, WebApi.ActionDownloadInfo>> GetDownloadInfoAsync(IExecutionContext executionContext, List<Pipelines.ActionStep> actions)
         {
             executionContext.Output("Getting action download info");
-            
+
             // Convert to action reference
             var actionReferences = actions
                 .GroupBy(x => GetDownloadInfoLookupKey(x))

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -619,7 +619,6 @@ namespace GitHub.Runner.Worker
         private async Task<IDictionary<string, WebApi.ActionDownloadInfo>> GetDownloadInfoAsync(IExecutionContext executionContext, List<Pipelines.ActionStep> actions)
         {
             executionContext.Output("Getting action download info");
-            executionContext.Output($"yay!!!! got jobid: {executionContext.Root.Id}");
             // Convert to action reference
             var actionReferences = actions
                 .GroupBy(x => GetDownloadInfoLookupKey(x))
@@ -650,7 +649,7 @@ namespace GitHub.Runner.Worker
             for (var attempt = 1; attempt <= 3; attempt++)
             {
                 try
-                {   
+                {
                     actionDownloadInfos = await jobServer.ResolveActionDownloadInfoAsync(executionContext.Global.Plan.ScopeIdentifier, executionContext.Global.Plan.PlanType, executionContext.Global.Plan.PlanId, executionContext.Root.Id, new WebApi.ActionReferenceList { Actions = actionReferences }, executionContext.CancellationToken);
                     break;
                 }

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -619,7 +619,7 @@ namespace GitHub.Runner.Worker
         private async Task<IDictionary<string, WebApi.ActionDownloadInfo>> GetDownloadInfoAsync(IExecutionContext executionContext, List<Pipelines.ActionStep> actions)
         {
             executionContext.Output("Getting action download info");
-
+            executionContext.Output($"yay!!!! got jobid: {executionContext.Root.Id}");
             // Convert to action reference
             var actionReferences = actions
                 .GroupBy(x => GetDownloadInfoLookupKey(x))
@@ -650,8 +650,8 @@ namespace GitHub.Runner.Worker
             for (var attempt = 1; attempt <= 3; attempt++)
             {
                 try
-                {
-                    actionDownloadInfos = await jobServer.ResolveActionDownloadInfoAsync(executionContext.Global.Plan.ScopeIdentifier, executionContext.Global.Plan.PlanType, executionContext.Global.Plan.PlanId, new WebApi.ActionReferenceList { Actions = actionReferences }, executionContext.CancellationToken);
+                {   
+                    actionDownloadInfos = await jobServer.ResolveActionDownloadInfoAsync(executionContext.Global.Plan.ScopeIdentifier, executionContext.Global.Plan.PlanType, executionContext.Global.Plan.PlanId, executionContext.Root.Id, new WebApi.ActionReferenceList { Actions = actionReferences }, executionContext.CancellationToken);
                     break;
                 }
                 catch (Exception ex) when (!executionContext.CancellationToken.IsCancellationRequested) // Do not retry if the run is canceled.

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -619,6 +619,7 @@ namespace GitHub.Runner.Worker
         private async Task<IDictionary<string, WebApi.ActionDownloadInfo>> GetDownloadInfoAsync(IExecutionContext executionContext, List<Pipelines.ActionStep> actions)
         {
             executionContext.Output("Getting action download info");
+            
             // Convert to action reference
             var actionReferences = actions
                 .GroupBy(x => GetDownloadInfoLookupKey(x))

--- a/src/Sdk/DTGenerated/Generated/TaskHttpClientBase.cs
+++ b/src/Sdk/DTGenerated/Generated/TaskHttpClientBase.cs
@@ -341,7 +341,7 @@ namespace GitHub.DistributedTask.WebApi
             Guid locationId = new Guid("27d7f831-88c1-4719-8ca1-6a061dad90eb");
             object routeValues = new { scopeIdentifier = scopeIdentifier, hubName = hubName, planId = planId, jobId = jobId };
             HttpContent content = new ObjectContent<ActionReferenceList>(actionReferenceList, new VssJsonMediaTypeFormatter(true));
-    
+
             return SendAsync<ActionDownloadInfoCollection>(
                 httpMethod,
                 locationId,

--- a/src/Sdk/DTGenerated/Generated/TaskHttpClientBase.cs
+++ b/src/Sdk/DTGenerated/Generated/TaskHttpClientBase.cs
@@ -339,7 +339,7 @@ namespace GitHub.DistributedTask.WebApi
         {
             HttpMethod httpMethod = new HttpMethod("POST");
             Guid locationId = new Guid("27d7f831-88c1-4719-8ca1-6a061dad90eb");
-            object routeValues = new { scopeIdentifier = scopeIdentifier, hubName = hubName, planId = planId};
+            object routeValues = new { scopeIdentifier = scopeIdentifier, hubName = hubName, planId = planId };
             HttpContent content = new ObjectContent<ActionReferenceList>(actionReferenceList, new VssJsonMediaTypeFormatter(true));
       
             List<KeyValuePair<string, string>> queryParams = new List<KeyValuePair<string, string>>();

--- a/src/Sdk/DTGenerated/Generated/TaskHttpClientBase.cs
+++ b/src/Sdk/DTGenerated/Generated/TaskHttpClientBase.cs
@@ -337,11 +337,11 @@ namespace GitHub.DistributedTask.WebApi
             object userState = null,
             CancellationToken cancellationToken = default)
         {
-           HttpMethod httpMethod = new HttpMethod("POST");
+            HttpMethod httpMethod = new HttpMethod("POST");
             Guid locationId = new Guid("27d7f831-88c1-4719-8ca1-6a061dad90eb");
             object routeValues = new { scopeIdentifier = scopeIdentifier, hubName = hubName, planId = planId};
             HttpContent content = new ObjectContent<ActionReferenceList>(actionReferenceList, new VssJsonMediaTypeFormatter(true));
-            
+      
             List<KeyValuePair<string, string>> queryParams = new List<KeyValuePair<string, string>>();
             queryParams.Add("jobId", jobId);
             return SendAsync<ActionDownloadInfoCollection>(

--- a/src/Sdk/DTGenerated/Generated/TaskHttpClientBase.cs
+++ b/src/Sdk/DTGenerated/Generated/TaskHttpClientBase.cs
@@ -337,16 +337,19 @@ namespace GitHub.DistributedTask.WebApi
             object userState = null,
             CancellationToken cancellationToken = default)
         {
-            HttpMethod httpMethod = new HttpMethod("POST");
+           HttpMethod httpMethod = new HttpMethod("POST");
             Guid locationId = new Guid("27d7f831-88c1-4719-8ca1-6a061dad90eb");
-            object routeValues = new { scopeIdentifier = scopeIdentifier, hubName = hubName, planId = planId, jobId = jobId };
+            object routeValues = new { scopeIdentifier = scopeIdentifier, hubName = hubName, planId = planId};
             HttpContent content = new ObjectContent<ActionReferenceList>(actionReferenceList, new VssJsonMediaTypeFormatter(true));
-
+            
+            List<KeyValuePair<string, string>> queryParams = new List<KeyValuePair<string, string>>();
+            queryParams.Add("jobId", jobId);
             return SendAsync<ActionDownloadInfoCollection>(
                 httpMethod,
                 locationId,
                 routeValues: routeValues,
                 version: new ApiResourceVersion(6.0, 1),
+                queryParameters: queryParams,
                 userState: userState,
                 cancellationToken: cancellationToken,
                 content: content);

--- a/src/Sdk/DTGenerated/Generated/TaskHttpClientBase.cs
+++ b/src/Sdk/DTGenerated/Generated/TaskHttpClientBase.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * ---------------------------------------------------------
  * Copyright(C) Microsoft Corporation. All rights reserved.
  * ---------------------------------------------------------
@@ -324,6 +324,7 @@ namespace GitHub.DistributedTask.WebApi
         /// <param name="scopeIdentifier">The project GUID to scope the request</param>
         /// <param name="hubName">The name of the server hub: "build" for the Build server or "rm" for the Release Management server</param>
         /// <param name="planId"></param>
+        /// <param name="jobId"></param>
         /// <param name="actionReferenceList"></param>
         /// <param name="userState"></param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
@@ -331,15 +332,16 @@ namespace GitHub.DistributedTask.WebApi
             Guid scopeIdentifier,
             string hubName,
             Guid planId,
+            Guid jobId,
             ActionReferenceList actionReferenceList,
             object userState = null,
             CancellationToken cancellationToken = default)
         {
             HttpMethod httpMethod = new HttpMethod("POST");
             Guid locationId = new Guid("27d7f831-88c1-4719-8ca1-6a061dad90eb");
-            object routeValues = new { scopeIdentifier = scopeIdentifier, hubName = hubName, planId = planId };
+            object routeValues = new { scopeIdentifier = scopeIdentifier, hubName = hubName, planId = planId, jobId = jobId };
             HttpContent content = new ObjectContent<ActionReferenceList>(actionReferenceList, new VssJsonMediaTypeFormatter(true));
-
+    
             return SendAsync<ActionDownloadInfoCollection>(
                 httpMethod,
                 locationId,

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -2125,7 +2125,7 @@ runs:
         {
             _ecTokenSource?.Dispose();
             _ecTokenSource = new CancellationTokenSource();
-        
+
             // Test host context.
             _hc = new TestHostContext(this, name);
 

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -2156,8 +2156,8 @@ runs:
             _dockerManager.Setup(x => x.DockerBuild(_ec.Object, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(0));
 
             _jobServer = new Mock<IJobServer>();
-            _jobServer.Setup(x => x.ResolveActionDownloadInfoAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ActionReferenceList>(), It.IsAny<CancellationToken>()))
-                .Returns((Guid scopeIdentifier, string hubName, Guid planId, ActionReferenceList actions, CancellationToken cancellationToken) =>
+            _jobServer.Setup(x => x.ResolveActionDownloadInfoAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ActionReferenceList>(), It.IsAny<CancellationToken>()))
+                .Returns((Guid scopeIdentifier, string hubName, Guid planId, Guid jobId, ActionReferenceList actions, CancellationToken cancellationToken) =>
                 {
                     var result = new ActionDownloadInfoCollection { Actions = new Dictionary<string, ActionDownloadInfo>() };
                     foreach (var action in actions.Actions)

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -2125,7 +2125,7 @@ runs:
         {
             _ecTokenSource?.Dispose();
             _ecTokenSource = new CancellationTokenSource();
-
+        
             // Test host context.
             _hc = new TestHostContext(this, name);
 
@@ -2135,6 +2135,7 @@ runs:
             _ec = new Mock<IExecutionContext>();
             _ec.Setup(x => x.Global).Returns(new GlobalContext());
             _ec.Setup(x => x.CancellationToken).Returns(_ecTokenSource.Token);
+            _ec.Setup(x => x.Root).Returns(new GitHub.Runner.Worker.ExecutionContext());
             var variables = new Dictionary<string, VariableValue>();
             if (enableComposite)
             {


### PR DESCRIPTION
## Context
In order to have the job level telemetry in the github warehouse, `jobId` need to be passed to this table - `hive_hydro.hydro.github_actions_v0_resolve_action_request`
## Implementation
- In this PR `jobId` is being passed as a query parameter to the controller while downloading the actions info.
- This subsequently gets passed to the launch and launch passes this to dotcom's actions resolve API.
- Inside dotcom this `jobId` will be accepted and added to `hive_hydro.hydro.github_actions_v0_resolve_action_request`.
-  We have arrived at the `jobId` (`executionContext.Root.Id`) by matching it with the one from [CustomerIntelligenceHelper.cs](https://github.com/github/actions-dotnet/blob/1fdd638cf6a31a87a19fe6ade72a953ecf5b640e/Actions/Runtime/Sdk/Server/CustomerIntelligenceHelper.cs#L217)

👉[__ADR__](https://github.com/github/c2c-actions/blob/balaga-gayatri/ADR-for-adding-jobId/docs/adrs/3878-identifying-job-runs-from-gh-warehouse-data.md) for detailed implementation. 

**Tracking items** -
- EPIC - [ACE: Migrate to using Adoption data from dashboards instead of manual queries for Azure+GitHub collaboration reviews and reports](https://github.com/github/Actions-India/issues/52)
- Feature - [Deployments/Job Runs cannot be identified from GH warehouse data](https://github.com/github/c2c-actions/issues/3449)

**Other PRs**
- [Actions-dotnet](https://github.com/github/actions-dotnet/pull/10969)
- [Launch](https://github.com/github/launch/pull/5002)
- [Dotcom](https://github.com/github/github/pull/207293)
- [Hydro-schemas](https://github.com/github/hydro-schemas/pull/2390)