### PR TITLE
Lets allow up to 150 characters for services on linux/mac

### DIFF
--- a/src/Runner.Listener/Configuration/ServiceControlManager.cs
+++ b/src/Runner.Listener/Configuration/ServiceControlManager.cs
@@ -51,8 +51,8 @@ namespace GitHub.Runner.Listener.Configuration
             if (serviceName.Length > MaxServiceNameLength)
             {
                 Trace.Verbose($"Calculated service name is too long (> {MaxServiceNameLength} chars). Trying again by calculating a shorter name.");
-                // Subtract 5 to add -xxxx random number on the end
-                int exceededCharLength = serviceName.Length - MaxServiceNameLength - 5;
+                // Add 5 to add -xxxx random number on the end
+                int exceededCharLength = serviceName.Length - MaxServiceNameLength + 5;
                 string repoOrOrgNameSubstring = StringUtil.SubstringPrefix(repoOrOrgName, MaxRepoOrgCharacters);
 
                 exceededCharLength -= repoOrOrgName.Length - repoOrOrgNameSubstring.Length;

--- a/src/Runner.Listener/Configuration/ServiceControlManager.cs
+++ b/src/Runner.Listener/Configuration/ServiceControlManager.cs
@@ -65,19 +65,12 @@ namespace GitHub.Runner.Listener.Configuration
                 {
                     runnerNameSubstring = StringUtil.SubstringPrefix(settings.AgentName, settings.AgentName.Length - exceededCharLength);
                 }
-                #pragma warning disable CS0162
-                if (AdditionalDigits > 0)
-                {
-                    var random = new Random();
-                    var num = random.Next((int)Math.Pow(10, AdditionalDigits-1),(int)Math.Pow(10, AdditionalDigits)).ToString();
-                    runnerNameSubstring +=$"-{num}";
-                    serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgNameSubstring, runnerNameSubstring);
-                }
-                else
-                {
-                    serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgNameSubstring, runnerNameSubstring);
-                }
-                #pragma warning restore CS0162
+
+                // Lets add a suffix with a random number to reduce the chance of collisions between runner names once we truncate
+                var random = new Random();
+                var num = random.Next((int)Math.Pow(10, AdditionalDigits-1),(int)Math.Pow(10, AdditionalDigits)).ToString();
+                runnerNameSubstring +=$"-{num}";
+                serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgNameSubstring, runnerNameSubstring);
             }
 
             serviceDisplayName = StringUtil.Format(serviceDisplayNamePattern, repoOrOrgName, settings.AgentName);
@@ -89,9 +82,9 @@ namespace GitHub.Runner.Listener.Configuration
             const int MaxRepoOrgCharacters = 70;
             const int AdditionalDigits = 4;
         #elif OS_WINDOWS
-            const int MaxServiceNameLength = 80;
+            const int MaxServiceNameLength = 75;
             const int MaxRepoOrgCharacters = 45;
-            const int AdditionalDigits = 0;
+            const int AdditionalDigits = 4;
         #endif
     }
 }

--- a/src/Runner.Listener/Configuration/ServiceControlManager.cs
+++ b/src/Runner.Listener/Configuration/ServiceControlManager.cs
@@ -66,7 +66,19 @@ namespace GitHub.Runner.Listener.Configuration
                     runnerNameSubstring = StringUtil.SubstringPrefix(settings.AgentName, settings.AgentName.Length - exceededCharLength);
                 }
 
-                serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgNameSubstring, runnerNameSubstring);
+                if (AdditionalDigits > 0)
+                {
+                    var random = new Random();
+                    var num = random.Next((int)Math.Pow(10, AdditionalDigits-1),(int)Math.Pow(10, AdditionalDigits)).ToString();
+                    runnerNameSubstring +=$"-{num}";
+                    serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgNameSubstring, runnerNameSubstring);
+                }
+                #pragma warning disable CS0162
+                else
+                {
+                    serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgNameSubstring, runnerNameSubstring);
+                }
+                #pragma warning restore CS0162
             }
 
             serviceDisplayName = StringUtil.Format(serviceDisplayNamePattern, repoOrOrgName, settings.AgentName);
