### PR TITLE
Added examples and aligned language within docs/checks/actions.md

### DIFF
--- a/docs/checks/actions.md
+++ b/docs/checks/actions.md
@@ -6,13 +6,35 @@
 Make sure the runner has access to actions service for GitHub.com or GitHub Enterprise Server
 
 - For GitHub.com
-  - The runner needs to access https://api.github.com for downloading actions.
-  - The runner needs to access https://vstoken.actions.githubusercontent.com/_apis/.../ for requesting an access token.
-  - The runner needs to access https://pipelines.actions.githubusercontent.com/_apis/.../ for receiving workflow jobs.
+  - The runner needs to access `https://api.github.com` for downloading actions.
+  - The runner needs to access `https://vstoken.actions.githubusercontent.com/_apis/.../` for requesting an access token.
+  - The runner needs to access `https://pipelines.actions.githubusercontent.com/_apis/.../` for receiving workflow jobs.
+
+  These can by tested by running the following `curl` commands from your self-hosted runner machine:
+
+    ```
+    curl -v https://api.github.com/api/v3/zen
+    curl -v https://vstoken.actions.githubusercontent.com/_apis/health
+    curl -v https://pipelines.actions.githubusercontent/_apis/health
+    ```
+
 - For GitHub Enterprise Server
-  - The runner needs to access https://myGHES.com/api/v3 for downloading actions.
-  - The runner needs to access https://myGHES.com/_services/vstoken/_apis/.../ for requesting an access token.
-  - The runner needs to access https://myGHES.com/_services/pipelines/_apis/.../ for receiving workflow jobs.
+  - The runner needs to access `https://[hpstname]/api/v3` for downloading actions.
+  - The runner needs to access `https://[hpstname]/_services/vstoken/_apis/.../` for requesting an access token.
+  - The runner needs to access `https://[hpstname]/_services/pipelines/_apis/.../` for receiving workflow jobs.
+  
+  These can by tested by running the following `curl` commands from your self-hosted runner machine, replacing `[hostname]` with the hostname of your appliance, for instance `github.example.com`:
+
+    ```
+    curl -v https://[hpstname]/api/v3/zen
+    curl -v https://[hpstname]/_services/vstoken/_apis/health
+    curl -v https://[hpstname]/_services/pipelines/_apis/health
+    ```
+
+    A common cause of this these connectivity issues is if your to GitHub Enterprise Server appliance is using [the self-signed certificate that is enabled the first time](https://docs.github.com/en/enterprise-server/admin/configuration/configuring-network-settings/configuring-tls) your appliance is started. As self-signed certificates are not trusted by web browsers and Git clients, these clients (including the GitHub Actions runner) will report certificate warnings.
+    
+    We recommend [upload a certificate signed by a trusted authority](https://docs.github.com/en/enterprise-server/admin/configuration/configuring-network-settings/configuring-tls) to GitHub Enterprise Server, or enabling the built-in ][Let's Encrypt support](https://docs.github.com/en/enterprise-server/admin/configuration/configuring-network-settings/configuring-tls).
+
 
 ## What is checked?
 
@@ -42,4 +64,4 @@ Make sure the runner has access to actions service for GitHub.com or GitHub Ente
   
 ## Still not working?
 
-Contact GitHub customer service or log an issue at https://github.com/actions/runner if you think it's a runner issue.
+Contact [GitHub Support](https://support.github.com] if you have further questuons, or log an issue at https://github.com/actions/runner if you think it's a runner issue.

--- a/docs/checks/actions.md
+++ b/docs/checks/actions.md
@@ -19,16 +19,16 @@ Make sure the runner has access to actions service for GitHub.com or GitHub Ente
     ```
 
 - For GitHub Enterprise Server
-  - The runner needs to access `https://[hpstname]/api/v3` for downloading actions.
-  - The runner needs to access `https://[hpstname]/_services/vstoken/_apis/.../` for requesting an access token.
-  - The runner needs to access `https://[hpstname]/_services/pipelines/_apis/.../` for receiving workflow jobs.
+  - The runner needs to access `https://[hostname]/api/v3` for downloading actions.
+  - The runner needs to access `https://[hostname]/_services/vstoken/_apis/.../` for requesting an access token.
+  - The runner needs to access `https://[hostname]/_services/pipelines/_apis/.../` for receiving workflow jobs.
   
   These can by tested by running the following `curl` commands from your self-hosted runner machine, replacing `[hostname]` with the hostname of your appliance, for instance `github.example.com`:
 
     ```
-    curl -v https://[hpstname]/api/v3/zen
-    curl -v https://[hpstname]/_services/vstoken/_apis/health
-    curl -v https://[hpstname]/_services/pipelines/_apis/health
+    curl -v https://[hostname]/api/v3/zen
+    curl -v https://[hostname]/_services/vstoken/_apis/health
+    curl -v https://[hostname]/_services/pipelines/_apis/health
     ```
 
     A common cause of this these connectivity issues is if your to GitHub Enterprise Server appliance is using [the self-signed certificate that is enabled the first time](https://docs.github.com/en/enterprise-server/admin/configuration/configuring-network-settings/configuring-tls) your appliance is started. As self-signed certificates are not trusted by web browsers and Git clients, these clients (including the GitHub Actions runner) will report certificate warnings.


### PR DESCRIPTION
Added some practical examples to the `docs/checks` content.

This pages are linked to in the runner logs when the runner has connectivity issues. 

I've added examples to the Actions to connectivity  test, guiding users how to test this with `curl`, and aligned some formatting with the public GitHub documentation at https://docs.github.com. These updates align with the first troubleshooting steps that users will be requested to perform by GitHub Support.

In addition, for GitHub Enterprise Server, I included the common cause of these errors, that the default self-signed TLS certificate is being used rather than a trusted certificate. This will assist administrators with resolving this issue by uploading a trusted certificate to their appliance, or by enabling Let's Encrypt.

Using `[hostname]` within the GHES URL also aligns with best-practice from GitHub Support team.