### PR TITLE
Sending telemetry about actions usage.

### DIFF
--- a/src/Runner.Worker/ActionRunner.cs
+++ b/src/Runner.Worker/ActionRunner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,12 +8,11 @@ using GitHub.DistributedTask.ObjectTemplating.Tokens;
 using GitHub.DistributedTask.Pipelines;
 using GitHub.DistributedTask.Pipelines.ContextData;
 using GitHub.DistributedTask.Pipelines.ObjectTemplating;
+using GitHub.Runner.Common;
 using GitHub.Runner.Common.Util;
+using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker.Handlers;
 using Pipelines = GitHub.DistributedTask.Pipelines;
-using GitHub.Runner.Common;
-using GitHub.Runner.Sdk;
-using System.Collections.Generic;
 
 namespace GitHub.Runner.Worker
 {
@@ -274,8 +274,8 @@ namespace GitHub.Runner.Worker
                             actionDirectory: definition.Directory,
                             localActionContainerSetupSteps: localActionContainerSetupSteps);
 
-            // Print out action details
-            handler.PrintActionDetails(Stage);
+            // Print out action details and log telemetry
+            handler.PrepareExecution(Stage);
 
             // Run the task.
             try

--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -67,7 +67,7 @@ namespace GitHub.Runner.Worker.Handlers
                 steps = Data.Steps;
             }
 
-            // Add Telemetry to JobContext to send with JobCompleteMessage
+            // Set extra telemetry base on the current context.
             if (stage == ActionRunStage.Main)
             {
                 var hasRunsStep = false;
@@ -84,15 +84,14 @@ namespace GitHub.Runner.Worker.Handlers
                     }
                 }
 
-                ExecutionContext.StepTelemetry.Ref = GetActionRef();
                 ExecutionContext.StepTelemetry.HasPreStep = Data.HasPre;
                 ExecutionContext.StepTelemetry.HasPostStep = Data.HasPost;
-                ExecutionContext.StepTelemetry.IsEmbedded = ExecutionContext.IsEmbedded;
-                ExecutionContext.StepTelemetry.Type = "composite";
+                
                 ExecutionContext.StepTelemetry.HasRunsStep = hasRunsStep;
                 ExecutionContext.StepTelemetry.HasUsesStep = hasUsesStep;
                 ExecutionContext.StepTelemetry.StepCount = steps.Count;
             }
+            ExecutionContext.StepTelemetry.Type = "composite";
 
             try
             {

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -70,15 +70,13 @@ namespace GitHub.Runner.Worker.Handlers
             }
 
             string type = Action.Type == Pipelines.ActionSourceType.Repository ? "Dockerfile" : "DockerHub";
-            // Add Telemetry to JobContext to send with JobCompleteMessage
+            // Set extra telemetry base on the current context.
             if (stage == ActionRunStage.Main)
             {
-                ExecutionContext.StepTelemetry.Ref = GetActionRef();
                 ExecutionContext.StepTelemetry.HasPreStep = Data.HasPre;
                 ExecutionContext.StepTelemetry.HasPostStep = Data.HasPost;
-                ExecutionContext.StepTelemetry.IsEmbedded = ExecutionContext.IsEmbedded;
-                ExecutionContext.StepTelemetry.Type = type;
             }
+            ExecutionContext.StepTelemetry.Type = type;
 
             // run container
             var container = new ContainerInfo(HostContext)

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -74,15 +74,13 @@ namespace GitHub.Runner.Worker.Handlers
                 target = Data.Post;
             }
 
-            // Add Telemetry to JobContext to send with JobCompleteMessage
+            // Set extra telemetry base on the current context.
             if (stage == ActionRunStage.Main)
             {
-                ExecutionContext.StepTelemetry.Ref = GetActionRef();
                 ExecutionContext.StepTelemetry.HasPreStep = Data.HasPre;
                 ExecutionContext.StepTelemetry.HasPostStep = Data.HasPost;
-                ExecutionContext.StepTelemetry.IsEmbedded = ExecutionContext.IsEmbedded;
-                ExecutionContext.StepTelemetry.Type = Data.NodeVersion;
             }
+            ExecutionContext.StepTelemetry.Type = Data.NodeVersion;
 
             ArgUtil.NotNullOrEmpty(target, nameof(target));
             target = Path.Combine(ActionDirectory, target);

--- a/src/Runner.Worker/Handlers/RunnerPluginHandler.cs
+++ b/src/Runner.Worker/Handlers/RunnerPluginHandler.cs
@@ -1,7 +1,7 @@
-﻿using System.Threading.Tasks;
-using System;
-using GitHub.Runner.Sdk;
+﻿using System;
+using System.Threading.Tasks;
 using GitHub.Runner.Common;
+using GitHub.Runner.Sdk;
 using Pipelines = GitHub.DistributedTask.Pipelines;
 
 namespace GitHub.Runner.Worker.Handlers
