### PR TITLE
Move JobTelemetry and StepsTelemetry into GlobalContext.

### DIFF
--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -178,7 +178,7 @@ namespace GitHub.Runner.Worker
                     Message = $"Invoked ::stopCommand:: with token: [{stopToken}]",
                     Type = JobTelemetryType.ActionCommand
                 };
-                context.JobTelemetry.Add(telemetry);
+                context.Global.JobTelemetry.Add(telemetry);
             }
 
             if (isTokenInvalid && !allowUnsecureStopCommandTokens)

--- a/src/Runner.Worker/GlobalContext.cs
+++ b/src/Runner.Worker/GlobalContext.cs
@@ -14,6 +14,8 @@ namespace GitHub.Runner.Worker
         public PlanFeatures Features { get; set; }
         public IList<String> FileTable { get; set; }
         public IDictionary<String, IDictionary<String, String>> JobDefaults { get; set; }
+        public List<ActionsStepTelemetry> StepsTelemetry { get; set; }
+        public List<JobTelemetry> JobTelemetry { get; set; }
         public TaskOrchestrationPlanReference Plan { get; set; }
         public List<string> PrependPath { get; set; }
         public List<ContainerInfo> ServiceContainers { get; set; }

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -455,6 +455,7 @@ namespace GitHub.Runner.Worker.Handlers
 
             Trace.Info($"Step result: {step.ExecutionContext.Result}");
             step.ExecutionContext.Debug($"Finished: {step.DisplayName}");
+            step.ExecutionContext.PublishStepTelemetry();
         }
 
         private void SetStepConclusion(IStep step, TaskResult result)

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -42,7 +42,7 @@ namespace GitHub.Runner.Worker.Handlers
             {
                 ArgUtil.NotNull(Data.PreSteps, nameof(Data.PreSteps));
                 steps = Data.PreSteps;
-            } 
+            }
             else if (stage == ActionRunStage.Post)
             {
                 ArgUtil.NotNull(Data.PostSteps, nameof(Data.PostSteps));
@@ -60,7 +60,7 @@ namespace GitHub.Runner.Worker.Handlers
                         Trace.Info($"Skipping executing post step id: {step.Id}, name: ${step.DisplayName}");
                     }
                 }
-            }  
+            }
             else
             {
                 ArgUtil.NotNull(Data.Steps, nameof(Data.Steps));
@@ -83,20 +83,17 @@ namespace GitHub.Runner.Worker.Handlers
                         hasUsesStep = true;
                     }
                 }
-                var pathReference = Action as Pipelines.RepositoryPathReference;
-                var telemetry = new ActionsStepTelemetry {
-                    Ref = GetActionRef(),
-                    HasPreStep = Data.HasPre,
-                    HasPostStep = Data.HasPost,
-                    IsEmbedded = ExecutionContext.IsEmbedded,
-                    Type = "composite",
-                    HasRunsStep = hasRunsStep,
-                    HasUsesStep = hasUsesStep,
-                    StepCount = steps.Count
-                };
-                ExecutionContext.Root.ActionsStepsTelemetry.Add(telemetry);
+
+                ExecutionContext.StepTelemetry.Ref = GetActionRef();
+                ExecutionContext.StepTelemetry.HasPreStep = Data.HasPre;
+                ExecutionContext.StepTelemetry.HasPostStep = Data.HasPost;
+                ExecutionContext.StepTelemetry.IsEmbedded = ExecutionContext.IsEmbedded;
+                ExecutionContext.StepTelemetry.Type = "composite";
+                ExecutionContext.StepTelemetry.HasRunsStep = hasRunsStep;
+                ExecutionContext.StepTelemetry.HasUsesStep = hasUsesStep;
+                ExecutionContext.StepTelemetry.StepCount = steps.Count;
             }
