### PR TITLE
worker: expose `github.triggering_actor` as an env-var

### DIFF
--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -13,6 +13,7 @@ namespace GitHub.Runner.Worker
             "action_ref",
             "action_repository",
             "actor",
+            "triggering_actor",
             "api_url",
             "base_ref",
             "env",

--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -8,12 +8,11 @@ namespace GitHub.Runner.Worker
     {
         private readonly HashSet<string> _contextEnvAllowlist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "action",
             "action_path",
             "action_ref",
             "action_repository",
+            "action",
             "actor",
-            "triggering_actor",
             "api_url",
             "base_ref",
             "env",
@@ -23,12 +22,12 @@ namespace GitHub.Runner.Worker
             "head_ref",
             "job",
             "path",
-            "ref",
             "ref_name",
             "ref_protected",
             "ref_type",
-            "repository",
+            "ref",
             "repository_owner",
+            "repository",
             "retention_days",
             "run_attempt",
             "run_id",
@@ -36,6 +35,7 @@ namespace GitHub.Runner.Worker
             "server_url",
             "sha",
             "step_summary",
+            "triggering_actor",
             "workflow",
             "workspace",
         };


### PR DESCRIPTION
Reruns will distinguish between the executing (`github.actor`, whom created the first run) and triggering (`github.triggering_actor`, whom requested the rerun) soon, and the `github.actor` will always be stable across reruns. To allow users to act differently based on the triggering actor, we're adding support for `github.triggering_actor`. Since `"actor"` is an allowed field that ends up in the env vars exposed to workflow steps, we concluded that `triggering_actor` also should be allowed.