@@ -76,9 +88,11 @@ namespace GitHub.Runner.Listener.Configuration
         #if (OS_LINUX || OS_OSX)
             const int MaxServiceNameLength = 150;
             const int MaxRepoOrgCharacters = 70;
+            const int AdditionalDigits = 4;
         #elif OS_WINDOWS
             const int MaxServiceNameLength = 80;
             const int MaxRepoOrgCharacters = 45;
+            const int AdditionalDigits = 0;
         #endif
     }
 }

--- a/src/Runner.Listener/Configuration/ServiceControlManager.cs
+++ b/src/Runner.Listener/Configuration/ServiceControlManager.cs
@@ -65,7 +65,7 @@ namespace GitHub.Runner.Listener.Configuration
                 {
                     runnerNameSubstring = StringUtil.SubstringPrefix(settings.AgentName, settings.AgentName.Length - exceededCharLength);
                 }
-
+                #pragma warning disable CS0162
                 if (AdditionalDigits > 0)
                 {
                     var random = new Random();
@@ -73,7 +73,6 @@ namespace GitHub.Runner.Listener.Configuration
                     runnerNameSubstring +=$"-{num}";
                     serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgNameSubstring, runnerNameSubstring);
                 }
-                #pragma warning disable CS0162
                 else
                 {
                     serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgNameSubstring, runnerNameSubstring);

--- a/src/Runner.Listener/Configuration/ServiceControlManager.cs
+++ b/src/Runner.Listener/Configuration/ServiceControlManager.cs
@@ -48,12 +48,11 @@ namespace GitHub.Runner.Listener.Configuration
             string repoOrOrgName = regex.Replace(settings.RepoOrOrgName, "-");
 
             serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgName, settings.AgentName);
-
             if (serviceName.Length > MaxServiceNameLength)
             {
                 Trace.Verbose($"Calculated service name is too long (> {MaxServiceNameLength} chars). Trying again by calculating a shorter name.");
-
-                int exceededCharLength = serviceName.Length - MaxServiceNameLength;
+                // Subtract 5 to add -xxxx random number on the end
+                int exceededCharLength = serviceName.Length - MaxServiceNameLength - 5;
                 string repoOrOrgNameSubstring = StringUtil.SubstringPrefix(repoOrOrgName, MaxRepoOrgCharacters);
 
                 exceededCharLength -= repoOrOrgName.Length - repoOrOrgNameSubstring.Length;
@@ -81,7 +80,7 @@ namespace GitHub.Runner.Listener.Configuration
             const int MaxServiceNameLength = 150;
             const int MaxRepoOrgCharacters = 70;
         #elif OS_WINDOWS
-            const int MaxServiceNameLength = 75;
+            const int MaxServiceNameLength = 80;
             const int MaxRepoOrgCharacters = 45;
         #endif
     }

--- a/src/Runner.Listener/Configuration/ServiceControlManager.cs
+++ b/src/Runner.Listener/Configuration/ServiceControlManager.cs
@@ -49,12 +49,12 @@ namespace GitHub.Runner.Listener.Configuration
 
             serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgName, settings.AgentName);
 
-            if (serviceName.Length > 80)
+            if (serviceName.Length > MaxServiceNameLength)
             {
-                Trace.Verbose($"Calculated service name is too long (> 80 chars). Trying again by calculating a shorter name.");
+                Trace.Verbose($"Calculated service name is too long (> {MaxServiceNameLength} chars). Trying again by calculating a shorter name.");
 
-                int exceededCharLength = serviceName.Length - 80;
-                string repoOrOrgNameSubstring = StringUtil.SubstringPrefix(repoOrOrgName, 45);
+                int exceededCharLength = serviceName.Length - MaxServiceNameLength;
+                string repoOrOrgNameSubstring = StringUtil.SubstringPrefix(repoOrOrgName, MaxRepoOrgCharacters);
 
                 exceededCharLength -= repoOrOrgName.Length - repoOrOrgNameSubstring.Length;
 
@@ -73,5 +73,12 @@ namespace GitHub.Runner.Listener.Configuration
 
             Trace.Info($"Service name '{serviceName}' display name '{serviceDisplayName}' will be used for service configuration.");
         }
