### PR TITLE
Standardize casing for x64 and x86

### DIFF
--- a/src/Runner.Common/Util/VarUtil.cs
+++ b/src/Runner.Common/Util/VarUtil.cs
@@ -49,9 +49,9 @@ namespace GitHub.Runner.Common.Util
                 switch (Constants.Runner.PlatformArchitecture)
                 {
                     case Constants.Architecture.X86:
-                        return "X86";
+                        return "x86";
                     case Constants.Architecture.X64:
-                        return "X64";
+                        return "x64";
                     case Constants.Architecture.Arm:
                         return "ARM";
                     case Constants.Architecture.Arm64:


### PR DESCRIPTION
When a user creates a self-hosted runner, it selects an architecture to use for the runner. 

We use this value in the runner details page. 

`X64` should be `x64` and `X86` should be `x86` for consistency. 