### PR TITLE
Issue 1596: Runner throws null ref exception when new line after EOF is missing

### DIFF
--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -181,6 +181,10 @@ namespace GitHub.Runner.Worker
                                 {
                                     throw new Exception($"Invalid environment variable value. Matching delimiter not found '{delimiter}'");
                                 }
+                                if (newline == null)
+                                {
+                                    throw new Exception($"Invalid environment variable value. EOF marker missing newline.");
+                                }
                                 endIndex = index - newline.Length;
                                 tempLine = ReadLine(text, ref index, out newline);
                             }

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -183,7 +183,7 @@ namespace GitHub.Runner.Worker
                                 }
                                 if (newline == null)
                                 {
-                                    throw new Exception($"Invalid environment variable value. EOF marker missing newline.");
+                                    throw new Exception($"Invalid environment variable value. EOF marker missing new line.");
                                 }
                                 endIndex = index - newline.Length;
                                 tempLine = ReadLine(text, ref index, out newline);

--- a/src/Test/L0/Worker/SetEnvFileCommandL0.cs
+++ b/src/Test/L0/Worker/SetEnvFileCommandL0.cs
@@ -342,7 +342,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 };
                 WriteContent(envFile, content, " ");
                 var ex = Assert.Throws<Exception>(() => _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null));
-                Assert.Contains("EOF marker missing newline", ex.Message);
+                Assert.Contains("EOF marker missing new line", ex.Message);
             }
         }
 

--- a/src/Test/L0/Worker/SetEnvFileCommandL0.cs
+++ b/src/Test/L0/Worker/SetEnvFileCommandL0.cs
@@ -302,6 +302,50 @@ namespace GitHub.Runner.Common.Tests.Worker
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void SetEnvFileCommand_Heredoc_MissingNewLine()
+        {
+            using (var hostContext = Setup())
+            {
+                var envFile = Path.Combine(_rootDirectory, "heredoc");
+                var content = new List<string>
+                {
+                    "MY_ENV<<EOF",
+                    "line one",
+                    "line two",
+                    "line three",
+                    "EOF",
+                };
+                WriteContent(envFile, content, " ");
+                var ex = Assert.Throws<Exception>(() => _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null));
+                Assert.Contains("Matching delimiter not found", ex.Message);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void SetEnvFileCommand_Heredoc_MissingNewLineMultipleLinesEnv()
+        {
+            using (var hostContext = Setup())
+            {
+                var envFile = Path.Combine(_rootDirectory, "heredoc");
+                var content = new List<string>
+                {
+                    "MY_ENV<<EOF",
+                    @"line one
+                    line two
+                    line three",
+                    "EOF",
+                };
+                WriteContent(envFile, content, " ");
+                var ex = Assert.Throws<Exception>(() => _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null));
+                Assert.Contains("EOF marker missing newline", ex.Message);
+            }
+        }
+
 #if OS_WINDOWS
         [Fact]
         [Trait("Level", "L0")]


### PR DESCRIPTION
Description: Runner throws null ref exception when new line after EOF is missing. The problem occurs when the string being written to the variable contains new line and a new line is missing after the EOF marker.

Related issue: #1596 

After this change, the described problem was removed and additional tests covering this part of the code were implemented.