### PR TITLE
Fix windows console runner update crash

### DIFF
--- a/src/Runner.Listener/SelfUpdater.cs
+++ b/src/Runner.Listener/SelfUpdater.cs
@@ -581,17 +581,17 @@ namespace GitHub.Runner.Listener
             IOUtil.CopyDirectory(Path.Combine(latestRunnerDirectory, Constants.Path.ExternalsDirectory), externalsVersionDir, token);
 
             // copy and replace all .sh/.cmd files
-            Trace.Info($"DISABLED");
-            // foreach (FileInfo file in new DirectoryInfo(latestRunnerDirectory).GetFiles() ?? new FileInfo[0])
-            // {
-            //     string destination = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Root), file.Name);
+            Trace.Info($"Copy any remaining .sh/.cmd files into runner root.");
+            foreach (FileInfo file in new DirectoryInfo(latestRunnerDirectory).GetFiles() ?? new FileInfo[0])
+            {
+                string destination = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Root), file.Name);
 
-            //     // Removing the file instead of just trying to overwrite it works around permissions issues on linux.
-            //     // https://github.com/actions/runner/issues/981
-            //     Trace.Info($"Copy {file.FullName} to {destination}");
-            //     IOUtil.DeleteFile(destination);
-            //     file.CopyTo(destination, true);
-            // }
+                // Removing the file instead of just trying to overwrite it works around permissions issues on linux.
+                // https://github.com/actions/runner/issues/981
+                Trace.Info($"Copy {file.FullName} to {destination}");
+                IOUtil.DeleteFile(destination);
+                file.CopyTo(destination, true);
+            }
 
             stopWatch.Stop();
             _updateTrace.Enqueue($"CopyRunnerToRootTime: {stopWatch.ElapsedMilliseconds}ms");

--- a/src/Runner.Listener/SelfUpdater.cs
+++ b/src/Runner.Listener/SelfUpdater.cs
@@ -581,17 +581,17 @@ namespace GitHub.Runner.Listener
             IOUtil.CopyDirectory(Path.Combine(latestRunnerDirectory, Constants.Path.ExternalsDirectory), externalsVersionDir, token);
 
             // copy and replace all .sh/.cmd files
-            Trace.Info($"Copy any remaining .sh/.cmd files into runner root.");
-            foreach (FileInfo file in new DirectoryInfo(latestRunnerDirectory).GetFiles() ?? new FileInfo[0])
-            {
-                string destination = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Root), file.Name);
+            Trace.Info($"DISABLED");
+            // foreach (FileInfo file in new DirectoryInfo(latestRunnerDirectory).GetFiles() ?? new FileInfo[0])
+            // {
+            //     string destination = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Root), file.Name);
 
-                // Removing the file instead of just trying to overwrite it works around permissions issues on linux.
-                // https://github.com/actions/runner/issues/981
-                Trace.Info($"Copy {file.FullName} to {destination}");
-                IOUtil.DeleteFile(destination);
-                file.CopyTo(destination, true);
-            }
+            //     // Removing the file instead of just trying to overwrite it works around permissions issues on linux.
+            //     // https://github.com/actions/runner/issues/981
+            //     Trace.Info($"Copy {file.FullName} to {destination}");
+            //     IOUtil.DeleteFile(destination);
+            //     file.CopyTo(destination, true);
+            // }
 
             stopWatch.Stop();
             _updateTrace.Enqueue($"CopyRunnerToRootTime: {stopWatch.ElapsedMilliseconds}ms");
@@ -1060,6 +1060,8 @@ namespace GitHub.Runner.Listener
                                               arguments: $"\"{hashFilesScript.Replace("\"", "\\\"")}\"",
                                               environment: env,
                                               requireExitCodeZero: false,
+                                              outputEncoding: null,
+                                              killProcessOnCancel: true,
                                               cancellationToken: token);
 
                 if (exitCode != 0)


### PR DESCRIPTION
Fixes [#1669](https://github.com/actions/runner/issues/1669)

By not killing the process on cancel, the handle to the console is lost and subsequent attempts to write to the terminal will throw an exception (leading to the crash + logs in the issue).
See the relevant ProcessInvoker behaviour [here](https://github.com/actions/runner/blob/2946801fb6c2afd960ba4d86e5269ca8ecf012ac/src/Runner.Sdk/ProcessInvoker.cs#L433) and [here](https://github.com/actions/runner/blob/2946801fb6c2afd960ba4d86e5269ca8ecf012ac/src/Runner.Sdk/ProcessInvoker.cs#L634) for details.