### PR TITLE
Use absolute path when invoking run-helper.sh or Runner.Listener

### DIFF
--- a/src/Misc/layoutroot/run-helper.sh.template
+++ b/src/Misc/layoutroot/run-helper.sh.template
@@ -26,7 +26,15 @@ safe_sleep() {
     fi
 }
 
-bin/Runner.Listener run $*
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+"$DIR"/bin/Runner.Listener run $*
+
 returnCode=$?
 if [[ $returnCode == 0 ]]; then
     echo "Runner listener exit with 0 return code, stop the service, no retry needed."

--- a/src/Misc/layoutroot/run.sh
+++ b/src/Misc/layoutroot/run.sh
@@ -9,7 +9,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
     [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-cp -f run-helper.sh.template run-helper.sh
+cp -f "$DIR"/run-helper.sh.template "$DIR"/run-helper.sh
 # run the helper process which keep the listener alive
 while :;
 do


### PR DESCRIPTION
This PR restores correct results of `CMD` column of `ps -ef`. Also fixes possible path related errors when running `run.sh` with a relative path from another folder.
Also fails `run.sh` earlier if run by sudo.

Runner process is once again shown as:
`workspaces/runner/_layout/bin/Runner.Listener run`
Instead of:
`bin/Runner.Listener run`
