### PR TITLE
Use better exit codes and comparison

### DIFF
--- a/src/Misc/layoutroot/run-helper.sh.template
+++ b/src/Misc/layoutroot/run-helper.sh.template
@@ -45,17 +45,17 @@ elif [[ $returnCode == 1 ]]; then
 elif [[ $returnCode == 2 ]]; then
     echo "Runner listener exit with retryable error, re-launch runner in 5 seconds."
     safe_sleep
-    exit 1
+    exit 2
 elif [[ $returnCode == 3 ]]; then
     # Sleep 5 seconds to wait for the runner update process finish
     echo "Runner listener exit because of updating, re-launch runner in 5 seconds"
     safe_sleep
-    exit 1
+    exit 2
 elif [[ $returnCode == 4 ]]; then
     # Sleep 5 seconds to wait for the ephemeral runner update process finish
     echo "Runner listener exit because of updating, re-launch ephemeral runner in 5 seconds"
     safe_sleep
-    exit 1
+    exit 2
 else
     echo "Exiting with unknown error code: ${returnCode}"
     exit 0

--- a/src/Misc/layoutroot/run.sh
+++ b/src/Misc/layoutroot/run.sh
@@ -15,7 +15,7 @@ while :;
 do
     "$DIR"/run-helper.sh $*
     returnCode=$?
-    if [[ $returnCode == 1 ]]; then
+    if [[ $returnCode -eq 2 ]]; then
         echo "Restarting runner..."
     else
         echo "Exiting runner..."


### PR DESCRIPTION
Exiting with `exit 1` in `run-helper.sh` and then reacting to it with `if [[ $returnCode == 1 ]]; then` will also restart on generic errors occuring in run-helper, like how we `exit 1` in `run-helper.sh` (line 7) if it's run with sudo.

I suggest we indicate a restart request with `exit 2`, then react to it with `if [[ $returnCode -eq 2 ]]; then`

Also changes `==` to `-eq` for numerical comparison.