+        #if (OS_LINUX || OS_OSX)
+            const int MaxServiceNameLength = 150;
+            const int MaxRepoOrgCharacters = 70;
+        #elif OS_WINDOWS
+            const int MaxServiceNameLength = 80;
+            const int MaxRepoOrgCharacters = 45;
+        #endif
     }
 }

--- a/src/Runner.Listener/Configuration/ServiceControlManager.cs
+++ b/src/Runner.Listener/Configuration/ServiceControlManager.cs
@@ -68,7 +68,7 @@ namespace GitHub.Runner.Listener.Configuration
 
                 // Lets add a suffix with a random number to reduce the chance of collisions between runner names once we truncate
                 var random = new Random();
-                var num = random.Next((int)Math.Pow(10, AdditionalDigits-1),(int)Math.Pow(10, AdditionalDigits)).ToString();
+                var num = random.Next(1000, 9999).ToString();
                 runnerNameSubstring +=$"-{num}";
                 serviceName = StringUtil.Format(serviceNamePattern, repoOrOrgNameSubstring, runnerNameSubstring);
             }
@@ -80,11 +80,9 @@ namespace GitHub.Runner.Listener.Configuration
         #if (OS_LINUX || OS_OSX)
             const int MaxServiceNameLength = 150;
             const int MaxRepoOrgCharacters = 70;
-            const int AdditionalDigits = 4;
         #elif OS_WINDOWS
             const int MaxServiceNameLength = 75;
             const int MaxRepoOrgCharacters = 45;
-            const int AdditionalDigits = 4;
         #endif
     }
 }

--- a/src/Test/L0/ServiceControlManagerL0.cs
+++ b/src/Test/L0/ServiceControlManagerL0.cs
@@ -16,7 +16,7 @@ namespace GitHub.Runner.Common.Tests
         {
             RunnerSettings settings = new RunnerSettings();
 
-            settings.AgentName = "thisiskindofalongrunnername1";
+            settings.AgentName = "thisiskindofalongrunnerabcde";
             settings.ServerUrl = "https://example.githubusercontent.com/12345678901234567890123456789012345678901234567890";
             settings.GitHubUrl = "https://github.com/myorganizationexample/myrepoexample";
 
@@ -44,7 +44,7 @@ namespace GitHub.Runner.Common.Tests
                 Assert.Equal("actions", serviceNameParts[0]);
                 Assert.Equal("runner", serviceNameParts[1]);
                 Assert.Equal("myorganizationexample-myrepoexample", serviceNameParts[2]); // '/' has been replaced with '-'
-                Assert.Equal("thisiskindofalongrunnername1", serviceNameParts[3]);
+                Assert.Equal("thisiskindofalongrunnerabcde", serviceNameParts[3]);
             }
         }
 
@@ -55,7 +55,7 @@ namespace GitHub.Runner.Common.Tests
         {
             RunnerSettings settings = new RunnerSettings();
 
-            settings.AgentName = "thisiskindofalongrunnername12";
+            settings.AgentName = "thisiskindofalongrunnernabcde";
             settings.ServerUrl = "https://example.githubusercontent.com/12345678901234567890123456789012345678901234567890";
             settings.GitHubUrl = "https://github.com/myorganizationexample/myrepoexample";
 
@@ -83,7 +83,7 @@ namespace GitHub.Runner.Common.Tests
                 Assert.Equal("actions", serviceNameParts[0]);
                 Assert.Equal("runner", serviceNameParts[1]);
                 Assert.Equal("myorganizationexample-myrepoexample", serviceNameParts[2]); // '/' has been replaced with '-'
-                Assert.Equal("thisiskindofalongrunnername12", serviceNameParts[3]);
+                Assert.Equal("thisiskindofalongrunnernabcde", serviceNameParts[3]); // should not have random numbers unless we exceed 80
             }
         }
 