@@ -35,6 +35,8 @@ namespace GitHub.Runner.Worker.Handlers
             }
 
             ArgUtil.NotNullOrEmpty(plugin, nameof(plugin));
+            // Set extra telemetry base on the current context.
+            ExecutionContext.StepTelemetry.Type = plugin;
 
             // Update the env dictionary.
             AddPrependPathToEnvironment();

--- a/src/Runner.Worker/Handlers/ScriptHandler.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandler.cs
@@ -21,7 +21,7 @@ namespace GitHub.Runner.Worker.Handlers
     {
         public ScriptActionExecutionData Data { get; set; }
 
-        public override void PrintActionDetails(ActionRunStage stage)
+        protected override void PrintActionDetails(ActionRunStage stage)
         {
 
             if (stage == ActionRunStage.Post)
@@ -144,13 +144,6 @@ namespace GitHub.Runner.Worker.Handlers
             var githubContext = ExecutionContext.ExpressionValues["github"] as GitHubContext;
             ArgUtil.NotNull(githubContext, nameof(githubContext));
 
-            // Add Telemetry to JobContext to send with JobCompleteMessage
-            if (stage == ActionRunStage.Main)
-            {
-                ExecutionContext.StepTelemetry.IsEmbedded = ExecutionContext.IsEmbedded;
-                ExecutionContext.StepTelemetry.Type = "run";
-            }
-
             var tempDirectory = HostContext.GetDirectory(WellKnownDirectory.Temp);
 
             Inputs.TryGetValue("script", out var contents);
@@ -216,6 +209,11 @@ namespace GitHub.Runner.Worker.Handlers
                 {
                     argFormat = ScriptHandlerHelpers.GetScriptArgumentsFormat(shellCommand);
                 }
+            }
+
+            if (!string.IsNullOrEmpty(shellCommand))
+            {
+                ExecutionContext.StepTelemetry.Action = shellCommand;
             }
 
             // No arg format was given, shell must be a built-in

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -56,6 +56,8 @@ namespace GitHub.Runner.Worker
 
             // Create a new timeline record for 'Set up job'
             IExecutionContext context = jobContext.CreateChild(Guid.NewGuid(), "Set up job", $"{nameof(JobExtension)}_Init", null, null, ActionRunStage.Pre);
+            context.StepTelemetry.Type = "runner";
+            context.StepTelemetry.Action = "setup_job";
 
             List<IStep> preJobSteps = new List<IStep>();
             List<IStep> jobSteps = new List<IStep>();
@@ -313,6 +315,8 @@ namespace GitHub.Runner.Worker
                             ArgUtil.NotNull(extensionStep, extensionStep.DisplayName);
                             Guid stepId = Guid.NewGuid();
                             extensionStep.ExecutionContext = jobContext.CreateChild(stepId, extensionStep.DisplayName, stepId.ToString("N"), null, stepId.ToString("N"), ActionRunStage.Pre);
+                            extensionStep.ExecutionContext.StepTelemetry.Type = "runner";
+                            extensionStep.ExecutionContext.StepTelemetry.Action = extensionStep.DisplayName.ToLowerInvariant().Replace(' ', '_');
                         }
                         else if (step is IActionRunner actionStep)
                         {
@@ -401,6 +405,8 @@ namespace GitHub.Runner.Worker
 
             // create a new timeline record node for 'Finalize job'
             IExecutionContext context = jobContext.CreateChild(Guid.NewGuid(), "Complete job", $"{nameof(JobExtension)}_Final", null, null, ActionRunStage.Post);
+            context.StepTelemetry.Type = "runner";
+            context.StepTelemetry.Action = "complete_joh";
             using (var register = jobContext.CancellationToken.Register(() => { context.CancelToken(); }))
             {
                 try

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -284,8 +284,8 @@ namespace GitHub.Runner.Worker
             // Make sure we don't submit secrets as telemetry
             MaskTelemetrySecrets(jobContext.Global.JobTelemetry);
 
+            Trace.Info($"Raising job completed event");
             var jobCompletedEvent = new JobCompletedEvent(message.RequestId, message.JobId, result, jobContext.JobOutputs, jobContext.ActionsEnvironment, jobContext.Global.StepsTelemetry, jobContext.Global.JobTelemetry);
-            Trace.Info($"Raising job completed event: {StringUtil.ConvertToJson(jobCompletedEvent)}");
 
             var completeJobRetryLimit = 5;
             var exceptions = new List<Exception>();

--- a/src/Sdk/DTWebApi/WebApi/ActionsStepTelemetry.cs
+++ b/src/Sdk/DTWebApi/WebApi/ActionsStepTelemetry.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace GitHub.DistributedTask.WebApi
 {
@@ -8,6 +10,13 @@ namespace GitHub.DistributedTask.WebApi
     [DataContract]
     public class ActionsStepTelemetry
     {
+        public ActionsStepTelemetry()
+        {
+            this.ErrorMessages = new List<string>();
+        }
+
+        [DataMember(EmitDefaultValue = false)]
+        public string Action { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
         public string Ref { get; set; }
@@ -16,8 +25,14 @@ namespace GitHub.DistributedTask.WebApi
         public string Type { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
+        public string Stage { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public Guid StepId { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
         public bool? HasRunsStep { get; set; }
-                
+
         [DataMember(EmitDefaultValue = false)]
         public bool? HasUsesStep { get; set; }
 
@@ -32,5 +47,14 @@ namespace GitHub.DistributedTask.WebApi
 
         [DataMember(EmitDefaultValue = false)]
         public int? StepCount { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public TaskResult? Result { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public List<string> ErrorMessages { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public int? ExecutionTimeInSeconds { get; set; }
     }
 }

--- a/src/Test/L0/Worker/ExecutionContextL0.cs
+++ b/src/Test/L0/Worker/ExecutionContextL0.cs
@@ -521,6 +521,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
                 ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
                 ec.AddIssue(new Issue() { Type = IssueType.Notice, Message = "notice" });
+                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
+                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
+                ec.AddIssue(new Issue() { Type = IssueType.Notice, Message = "notice" });
 
                 ec.Complete();
 
@@ -531,7 +534,8 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("v2", ec.Global.StepsTelemetry.Single().Ref);
                 Assert.Equal(TaskResult.Succeeded, ec.Global.StepsTelemetry.Single().Result);
                 Assert.NotNull(ec.Global.StepsTelemetry.Single().ExecutionTimeInSeconds);
-                Assert.Equal(2, ec.Global.StepsTelemetry.Single().ErrorMessages.Count);
+                Assert.Equal(3, ec.Global.StepsTelemetry.Single().ErrorMessages.Count);
+                Assert.DoesNotContain(ec.Global.StepsTelemetry.Single().ErrorMessages, x => x.Contains("notice"));
             }
         }
 

--- a/src/Test/L0/Worker/HandlerL0.cs
+++ b/src/Test/L0/Worker/HandlerL0.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Runtime.CompilerServices;
+using GitHub.DistributedTask.Pipelines;
+using GitHub.DistributedTask.WebApi;
+using GitHub.Runner.Sdk;
+using GitHub.Runner.Worker;
+using GitHub.Runner.Worker.Handlers;
+using Moq;
+using Xunit;
+
+namespace GitHub.Runner.Common.Tests.Worker
+{
+    public sealed class HandlerL0
+    {
+        private Mock<IExecutionContext> _ec;
+        private ActionsStepTelemetry _stepTelemetry;
+        private TestHostContext CreateTestContext([CallerMemberName] String testName = "")
+        {
+            var hc = new TestHostContext(this, testName);
+            _stepTelemetry = new ActionsStepTelemetry();
+            _ec = new Mock<IExecutionContext>();
+            _ec.SetupAllProperties();
+            _ec.Setup(x => x.StepTelemetry).Returns(_stepTelemetry);
+
+            var trace = hc.GetTrace();
+            _ec.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>())).Callback((string tag, string message) => { trace.Info($"[{tag}]{message}"); });
+
+            hc.EnqueueInstance<IActionCommandManager>(new Mock<IActionCommandManager>().Object);
+            return hc;
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void PrepareExecution_PopulateTelemetry_RepoActions()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // Arrange.
+                var nodeHandler = new NodeScriptActionHandler();
+                nodeHandler.Initialize(hc);
+
+                nodeHandler.ExecutionContext = _ec.Object;
+                nodeHandler.Action = new RepositoryPathReference()
+                {
+                    Name = "actions/checkout",
+                    Ref = "v2"
+                };
+
+                // Act.
+                nodeHandler.PrepareExecution(ActionRunStage.Main);
+                hc.GetTrace().Info($"Telemetry: {StringUtil.ConvertToJson(_stepTelemetry)}");
+
+                // Assert.
+                Assert.Equal("repository", _stepTelemetry.Type);
+                Assert.Equal("actions/checkout", _stepTelemetry.Action);
+                Assert.Equal("v2", _stepTelemetry.Ref);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void PrepareExecution_PopulateTelemetry_DockerActions()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // Arrange.
+                var nodeHandler = new NodeScriptActionHandler();
+                nodeHandler.Initialize(hc);
+
+                nodeHandler.ExecutionContext = _ec.Object;
+                nodeHandler.Action = new ContainerRegistryReference()
+                {
+                    Image = "ubuntu:20.04"
+                };
+
+                // Act.
+                nodeHandler.PrepareExecution(ActionRunStage.Main);
+                hc.GetTrace().Info($"Telemetry: {StringUtil.ConvertToJson(_stepTelemetry)}");
+
+                // Assert.
+                Assert.Equal("docker", _stepTelemetry.Type);
+                Assert.Equal("ubuntu:20.04", _stepTelemetry.Action);
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/github/c2c-actions-runtime/issues/1674

We are basically blind about how actions are running today.

Adding telemetry about how actions are failing with error, slowing down on execution, etc.

This should help us better support our customers, especially for actions author.