-            
+
             try
             {
                 // Inputs of the composite step
@@ -117,7 +114,7 @@ namespace GitHub.Runner.Worker.Handlers
                 // Create embedded steps
                 var embeddedSteps = new List<IStep>();
 
-                 // If we need to setup containers beforehand, do it
+                // If we need to setup containers beforehand, do it
                 // only relevant for local composite actions that need to JIT download/setup containers
                 if (LocalActionContainerSetupSteps != null && LocalActionContainerSetupSteps.Count > 0)
                 {
@@ -152,7 +149,7 @@ namespace GitHub.Runner.Worker.Handlers
                     }
                     else
                     {
-                        step.ExecutionContext.ExpressionValues["steps"] = ExecutionContext.Global.StepsContext.GetScope(childScopeName);   
+                        step.ExecutionContext.ExpressionValues["steps"] = ExecutionContext.Global.StepsContext.GetScope(childScopeName);
                     }
 
                     // Shallow copy github context
@@ -309,7 +306,7 @@ namespace GitHub.Runner.Worker.Handlers
                             // Mark job as cancelled
                             ExecutionContext.Root.Result = TaskResult.Canceled;
                             ExecutionContext.Root.JobContext.Status = ExecutionContext.Root.Result?.ToActionResult();
-                            
+
                             step.ExecutionContext.Debug($"Re-evaluate condition on job cancellation for step: '{step.DisplayName}'.");
                             var conditionReTestTraceWriter = new ConditionTraceWriter(Trace, null); // host tracing only
                             var conditionReTestResult = false;
@@ -393,7 +390,7 @@ namespace GitHub.Runner.Worker.Handlers
                     {
                         await RunStepAsync(step);
                     }
-                
+
                 }
                 finally
                 {

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -1,14 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
-using System;
-using GitHub.Runner.Worker.Container;
-using Pipelines = GitHub.DistributedTask.Pipelines;
+using GitHub.DistributedTask.Pipelines.ContextData;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Common;
 using GitHub.Runner.Sdk;
-using GitHub.DistributedTask.WebApi;
-using GitHub.DistributedTask.Pipelines.ContextData;
-using System.Linq;
+using GitHub.Runner.Worker.Container;
+using Pipelines = GitHub.DistributedTask.Pipelines;
 
 namespace GitHub.Runner.Worker.Handlers
 {
@@ -73,14 +73,11 @@ namespace GitHub.Runner.Worker.Handlers
             // Add Telemetry to JobContext to send with JobCompleteMessage
             if (stage == ActionRunStage.Main)
             {
-                var telemetry = new ActionsStepTelemetry {
-                    Ref = GetActionRef(),
-                    HasPreStep = Data.HasPre,
-                    HasPostStep = Data.HasPost,
-                    IsEmbedded = ExecutionContext.IsEmbedded,
-                    Type = type
-                };
-                ExecutionContext.Root.ActionsStepsTelemetry.Add(telemetry);
+                ExecutionContext.StepTelemetry.Ref = GetActionRef();
+                ExecutionContext.StepTelemetry.HasPreStep = Data.HasPre;
+                ExecutionContext.StepTelemetry.HasPostStep = Data.HasPost;
+                ExecutionContext.StepTelemetry.IsEmbedded = ExecutionContext.IsEmbedded;
+                ExecutionContext.StepTelemetry.Type = type;
             }
 
             // run container

--- a/src/Runner.Worker/Handlers/Handler.cs
+++ b/src/Runner.Worker/Handlers/Handler.cs
@@ -44,39 +44,6 @@ namespace GitHub.Runner.Worker.Handlers
         public string ActionDirectory { get; set; }
         public List<JobExtensionRunner> LocalActionContainerSetupSteps { get; set; }
 
-        public string GetActionRef()
-        {
-            if (Action.Type == Pipelines.ActionSourceType.ContainerRegistry)
-            {
-                var registryAction = Action as Pipelines.ContainerRegistryReference;
-                return registryAction.Image;
-            }
-            else if (Action.Type == Pipelines.ActionSourceType.Repository)
-            {
-                var repoAction = Action as Pipelines.RepositoryPathReference;
-                if (string.Equals(repoAction.RepositoryType, Pipelines.PipelineConstants.SelfAlias, StringComparison.OrdinalIgnoreCase))
-                {
-                    return repoAction.Path;
-                }
-                else
-                {
-                    if (string.IsNullOrEmpty(repoAction.Path))
-                    {
-                        return $"{repoAction.Name}@{repoAction.Ref}";
-                    }
-                    else
-                    {
-                        return $"{repoAction.Name}/{repoAction.Path}@{repoAction.Ref}";
-                    }
-                }
-            }
-            else
-            {
-                // this should never happen
-                Trace.Error($"Can't generate ref for {Action.Type.ToString()}");
-            }
-            return "";
-        }
 
         public virtual void PrintActionDetails(ActionRunStage stage)
         {
@@ -149,6 +116,40 @@ namespace GitHub.Runner.Worker.Handlers
         {
             base.Initialize(hostContext);
             ActionCommandManager = hostContext.CreateService<IActionCommandManager>();
+        }
+
+        protected string GetActionRef()
+        {
+            if (Action.Type == Pipelines.ActionSourceType.ContainerRegistry)
+            {
+                var registryAction = Action as Pipelines.ContainerRegistryReference;
+                return registryAction.Image;
+            }
+            else if (Action.Type == Pipelines.ActionSourceType.Repository)
+            {
+                var repoAction = Action as Pipelines.RepositoryPathReference;
+                if (string.Equals(repoAction.RepositoryType, Pipelines.PipelineConstants.SelfAlias, StringComparison.OrdinalIgnoreCase))
+                {
+                    return repoAction.Path;
+                }
+                else
+                {
+                    if (string.IsNullOrEmpty(repoAction.Path))
+                    {
+                        return $"{repoAction.Name}@{repoAction.Ref}";
+                    }
+                    else
+                    {
+                        return $"{repoAction.Name}/{repoAction.Path}@{repoAction.Ref}";
+                    }
+                }
+            }
+            else
+            {
+                // this should never happen
+                Trace.Error($"Can't generate ref for {Action.Type.ToString()}");
+            }
+            return "";
         }
 
         protected void AddInputsToEnvironment()

--- a/src/Runner.Worker/Handlers/Handler.cs
+++ b/src/Runner.Worker/Handlers/Handler.cs
@@ -1,13 +1,13 @@
-using GitHub.DistributedTask.WebApi;
-using GitHub.Runner.Common.Util;
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using System.Linq;
 using System.IO;
-using Pipelines = GitHub.DistributedTask.Pipelines;
+using System.Linq;
+using System.Threading.Tasks;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Common;
+using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
+using Pipelines = GitHub.DistributedTask.Pipelines;
 
 namespace GitHub.Runner.Worker.Handlers
 {
@@ -44,7 +44,7 @@ namespace GitHub.Runner.Worker.Handlers
         public string ActionDirectory { get; set; }
         public List<JobExtensionRunner> LocalActionContainerSetupSteps { get; set; }
 
-        public virtual string GetActionRef()
+        public string GetActionRef()
         {
             if (Action.Type == Pipelines.ActionSourceType.ContainerRegistry)
             {
@@ -77,9 +77,10 @@ namespace GitHub.Runner.Worker.Handlers
             }
             return "";
         }
+
         public virtual void PrintActionDetails(ActionRunStage stage)
         {
-            
+
             if (stage == ActionRunStage.Post)
             {
                 ExecutionContext.Output($"Post job cleanup.");

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -1,12 +1,12 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Common;
 using GitHub.Runner.Sdk;
-using GitHub.DistributedTask.WebApi;
 using Pipelines = GitHub.DistributedTask.Pipelines;
-using System;
-using System.Linq;
 
 namespace GitHub.Runner.Worker.Handlers
 {
@@ -77,15 +77,11 @@ namespace GitHub.Runner.Worker.Handlers
             // Add Telemetry to JobContext to send with JobCompleteMessage
             if (stage == ActionRunStage.Main)
             {
-                var telemetry = new ActionsStepTelemetry
-                {
-                    Ref = GetActionRef(),
-                    HasPreStep = Data.HasPre,
-                    HasPostStep = Data.HasPost,
-                    IsEmbedded = ExecutionContext.IsEmbedded,
-                    Type = Data.NodeVersion
-                };
-                ExecutionContext.Root.ActionsStepsTelemetry.Add(telemetry);
+                ExecutionContext.StepTelemetry.Ref = GetActionRef();
+                ExecutionContext.StepTelemetry.HasPreStep = Data.HasPre;
+                ExecutionContext.StepTelemetry.HasPostStep = Data.HasPost;
+                ExecutionContext.StepTelemetry.IsEmbedded = ExecutionContext.IsEmbedded;
+                ExecutionContext.StepTelemetry.Type = Data.NodeVersion;
             }
 
             ArgUtil.NotNullOrEmpty(target, nameof(target));

--- a/src/Runner.Worker/Handlers/ScriptHandler.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandler.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Linq;
 using GitHub.DistributedTask.Pipelines.ContextData;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Common;
 using GitHub.Runner.Sdk;
-using GitHub.DistributedTask.WebApi;
 using Pipelines = GitHub.DistributedTask.Pipelines;
 
 namespace GitHub.Runner.Worker.Handlers
@@ -147,12 +147,8 @@ namespace GitHub.Runner.Worker.Handlers
             // Add Telemetry to JobContext to send with JobCompleteMessage
             if (stage == ActionRunStage.Main)
             {
-                var telemetry = new ActionsStepTelemetry
-                {
-                    IsEmbedded = ExecutionContext.IsEmbedded,
-                    Type = "run",
-                };
-                ExecutionContext.Root.ActionsStepsTelemetry.Add(telemetry);
+                ExecutionContext.StepTelemetry.IsEmbedded = ExecutionContext.IsEmbedded;
+                ExecutionContext.StepTelemetry.Type = "run";
             }
 
             var tempDirectory = HostContext.GetDirectory(WellKnownDirectory.Temp);

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -279,14 +279,13 @@ namespace GitHub.Runner.Worker
             }
 
             // Load any upgrade telemetry
-            LoadFromTelemetryFile(jobContext.JobTelemetry);
+            LoadFromTelemetryFile(jobContext.Global.JobTelemetry);
 
             // Make sure we don't submit secrets as telemetry
-            MaskTelemetrySecrets(jobContext.JobTelemetry);
+            MaskTelemetrySecrets(jobContext.Global.JobTelemetry);
 
-            Trace.Info("Raising job completed event.");
-            var jobCompletedEvent = new JobCompletedEvent(message.RequestId, message.JobId, result, jobContext.JobOutputs, jobContext.ActionsEnvironment, jobContext.ActionsStepsTelemetry, jobContext.JobTelemetry);
-
+            var jobCompletedEvent = new JobCompletedEvent(message.RequestId, message.JobId, result, jobContext.JobOutputs, jobContext.ActionsEnvironment, jobContext.Global.StepsTelemetry, jobContext.Global.JobTelemetry);
+            Trace.Info($"Raising job completed event: {StringUtil.ConvertToJson(jobCompletedEvent)}");
 
             var completeJobRetryLimit = 5;
             var exceptions = new List<Exception>();

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -121,6 +121,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             using (TestHostContext hc = CreateTestContext())
             {
                 _ec.Object.Global.EnvironmentVariables = new Dictionary<string, string>();
+                _ec.Object.Global.JobTelemetry = new List<JobTelemetry>();
                 var expressionValues = new DictionaryContextData
                 {
                     ["env"] =
@@ -131,7 +132,6 @@ namespace GitHub.Runner.Common.Tests.Worker
 #endif
                 };
                 _ec.Setup(x => x.ExpressionValues).Returns(expressionValues);
-                _ec.Setup(x => x.JobTelemetry).Returns(new List<JobTelemetry>());
 
                 Assert.True(_commandManager.TryProcessCommand(_ec.Object, $"::stop-commands::{invalidToken}", null));
             }
@@ -148,8 +148,8 @@ namespace GitHub.Runner.Common.Tests.Worker
             using (TestHostContext hc = CreateTestContext())
             {
                 _ec.Object.Global.EnvironmentVariables = new Dictionary<string, string>();
+                _ec.Object.Global.JobTelemetry = new List<JobTelemetry>();
                 _ec.Setup(x => x.ExpressionValues).Returns(GetExpressionValues());
-                _ec.Setup(x => x.JobTelemetry).Returns(new List<JobTelemetry>());
                 Assert.Throws<Exception>(() => _commandManager.TryProcessCommand(_ec.Object, $"::stop-commands::{invalidToken}", null));
             }
         }


### PR DESCRIPTION
We introduced `GlobalContext` to `ExecutionContext` for holding shared objects of all `ExecutionContext` (Job + Steps).

Both `ActionsStepsTelemetry` and `JobTelemetry` fail into this `shared objects` category, so I am moving both into the `GlobalContext`.

Moving forward, you will not need to worry about which context (job vs. step) to use in order to get the right object.

![image](https://user-images.githubusercontent.com/1750815/153653656-a62f9eeb-2168-46c1-ba6d-50b7b29bbcdc.png)