@@ -123,7 +123,7 @@ namespace GitHub.Runner.Common.Tests
                     Assert.Equal("actions", serviceNameParts[0]); // Never shortened
                     Assert.Equal("runner", serviceNameParts[1]); // Never shortened
                     Assert.Equal("myreallylongorganizationexample-myreallylongr", serviceNameParts[2]); // First 45 chars, '/' has been replaced with '-'
-                    Assert.Matches(@"^(thisisareallyr-[0-9]{4})$", serviceNameParts[3]); // Remainder of unused chars
+                    Assert.Matches(@"^(thisisareallyr-[0-9]{4})$", serviceNameParts[3]); // Remainder of unused chars, 4 random numbers added at the end
                 }
             }
 

--- a/src/Test/L0/ServiceControlManagerL0.cs
+++ b/src/Test/L0/ServiceControlManagerL0.cs
@@ -193,8 +193,8 @@ namespace GitHub.Runner.Common.Tests
                         out string serviceName,
                         out string serviceDisplayName);
 
-                    // Verify name has been shortened to 150 + 5 randomized characters
-                    Assert.Equal(155, serviceName.Length);
+                    // Verify name has been shortened to 150
+                    Assert.Equal(150, serviceName.Length);
 
                     var serviceNameParts = serviceName.Split('.');
 
@@ -202,7 +202,7 @@ namespace GitHub.Runner.Common.Tests
                     Assert.Equal("actions", serviceNameParts[0]); // Never shortened
                     Assert.Equal("runner", serviceNameParts[1]); // Never shortened
                     Assert.Equal("myreallylongorganizationexampleonlinux-myreallylongrepoexampleonlinux1", serviceNameParts[2]); // First 70 chars, '/' has been replaced with '-'
-                    Assert.Matches(@"^(thisisareallyreallylongbutstillvalidagentnameiamusingforthisexam-[0-9]{4})$", serviceNameParts[3]);
+                    Assert.Matches(@"^(thisisareallyreallylongbutstillvalidagentnameiamusingforthi-[0-9]{4})$", serviceNameParts[3]);
                 }
             }
         #endif

--- a/src/Test/L0/ServiceControlManagerL0.cs
+++ b/src/Test/L0/ServiceControlManagerL0.cs
@@ -123,7 +123,7 @@ namespace GitHub.Runner.Common.Tests
                     Assert.Equal("actions", serviceNameParts[0]); // Never shortened
                     Assert.Equal("runner", serviceNameParts[1]); // Never shortened
                     Assert.Equal("myreallylongorganizationexample-myreallylongr", serviceNameParts[2]); // First 45 chars, '/' has been replaced with '-'
-                    Assert.Equal("thisisareallyreally", serviceNameParts[3]); // Remainder of unused chars
+                    Assert.Matches(@"^(thisisareallyr-[0-9]{4})$", serviceNameParts[3]); // Remainder of unused chars
                 }
             }
 

--- a/src/Test/L0/ServiceControlManagerL0.cs
+++ b/src/Test/L0/ServiceControlManagerL0.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using GitHub.Runner.Common;
 using GitHub.Runner.Listener.Configuration;
 using Xunit;
@@ -192,8 +193,8 @@ namespace GitHub.Runner.Common.Tests
                         out string serviceName,
                         out string serviceDisplayName);
 
-                    // Verify name has been shortened to 150 characters
-                    Assert.Equal(150, serviceName.Length);
+                    // Verify name has been shortened to 150 + 5 randomized characters
+                    Assert.Equal(155, serviceName.Length);
 
                     var serviceNameParts = serviceName.Split('.');
 
