### PR TITLE
Enhancement: RunnerService.js added logic to fail on N attempts if env variable exported

### DIFF
--- a/src/Misc/layoutbin/RunnerService.js
+++ b/src/Misc/layoutbin/RunnerService.js
@@ -4,7 +4,6 @@
 
 var childProcess = require("child_process");
 var path = require("path");
-const { exit } = require("process");
 
 var supported = ["linux", "darwin"];
 
@@ -27,7 +26,7 @@ if (exitServiceAfterNFailures <= 0) {
 
 var consecutiveFailureCount = 0;
 
-var gracefulShutdown = function (code) {
+var gracefulShutdown = function () {
   console.log("Shutting down runner listener");
   stopping = true;
   if (listener) {
@@ -109,7 +108,7 @@ var runService = function () {
             console.error(
               `${messagePrefix}, exiting service after ${consecutiveFailureCount} consecutive failures`
             );
-            gracefulShutdown(5);
+            gracefulShutdown();
             return;
           } else {
             console.log(`${messagePrefix}, re-launch runner in 5 seconds.`);
@@ -130,9 +129,9 @@ runService();
 console.log("Started running service");
 
 process.on("SIGINT", () => {
-  gracefulShutdown(0);
+  gracefulShutdown();
 });
 
 process.on("SIGTERM", () => {
-  gracefulShutdown(0);
+  gracefulShutdown();
 });

--- a/src/Misc/layoutbin/RunnerService.js
+++ b/src/Misc/layoutbin/RunnerService.js
@@ -3,94 +3,136 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 var childProcess = require("child_process");
-var path = require("path")
+var path = require("path");
+const { exit } = require("process");
 
-var supported = ['linux', 'darwin']
+var supported = ["linux", "darwin"];
 
 if (supported.indexOf(process.platform) == -1) {
-    console.log('Unsupported platform: ' + process.platform);
-    console.log('Supported platforms are: ' + supported.toString());
-    process.exit(1);
+  console.log("Unsupported platform: " + process.platform);
+  console.log("Supported platforms are: " + supported.toString());
+  process.exit(1);
 }
 
 var stopping = false;
 var listener = null;
 
-var runService = function () {
-    var listenerExePath = path.join(__dirname, '../bin/Runner.Listener');
-    var interactive = process.argv[2] === "interactive";
+var exitServiceAfterNFailures = Number(
+  process.env.GITHUB_ACTIONS_SERVICE_EXIT_AFTER_N_FAILURES
+);
 
-    if (!stopping) {
-        try {
-            if (interactive) {
-                console.log('Starting Runner listener interactively');
-                listener = childProcess.spawn(listenerExePath, ['run'], { env: process.env });
-            } else {
-                console.log('Starting Runner listener with startup type: service');
-                listener = childProcess.spawn(listenerExePath, ['run', '--startuptype', 'service'], { env: process.env });
-            }
-
-            console.log(`Started listener process, pid: ${listener.pid}`);
-
-            listener.stdout.on('data', (data) => {
-                process.stdout.write(data.toString('utf8'));
-            });
-
-            listener.stderr.on('data', (data) => {
-                process.stdout.write(data.toString('utf8'));
-            });
-
-            listener.on("error", (err) => {
-                console.log(`Runner listener fail to start with error ${err.message}`);
-            });
-
-            listener.on('close', (code) => {
-                console.log(`Runner listener exited with error code ${code}`);
-
-                if (code === 0) {
-                    console.log('Runner listener exit with 0 return code, stop the service, no retry needed.');
-                    stopping = true;
-                } else if (code === 1) {
-                    console.log('Runner listener exit with terminated error, stop the service, no retry needed.');
-                    stopping = true;
-                } else if (code === 2) {
-                    console.log('Runner listener exit with retryable error, re-launch runner in 5 seconds.');
-                } else if (code === 3) {
-                    console.log('Runner listener exit because of updating, re-launch runner in 5 seconds.');
-                } else {
-                    console.log('Runner listener exit with undefined return code, re-launch runner in 5 seconds.');
-                }
-
-                if (!stopping) {
-                    setTimeout(runService, 5000);
-                }
-            });
-
-        } catch (ex) {
-            console.log(ex);
-        }
-    }
+if (exitServiceAfterNFailures <= 0) {
+  exitServiceAfterNFailures = NaN;
 }
 
-runService();
-console.log('Started running service');
+var consecutiveFailureCount = 0;
 
 var gracefulShutdown = function (code) {
-    console.log('Shutting down runner listener');
-    stopping = true;
-    if (listener) {
-        console.log('Sending SIGINT to runner listener to stop');
-        listener.kill('SIGINT');
+  console.log("Shutting down runner listener");
+  stopping = true;
+  if (listener) {
+    console.log("Sending SIGINT to runner listener to stop");
+    listener.kill("SIGINT");
 
-        console.log('Sending SIGKILL to runner listener');
-        setTimeout(() => listener.kill('SIGKILL'), 30000).unref();
+    console.log("Sending SIGKILL to runner listener");
+    setTimeout(() => listener.kill("SIGKILL"), 30000).unref();
+  }
+};
+
+var runService = function () {
+  var listenerExePath = path.join(__dirname, "../bin/Runner.Listener");
+  var interactive = process.argv[2] === "interactive";
+
+  if (!stopping) {
+    try {
+      if (interactive) {
+        console.log("Starting Runner listener interactively");
+        listener = childProcess.spawn(listenerExePath, ["run"], {
+          env: process.env,
+        });
+      } else {
+        console.log("Starting Runner listener with startup type: service");
+        listener = childProcess.spawn(
+          listenerExePath,
+          ["run", "--startuptype", "service"],
+          { env: process.env }
+        );
+      }
+
+      console.log(`Started listener process, pid: ${listener.pid}`);
+
+      listener.stdout.on("data", (data) => {
+        if (data.toString("utf8").includes("Listening for Jobs")) {
+          consecutiveFailureCount = 0;
+        }
+        process.stdout.write(data.toString("utf8"));
+      });
+
+      listener.stderr.on("data", (data) => {
+        process.stdout.write(data.toString("utf8"));
+      });
+
+      listener.on("error", (err) => {
+        console.log(`Runner listener fail to start with error ${err.message}`);
+      });
+
+      listener.on("close", (code) => {
+        console.log(`Runner listener exited with error code ${code}`);
+
+        if (code === 0) {
+          console.log(
+            "Runner listener exit with 0 return code, stop the service, no retry needed."
+          );
+          stopping = true;
+        } else if (code === 1) {
+          console.log(
+            "Runner listener exit with terminated error, stop the service, no retry needed."
+          );
+          stopping = true;
+        } else if (code === 2) {
+          console.log(
+            "Runner listener exit with retryable error, re-launch runner in 5 seconds."
+          );
+          consecutiveFailureCount = 0;
+        } else if (code === 3 || code === 4) {
+          console.log(
+            "Runner listener exit because of updating, re-launch runner in 5 seconds."
+          );
+          consecutiveFailureCount = 0;
+        } else {
+          var messagePrefix = "Runner listener exit with undefined return code";
+          consecutiveFailureCount++;
+          if (
+            !isNaN(exitServiceAfterNFailures) &&
+            consecutiveFailureCount >= exitServiceAfterNFailures
+          ) {
+            console.error(
+              `${messagePrefix}, exiting service after ${consecutiveFailureCount} consecutive failures`
+            );
+            gracefulShutdown(5);
+            return;
+          } else {
+            console.log(`${messagePrefix}, re-launch runner in 5 seconds.`);
+          }
+        }
+
+        if (!stopping) {
+          setTimeout(runService, 5000);
+        }
+      });
+    } catch (ex) {
+      console.log(ex);
     }
-}
+  }
+};
 
-process.on('SIGINT', () => {
-    gracefulShutdown(0);
+runService();
+console.log("Started running service");
+
+process.on("SIGINT", () => {
+  gracefulShutdown(0);
 });
 
-process.on('SIGTERM', () => {
-    gracefulShutdown(0);
+process.on("SIGTERM", () => {
+  gracefulShutdown(0);
 });


### PR DESCRIPTION
Added behaviour so that system service could exit after a specified number of failures, depending on the `GITHUB_ACTIONS_SERVICE_EXIT_AFTER_N_FAILURES` env variable.

This feature should aid customers that have their own service templates to exit the service and leave restarting and notifying logic to the service they are using.

This change should not affect previous runners, that don't have this environment variable exported.

Added restart logic on status code 4 which is not caught before on the RunnerService.js, but is returned on update runOnce.

This change relates to #1677 