### PR TITLE
Use job execution context instead of step for adding summary attachments

### DIFF
--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -317,7 +317,8 @@ namespace GitHub.Runner.Worker
                 var attachmentName = context.Id.ToString();
 
                 Trace.Info($"Queueing file ({filePath}) for attachment upload ({attachmentName})");
-                context.QueueAttachFile(ChecksAttachmentType.StepSummary, attachmentName, scrubbedFilePath);
+                // Attachments must be added to the parent context (job), not the current context (step)
+                context.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, attachmentName, scrubbedFilePath);
             }
             catch (Exception e)
             {

--- a/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
+++ b/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
@@ -31,7 +31,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             {
                 var stepSummaryFile = Path.Combine(_rootDirectory, "feature-off");
 
-                _executionContext.Verify(e => e.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
 
                 Assert.Equal(0, _issues.Count);
             }
@@ -46,7 +46,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             {
                 _createStepCommand.ProcessCommand(_executionContext.Object, null, null);
 
-                _executionContext.Verify(e => e.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -62,7 +62,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
 
-                _executionContext.Verify(e => e.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -78,7 +78,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
 
-                _executionContext.Verify(e => e.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -95,7 +95,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
 
-                _executionContext.Verify(e => e.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -112,7 +112,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
 
-                _executionContext.Verify(e => e.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
                 Assert.Equal(1, _issues.Count);
             }
         }
@@ -135,7 +135,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
 
-                _executionContext.Verify(e => e.QueueAttachFile(ChecksAttachmentType.StepSummary, _executionContext.Object.Id.ToString(), stepSummaryFile + "-scrubbed"), Times.Once());
+                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, _executionContext.Object.Id.ToString(), stepSummaryFile + "-scrubbed"), Times.Once());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -167,7 +167,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.DoesNotContain("ThisIsMySecretPassword!", scrubbedFileContents);
                 Assert.DoesNotContain("ghs_verysecuretoken", scrubbedFileContents);
 
-                _executionContext.Verify(e => e.QueueAttachFile(ChecksAttachmentType.StepSummary, _executionContext.Object.Id.ToString(), scrubbedFile), Times.Once());
+                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, _executionContext.Object.Id.ToString(), scrubbedFile), Times.Once());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -209,7 +209,11 @@ namespace GitHub.Runner.Common.Tests.Worker
             _rootDirectory = Path.Combine(workDirectory, nameof(CreateStepSummaryCommandL0));
             Directory.CreateDirectory(_rootDirectory);
 
-            // Execution context
+            // Job execution context
+            var jobContext = new ExecutionContext();
+            jobContext.Initialize(hostContext);
+
+            // Step execution context
             _executionContext = new Mock<IExecutionContext>();
             _executionContext.Setup(x => x.Global)
                 .Returns(new GlobalContext
@@ -230,6 +234,8 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _trace.Info($"{tag}{message}");
                 });
+            _executionContext.SetupGet(x => x.Root)
+                .Returns(jobContext);
 
             //CreateStepSummaryCommand
             _createStepCommand = new CreateStepSummaryCommand();

--- a/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
+++ b/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
@@ -10,12 +10,15 @@ using Moq;
 using Xunit;
 using DTWebApi = GitHub.DistributedTask.WebApi;
 using GitHub.DistributedTask.WebApi;
+using Pipelines = GitHub.DistributedTask.Pipelines;
 
 namespace GitHub.Runner.Common.Tests.Worker
 {
     public sealed class CreateStepSummaryCommandL0
     {
         private Mock<IExecutionContext> _executionContext;
+        private Mock<IJobServerQueue> _jobServerQueue;
+        private ExecutionContext _jobExecutionContext;
         private List<Tuple<DTWebApi.Issue, string>> _issues;
         private Variables _variables;
         private string _rootDirectory;
@@ -30,9 +33,11 @@ namespace GitHub.Runner.Common.Tests.Worker
             using (var hostContext = Setup(featureFlagState: "false"))
             {
                 var stepSummaryFile = Path.Combine(_rootDirectory, "feature-off");
+                
+                _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
+                _jobExecutionContext.Complete();
 
-                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
-
+                _jobServerQueue.Verify(x => x.QueueFileUpload(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -45,8 +50,9 @@ namespace GitHub.Runner.Common.Tests.Worker
             using (var hostContext = Setup())
             {
                 _createStepCommand.ProcessCommand(_executionContext.Object, null, null);
+                _jobExecutionContext.Complete();
 
-                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                _jobServerQueue.Verify(x => x.QueueFileUpload(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -61,8 +67,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var stepSummaryFile = Path.Combine(_rootDirectory, "directory-not-found", "env");
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
+                _jobExecutionContext.Complete();
 
-                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                _jobServerQueue.Verify(x => x.QueueFileUpload(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -77,8 +84,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var stepSummaryFile = Path.Combine(_rootDirectory, "file-not-found");
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
+                _jobExecutionContext.Complete();
 
-                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                _jobServerQueue.Verify(x => x.QueueFileUpload(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -94,8 +102,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 File.Create(stepSummaryFile).Dispose();
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
+                _jobExecutionContext.Complete();
 
-                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                _jobServerQueue.Verify(x => x.QueueFileUpload(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -111,8 +120,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 File.WriteAllBytes(stepSummaryFile, new byte[128 * 1024 + 1]);
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
+                _jobExecutionContext.Complete();
 
-                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                _jobServerQueue.Verify(x => x.QueueFileUpload(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never());
                 Assert.Equal(1, _issues.Count);
             }
         }
@@ -134,8 +144,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 WriteContent(stepSummaryFile, content);
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
+                _jobExecutionContext.Complete();
 
-                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, _executionContext.Object.Id.ToString(), stepSummaryFile + "-scrubbed"), Times.Once());
+                _jobServerQueue.Verify(x => x.QueueFileUpload(It.IsAny<Guid>(), It.IsAny<Guid>(), ChecksAttachmentType.StepSummary, _executionContext.Object.Id.ToString(), stepSummaryFile + "-scrubbed", It.IsAny<bool>()), Times.Once());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -166,8 +177,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var scrubbedFileContents = File.ReadAllText(scrubbedFile);
                 Assert.DoesNotContain("ThisIsMySecretPassword!", scrubbedFileContents);
                 Assert.DoesNotContain("ghs_verysecuretoken", scrubbedFileContents);
+                _jobExecutionContext.Complete();
 
-                _executionContext.Verify(e => e.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, _executionContext.Object.Id.ToString(), scrubbedFile), Times.Once());
+                _jobServerQueue.Verify(x => x.QueueFileUpload(It.IsAny<Guid>(), It.IsAny<Guid>(), ChecksAttachmentType.StepSummary, _executionContext.Object.Id.ToString(), scrubbedFile, It.IsAny<bool>()), Times.Once());
                 Assert.Equal(0, _issues.Count);
             }
         }
@@ -189,13 +201,43 @@ namespace GitHub.Runner.Common.Tests.Worker
 
         private TestHostContext Setup([CallerMemberName] string name = "", string featureFlagState = "true")
         {
+            var hostContext = new TestHostContext(this, name);
+
             _issues = new List<Tuple<DTWebApi.Issue, string>>();
 
-            var hostContext = new TestHostContext(this, name);
+            // Setup a job request
+            TaskOrchestrationPlanReference plan = new TaskOrchestrationPlanReference();
+            TimelineReference timeline = new TimelineReference();
+            Guid jobId = Guid.NewGuid();
+            string jobName = "Summary Job";
+            var jobRequest = new Pipelines.AgentJobRequestMessage(plan, timeline, jobId, jobName, jobName, null, null, null, new Dictionary<string, VariableValue>(), new List<MaskHint>(), new Pipelines.JobResources(), new Pipelines.ContextData.DictionaryContextData(), new Pipelines.WorkspaceOptions(), new List<Pipelines.ActionStep>(), null, null, null, null);
+            jobRequest.Resources.Repositories.Add(new Pipelines.RepositoryResource()
+            {
+                Alias = Pipelines.PipelineConstants.SelfAlias,
+                Id = "github",
+                Version = "sha1"
+            });
+            jobRequest.ContextData["github"] = new Pipelines.ContextData.DictionaryContextData();
+            jobRequest.Variables["ACTIONS_STEP_DEBUG"] = "true";
+
+            // Server queue for job
+            _jobServerQueue = new Mock<IJobServerQueue>();
+            _jobServerQueue.Setup(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.IsAny<TimelineRecord>()));
+            hostContext.SetSingleton(_jobServerQueue.Object);
+
+            // Configuration store (required singleton)
+            var configurationStore = new Mock<IConfigurationStore>();
+            configurationStore.Setup(x => x.GetSettings()).Returns(new RunnerSettings());
+            hostContext.SetSingleton(configurationStore.Object);
+
+            // Paging Logger (required singleton)
+            var pagingLogger = new Mock<IPagingLogger>();
+            hostContext.EnqueueInstance(pagingLogger.Object);
 
             // Trace
             _trace = hostContext.GetTrace();
 
+            // Variables to test for secret scrubbing & FF options
             _variables = new Variables(hostContext, new Dictionary<string, VariableValue>
                 {
                     { "MySecretName", new VariableValue("My secret value", true) },
@@ -210,8 +252,9 @@ namespace GitHub.Runner.Common.Tests.Worker
             Directory.CreateDirectory(_rootDirectory);
 
             // Job execution context
-            var jobContext = new ExecutionContext();
-            jobContext.Initialize(hostContext);
+            _jobExecutionContext = new ExecutionContext();
+            _jobExecutionContext.Initialize(hostContext);
+            _jobExecutionContext.InitializeJob(jobRequest, System.Threading.CancellationToken.None);
 
             // Step execution context
             _executionContext = new Mock<IExecutionContext>();
@@ -234,8 +277,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _trace.Info($"{tag}{message}");
                 });
-            _executionContext.SetupGet(x => x.Root)
-                .Returns(jobContext);
+            _executionContext.SetupGet(x => x.Root).Returns(_jobExecutionContext);
 
             //CreateStepSummaryCommand
             _createStepCommand = new CreateStepSummaryCommand();


### PR DESCRIPTION
In #1642, the execution context used for `QueueAttachFile` was originally the [Job context](https://github.com/actions/runner/blob/e552c0cced4b841c91f4796578451d29e537ff14/src/Runner.Worker/StepsRunner.cs#L403) but was incorrectly refactored to use the [Step context](https://github.com/actions/runner/blob/2946801fb6c2afd960ba4d86e5269ca8ecf012ac/src/Runner.Worker/FileCommandManager.cs#L320). This is incorrect, since the API will use the job context as per: https://github.com/github/actions-dotnet/pull/10957

Also, attaching to the step context is not supported according to: https://github.com/actions/runner/blob/be9632302ceef50bfb36ea998cea9c94c75e5d4d/src/Runner.Worker/DiagnosticLogManager.cs#L106