@@ -201,7 +202,8 @@ namespace GitHub.Runner.Common.Tests
                     Assert.Equal("actions", serviceNameParts[0]); // Never shortened
                     Assert.Equal("runner", serviceNameParts[1]); // Never shortened
                     Assert.Equal("myreallylongorganizationexampleonlinux-myreallylongrepoexampleonlinux1", serviceNameParts[2]); // First 70 chars, '/' has been replaced with '-'
-                    Assert.Equal("thisisareallyreallylongbutstillvalidagentnameiamusingforthisexam", serviceNameParts[3]); // Remainder of unused chars
+                    Regex regex = new Regex(@"^(thisisareallyreallylongbutstillvalidagentnameiamusingforthisexam[0-9]{4})$");
+                    Assert.Matches(@"^(thisisareallyreallylongbutstillvalidagentnameiamusingforthisexam[0-9]{4})$", serviceNameParts[3]);
                 }
             }
         #endif

--- a/src/Test/L0/ServiceControlManagerL0.cs
+++ b/src/Test/L0/ServiceControlManagerL0.cs
@@ -86,84 +86,125 @@ namespace GitHub.Runner.Common.Tests
             }
         }
 
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Service")]
-        public void CalculateServiceNameLimitsServiceNameTo80Chars()
-        {
-            RunnerSettings settings = new RunnerSettings();
-
-            settings.AgentName = "thisisareallyreallylongbutstillvalidagentname";
-            settings.ServerUrl = "https://example.githubusercontent.com/12345678901234567890123456789012345678901234567890";
-            settings.GitHubUrl = "https://github.com/myreallylongorganizationexample/myreallylongrepoexample";
-
-            string serviceNamePattern = "actions.runner.{0}.{1}";
-            string serviceDisplayNamePattern = "GitHub Actions Runner ({0}.{1})";
-
-            using (TestHostContext hc = CreateTestContext())
+        #if OS_WINDOWS
+            [Fact]
+            [Trait("Level", "L0")]
+            [Trait("Category", "Service")]
+            public void CalculateServiceNameLimitsServiceNameTo80Chars()
             {
-                ServiceControlManager scm = new ServiceControlManager();
+                RunnerSettings settings = new RunnerSettings();
 
-                scm.Initialize(hc);
-                scm.CalculateServiceName(
-                    settings,
-                    serviceNamePattern,
-                    serviceDisplayNamePattern,
-                    out string serviceName,
-                    out string serviceDisplayName);
+                settings.AgentName = "thisisareallyreallylongbutstillvalidagentname";
+                settings.ServerUrl = "https://example.githubusercontent.com/12345678901234567890123456789012345678901234567890";
+                settings.GitHubUrl = "https://github.com/myreallylongorganizationexample/myreallylongrepoexample";
 
-                // Verify name has been shortened to 80 characters
-                Assert.Equal(80, serviceName.Length);
+                string serviceNamePattern = "actions.runner.{0}.{1}";
+                string serviceDisplayNamePattern = "GitHub Actions Runner ({0}.{1})";
 
-                var serviceNameParts = serviceName.Split('.');
+                using (TestHostContext hc = CreateTestContext())
+                {
+                    ServiceControlManager scm = new ServiceControlManager();
 
-                // Verify that each component has been shortened to a sensible length
-                Assert.Equal("actions", serviceNameParts[0]); // Never shortened
-                Assert.Equal("runner", serviceNameParts[1]); // Never shortened
-                Assert.Equal("myreallylongorganizationexample-myreallylongr", serviceNameParts[2]); // First 45 chars, '/' has been replaced with '-'
-                Assert.Equal("thisisareallyreally", serviceNameParts[3]); // Remainder of unused chars
+                    scm.Initialize(hc);
+                    scm.CalculateServiceName(
+                        settings,
+                        serviceNamePattern,
+                        serviceDisplayNamePattern,
+                        out string serviceName,
+                        out string serviceDisplayName);
+
+                    // Verify name has been shortened to 80 characters
+                    Assert.Equal(80, serviceName.Length);
+
+                    var serviceNameParts = serviceName.Split('.');
+
+                    // Verify that each component has been shortened to a sensible length
+                    Assert.Equal("actions", serviceNameParts[0]); // Never shortened
+                    Assert.Equal("runner", serviceNameParts[1]); // Never shortened
+                    Assert.Equal("myreallylongorganizationexample-myreallylongr", serviceNameParts[2]); // First 45 chars, '/' has been replaced with '-'
+                    Assert.Equal("thisisareallyreally", serviceNameParts[3]); // Remainder of unused chars
+                }
             }
-        }
 
