### PR TITLE
Add git commit SHA to useragent.

### DIFF
--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -216,6 +216,8 @@ namespace GitHub.Runner.Common
                 _userAgents.Add(new ProductInfoHeaderValue("RunnerId", runnerSettings.AgentId.ToString(CultureInfo.InvariantCulture)));
                 _userAgents.Add(new ProductInfoHeaderValue("GroupId", runnerSettings.PoolId.ToString(CultureInfo.InvariantCulture)));
             }
+
+            _userAgents.Add(new ProductInfoHeaderValue("CommitSHA", BuildConstants.Source.CommitHash));
         }
 
         public string GetDirectory(WellKnownDirectory directory)


### PR DESCRIPTION
This should help us figure out whether the request is from a runner we build.

Ex:
```
VSServices/2.287.1.0 (NetStandard; Darwin 20.6.0 Darwin Kernel Version 20.6.0: Wed Jan 12 22:22:42 PST 2022; root:xnu-7195.141.19~2/RELEASE_X86_64) GitHubActionsRunner-osx-x64/2.287.1 ClientId/e597d690-0f59-4367-b74f-d5b448a0c5d6 RunnerId/573 GroupId/1 CommitSHA/fd243a8ddf198c8c44389f23e1967e29ca55519a (Darwin 20.6.0 Darwin Kernel Version 20.6.0: Wed Jan 12 22:22:42 PST 2022; root:xnu-7195.141.19~2/RELEASE_X86_64)
```