-        // Special 'defensive' test that verifies we can gracefully handle creating service names
-        // in case GitHub.com changes its org/repo naming convention in the future,
-        // and some of these characters may be invalid for service names
-        // Not meant to test character set exhaustively -- it's just here to exercise the sanitizing logic
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Service")]
-        public void CalculateServiceNameSanitizeOutOfRangeChars()
-        {
-            RunnerSettings settings = new RunnerSettings();
-
-            settings.AgentName = "name";
-            settings.ServerUrl = "https://example.githubusercontent.com/12345678901234567890123456789012345678901234567890";
-            settings.GitHubUrl = "https://github.com/org!@$*+[]()/repo!@$*+[]()";
-
-            string serviceNamePattern = "actions.runner.{0}.{1}";
-            string serviceDisplayNamePattern = "GitHub Actions Runner ({0}.{1})";
-
-            using (TestHostContext hc = CreateTestContext())
+            // Special 'defensive' test that verifies we can gracefully handle creating service names
+            // in case GitHub.com changes its org/repo naming convention in the future,
+            // and some of these characters may be invalid for service names
+            // Not meant to test character set exhaustively -- it's just here to exercise the sanitizing logic
+            [Fact]
+            [Trait("Level", "L0")]
+            [Trait("Category", "Service")]
+            public void CalculateServiceNameSanitizeOutOfRangeChars()
             {
-                ServiceControlManager scm = new ServiceControlManager();
+                RunnerSettings settings = new RunnerSettings();
 
-                scm.Initialize(hc);
-                scm.CalculateServiceName(
-                    settings,
-                    serviceNamePattern,
-                    serviceDisplayNamePattern,
-                    out string serviceName,
-                    out string serviceDisplayName);
+                settings.AgentName = "name";
+                settings.ServerUrl = "https://example.githubusercontent.com/12345678901234567890123456789012345678901234567890";
+                settings.GitHubUrl = "https://github.com/org!@$*+[]()/repo!@$*+[]()";
 
-                var serviceNameParts = serviceName.Split('.');
+                string serviceNamePattern = "actions.runner.{0}.{1}";
+                string serviceDisplayNamePattern = "GitHub Actions Runner ({0}.{1})";
 
-                // Verify service name parts are sanitized correctly
-                Assert.Equal("actions", serviceNameParts[0]);
-                Assert.Equal("runner", serviceNameParts[1]);
-                Assert.Equal("org----------repo---------", serviceNameParts[2]); // Chars replaced with '-'
-                Assert.Equal("name", serviceNameParts[3]);
+                using (TestHostContext hc = CreateTestContext())
+                {
+                    ServiceControlManager scm = new ServiceControlManager();
+
+                    scm.Initialize(hc);
+                    scm.CalculateServiceName(
+                        settings,
+                        serviceNamePattern,
+                        serviceDisplayNamePattern,
+                        out string serviceName,
+                        out string serviceDisplayName);
+
+                    var serviceNameParts = serviceName.Split('.');
+
+                    // Verify service name parts are sanitized correctly
+                    Assert.Equal("actions", serviceNameParts[0]);
+                    Assert.Equal("runner", serviceNameParts[1]);
+                    Assert.Equal("org----------repo---------", serviceNameParts[2]); // Chars replaced with '-'
+                    Assert.Equal("name", serviceNameParts[3]);
+                }
             }
-        }
+        #else
+            [Fact]
+            [Trait("Level", "L0")]
+            [Trait("Category", "Service")]
+            public void CalculateServiceNameLimitsServiceNameTo150Chars()
+            {
+                RunnerSettings settings = new RunnerSettings();
+
+                settings.AgentName = "thisisareallyreallylongbutstillvalidagentnameiamusingforthisexampletotestverylongnamelimits";
+                settings.ServerUrl = "https://example.githubusercontent.com/12345678901234567890123456789012345678901234567890";
+                settings.GitHubUrl = "https://github.com/myreallylongorganizationexampleonlinux/myreallylongrepoexampleonlinux1234";
+
+                string serviceNamePattern = "actions.runner.{0}.{1}";
+                string serviceDisplayNamePattern = "GitHub Actions Runner ({0}.{1})";
+
+                using (TestHostContext hc = CreateTestContext())
+                {
+                    ServiceControlManager scm = new ServiceControlManager();
+
+                    scm.Initialize(hc);
+                    scm.CalculateServiceName(
+                        settings,
+                        serviceNamePattern,
+                        serviceDisplayNamePattern,
+                        out string serviceName,
+                        out string serviceDisplayName);
+
+                    // Verify name has been shortened to 150 characters
+                    Assert.Equal(150, serviceName.Length);
+
+                    var serviceNameParts = serviceName.Split('.');
+
+                    // Verify that each component has been shortened to a sensible length
+                    Assert.Equal("actions", serviceNameParts[0]); // Never shortened
+                    Assert.Equal("runner", serviceNameParts[1]); // Never shortened
+                    Assert.Equal("myreallylongorganizationexampleonlinux-myreallylongrepoexampleonlinux1", serviceNameParts[2]); // First 70 chars, '/' has been replaced with '-'
+                    Assert.Equal("thisisareallyreallylongbutstillvalidagentnameiamusingforthisexam", serviceNameParts[3]); // Remainder of unused chars
+                }
+            }
+        #endif
 
         private TestHostContext CreateTestContext([CallerMemberName] string testName = "")
         {

--- a/src/Test/L0/ServiceControlManagerL0.cs
+++ b/src/Test/L0/ServiceControlManagerL0.cs
@@ -202,8 +202,7 @@ namespace GitHub.Runner.Common.Tests
                     Assert.Equal("actions", serviceNameParts[0]); // Never shortened
                     Assert.Equal("runner", serviceNameParts[1]); // Never shortened
                     Assert.Equal("myreallylongorganizationexampleonlinux-myreallylongrepoexampleonlinux1", serviceNameParts[2]); // First 70 chars, '/' has been replaced with '-'
-                    Regex regex = new Regex(@"^(thisisareallyreallylongbutstillvalidagentnameiamusingforthisexam[0-9]{4})$");
-                    Assert.Matches(@"^(thisisareallyreallylongbutstillvalidagentnameiamusingforthisexam[0-9]{4})$", serviceNameParts[3]);
+                    Assert.Matches(@"^(thisisareallyreallylongbutstillvalidagentnameiamusingforthisexam-[0-9]{4})$", serviceNameParts[3]);
                 }
             }
         #endif


### PR DESCRIPTION
This helps support users that use self hosted runners with very long runner/repository names to avoid collisions

Why 150?

Filenames in linux/mac are max of 255 characters, systemd is limited to 255 characters for the service name as well. While we could go all the way there, doubling the length from ~80 to ~150 should be plenty because **Runner names can only be 64 characters in length.** 

So after this change on linux/mac we should only trim the service name if the repository + org name exceeds 70 characters. That isn't a huge deal, as ~64 characters of runner name and 70 characters of org+repository should be unique enough where there are no collisions.

We can't do this on windows, as windows services have max name lengths that are very low, which is why we added this limit in the first place.

Fixing: https://github.com/actions/runner/issues/730