### PR TITLE
Add annotations if Node 12 action is found and FF is on

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -146,7 +146,7 @@ namespace GitHub.Runner.Common
                 public const int RunOnceRunnerUpdating = 4;
             }
 
-            public static class FeatureFlags
+            public static class Features
             {
                 public static readonly string DiskSpaceWarning = "runner.diskspace.warning";
                 public static readonly string Node12Warning = "DistributedTask.AddWarningToNode12Action";

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -146,9 +146,10 @@ namespace GitHub.Runner.Common
                 public const int RunOnceRunnerUpdating = 4;
             }
 
-            public static class Features
+            public static class FeatureFlags
             {
                 public static readonly string DiskSpaceWarning = "runner.diskspace.warning";
+                public static readonly string Node12Warning = "DistributedTask.Node12Warning";
             }
 
             public static readonly string InternalTelemetryIssueDataKey = "_internal_telemetry";

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -159,6 +159,7 @@ namespace GitHub.Runner.Common
             public static readonly string UnsupportedCommandMessageDisabled = "The `{0}` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
             public static readonly string UnsupportedStopCommandTokenDisabled = "You cannot use a endToken that is an empty string, the string 'pause-logging', or another workflow command. For more information see: https://docs.github.com/actions/learn-github-actions/workflow-commands-for-github-actions#example-stopping-and-starting-workflow-commands or opt into insecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_STOPCOMMAND_TOKENS` environment variable to `true`.";
             public static readonly string UnsupportedSummarySize = "$GITHUB_STEP_SUMMARY upload aborted, supports content up to a size of {0}k, got {1}k. For more information see: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-markdown-summary";
+            public static readonly string Node12DetectedAfterEndOfLife = "One or more actions in this job ran using Node v12 which is coming to its End-oflife on 2022-04-30. It is recommended to update all affected action definitions to use Node v16. Actions ran on Node v12: {0}";
         }
 
         public static class RunnerEvent

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -159,7 +159,7 @@ namespace GitHub.Runner.Common
             public static readonly string UnsupportedCommandMessageDisabled = "The `{0}` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/";
             public static readonly string UnsupportedStopCommandTokenDisabled = "You cannot use a endToken that is an empty string, the string 'pause-logging', or another workflow command. For more information see: https://docs.github.com/actions/learn-github-actions/workflow-commands-for-github-actions#example-stopping-and-starting-workflow-commands or opt into insecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_STOPCOMMAND_TOKENS` environment variable to `true`.";
             public static readonly string UnsupportedSummarySize = "$GITHUB_STEP_SUMMARY upload aborted, supports content up to a size of {0}k, got {1}k. For more information see: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-markdown-summary";
-            public static readonly string Node12DetectedAfterEndOfLife = "One or more actions in this job ran using Node v12 which is coming to its End-oflife on 2022-04-30. It is recommended to update all affected action definitions to use Node v16. Actions ran on Node v12: {0}";
+            public static readonly string Node12DetectedAfterEndOfLife = "Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: {0}";
         }
 
         public static class RunnerEvent

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -149,7 +149,7 @@ namespace GitHub.Runner.Common
             public static class FeatureFlags
             {
                 public static readonly string DiskSpaceWarning = "runner.diskspace.warning";
-                public static readonly string Node12Warning = "DistributedTask.Node12Warning";
+                public static readonly string Node12Warning = "DistributedTask.AddWarningToNode12Action";
             }
 
             public static readonly string InternalTelemetryIssueDataKey = "_internal_telemetry";

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -114,7 +114,7 @@ namespace GitHub.Runner.Worker.Handlers
             // Remove environment variable that may cause conflicts with the node within the runner.
             Environment.Remove("NODE_ICU_DATA"); // https://github.com/actions/runner/issues/795
 
-            if (Data.NodeVersion == "node12" && (ExecutionContext.Global.Variables.GetBoolean(Constants.Runner.FeatureFlags.Node12Warning) ?? false))
+            if (Data.NodeVersion == "node12" && (ExecutionContext.Global.Variables.GetBoolean(Constants.Runner.Features.Node12Warning) ?? false))
             {
                 if (!ExecutionContext.JobContext.ContainsKey("Node12ActionsWarnings"))
                 {                     

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -114,6 +114,17 @@ namespace GitHub.Runner.Worker.Handlers
             // Remove environment variable that may cause conflicts with the node within the runner.
             Environment.Remove("NODE_ICU_DATA"); // https://github.com/actions/runner/issues/795
 
+            if (Data.NodeVersion == "node12" && (ExecutionContext.Global.Variables.GetBoolean(Constants.Runner.FeatureFlags.Node12Warning) ?? false))
+            {
+                if (!ExecutionContext.JobContext.ContainsKey("Node12ActionsWarnings"))
+                {                     
+                    ExecutionContext.JobContext["Node12ActionsWarnings"] = new ArrayContextData();
+                }
+                var repoAction = Action as RepositoryPathReference;
+                var actionDisplayName = new StringContextData(repoAction.Name ?? repoAction.Path); // local actions don't have a 'Name'                
+                ExecutionContext.JobContext["Node12ActionsWarnings"].AssertArray("Node12ActionsWarnings").Add(actionDisplayName);
+            }
+
             using (var stdoutManager = new OutputManager(ExecutionContext, ActionCommandManager))
             using (var stderrManager = new OutputManager(ExecutionContext, ActionCommandManager))
             {
@@ -149,17 +160,6 @@ namespace GitHub.Runner.Worker.Handlers
                         ExecutionContext.Result = TaskResult.Failed;
                     }
                 }
-            }
-
-            if (Data.NodeVersion == "node12" && (ExecutionContext.Global.Variables.GetBoolean(Constants.Runner.FeatureFlags.Node12Warning) ?? false))
-            {
-                if (!ExecutionContext.JobContext.ContainsKey("Node12ActionsWarnings"))
-                {                     
-                    ExecutionContext.JobContext["Node12ActionsWarnings"] = new ArrayContextData();
-                }
-                var repoAction = Action as RepositoryPathReference;
-                var actionDisplayName = new StringContextData(repoAction.Name ?? repoAction.Path); // local actions don't have a 'Name'                
-                ExecutionContext.JobContext["Node12ActionsWarnings"].AssertArray("Node12ActionsWarnings").Add(actionDisplayName);
             }
         }
     }

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -151,7 +151,7 @@ namespace GitHub.Runner.Worker.Handlers
                 }
             }
 
-            if (Data.NodeVersion == "node12") // TODO: Add FF
+            if (Data.NodeVersion == "node12" && (ExecutionContext.Global.Variables.GetBoolean(Constants.Runner.FeatureFlags.Node12Warning) ?? false))
             {
                 if (!ExecutionContext.JobContext.ContainsKey("Node12ActionsWarnings"))
                 {                     

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GitHub.DistributedTask.Pipelines;
+using GitHub.DistributedTask.Pipelines.ContextData;
 using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Common;
 using GitHub.Runner.Sdk;
@@ -147,6 +149,17 @@ namespace GitHub.Runner.Worker.Handlers
                         ExecutionContext.Result = TaskResult.Failed;
                     }
                 }
+            }
+
+            if (Data.NodeVersion == "node12") // TODO: Add FF
+            {
+                if (!ExecutionContext.JobContext.ContainsKey("Node12ActionsWarnings"))
+                {                     
+                    ExecutionContext.JobContext["Node12ActionsWarnings"] = new ArrayContextData();
+                }
+                var repoAction = Action as RepositoryPathReference;
+                var actionDisplayName = new StringContextData(repoAction.Name ?? repoAction.Path); // local actions don't have a 'Name'                
+                ExecutionContext.JobContext["Node12ActionsWarnings"].AssertArray("Node12ActionsWarnings").Add(actionDisplayName);
             }
         }
     }

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -358,7 +358,7 @@ namespace GitHub.Runner.Worker
                         }
                     }
 
-                    jobContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.FeatureFlags.DiskSpaceWarning, out var enableWarning);
+                    jobContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.Features.DiskSpaceWarning, out var enableWarning);
                     if (StringUtil.ConvertToBoolean(enableWarning, defaultValue: true))
                     {
                         _diskSpaceCheckTask = CheckDiskSpaceAsync(context, _diskSpaceCheckToken.Token);

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -358,7 +358,7 @@ namespace GitHub.Runner.Worker
                         }
                     }
 
-                    jobContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.Features.DiskSpaceWarning, out var enableWarning);
+                    jobContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.FeatureFlags.DiskSpaceWarning, out var enableWarning);
                     if (StringUtil.ConvertToBoolean(enableWarning, defaultValue: true))
                     {
                         _diskSpaceCheckTask = CheckDiskSpaceAsync(context, _diskSpaceCheckToken.Token);

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -261,8 +261,7 @@ namespace GitHub.Runner.Worker
             if (jobContext.JobContext.ContainsKey("Node12ActionsWarnings"))
             {
                 var actions = string.Join(", ", jobContext.JobContext["Node12ActionsWarnings"].AssertArray("Node12ActionsWarnings").Select(action => action.ToString()));
-                var acm = HostContext.CreateService<IActionCommandManager>();
-                acm.TryProcessCommand(jobContext, $"::warning::Placeholder text: This action uses Node v12 with EoL in April. It is recommended to update to v16. For more info: https://nodejs.org/en/about/releases/ Actions: {actions}", null);
+                jobContext.Warning(string.Format(Constants.Runner.Node12DetectedAfterEndOfLife, actions));
             }
 
             try

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using GitHub.DistributedTask.Pipelines.ContextData;
 using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Common;
 using GitHub.Runner.Common.Util;
@@ -255,6 +256,13 @@ namespace GitHub.Runner.Worker
                     // Ignore any error since suggest runner update is best effort.
                     Trace.Error($"Caught exception during runner version check: {ex}");
                 }
+            }
+
+            if (jobContext.JobContext.ContainsKey("Node12ActionsWarnings"))
+            {
+                var actions = string.Join(", ", jobContext.JobContext["Node12ActionsWarnings"].AssertArray("Node12ActionsWarnings").Select(action => action.ToString()));
+                var acm = HostContext.CreateService<IActionCommandManager>();
+                acm.TryProcessCommand(jobContext, $"::warning::Placeholder text: This action uses Node v12 with EoL in April. It is recommended to update to v16. Actions: {actions}", null);
             }
 
             try

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -262,7 +262,7 @@ namespace GitHub.Runner.Worker
             {
                 var actions = string.Join(", ", jobContext.JobContext["Node12ActionsWarnings"].AssertArray("Node12ActionsWarnings").Select(action => action.ToString()));
                 var acm = HostContext.CreateService<IActionCommandManager>();
-                acm.TryProcessCommand(jobContext, $"::warning::Placeholder text: This action uses Node v12 with EoL in April. It is recommended to update to v16. Actions: {actions}", null);
+                acm.TryProcessCommand(jobContext, $"::warning::Placeholder text: This action uses Node v12 with EoL in April. It is recommended to update to v16. For more info: https://nodejs.org/en/about/releases/ Actions: {actions}", null);
             }
 
             try

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -247,13 +247,6 @@ namespace GitHub.Runner.Worker
 
                 Trace.Info($"Current state: job state = '{jobContext.Result}'");
             }
-
-            if (jobContext.JobContext.ContainsKey("Node12ActionsWarnings"))
-            {
-                var actions = string.Join(", ", jobContext.JobContext["Node12ActionsWarnings"].AssertArray("Node12ActionsWarnings").Select(action => action.ToString()));
-                var acm = HostContext.CreateService<IActionCommandManager>();
-                acm.TryProcessCommand(jobContext, $"::warning::Placeholder text: This action uses Node v12 with EoL in April. It is recommended to update to v16. Actions: {actions}", null);
-            }
         }
 
         private async Task RunStepAsync(IStep step, CancellationToken jobCancellationToken)

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -245,6 +246,13 @@ namespace GitHub.Runner.Worker
                 }
 
                 Trace.Info($"Current state: job state = '{jobContext.Result}'");
+            }
+
+            if (jobContext.JobContext.ContainsKey("Node12ActionsWarnings"))
+            {
+                var actions = string.Join(", ", jobContext.JobContext["Node12ActionsWarnings"].AssertArray("Node12ActionsWarnings").Select(action => action.ToString()));
+                var acm = HostContext.CreateService<IActionCommandManager>();
+                acm.TryProcessCommand(jobContext, "::warning::Placeholder text: Why not? This action uses Node v12 with EoL in April. It is recommended to update to v16. Actions: " + actions, null);
             }
         }
 

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -252,7 +252,7 @@ namespace GitHub.Runner.Worker
             {
                 var actions = string.Join(", ", jobContext.JobContext["Node12ActionsWarnings"].AssertArray("Node12ActionsWarnings").Select(action => action.ToString()));
                 var acm = HostContext.CreateService<IActionCommandManager>();
-                acm.TryProcessCommand(jobContext, "::warning::Placeholder text: Why not? This action uses Node v12 with EoL in April. It is recommended to update to v16. Actions: " + actions, null);
+                acm.TryProcessCommand(jobContext, $"::warning::Placeholder text: This action uses Node v12 with EoL in April. It is recommended to update to v16. Actions: {actions}", null);
             }
         }
 


### PR DESCRIPTION
We eventually plan on deprecating node 12 actions, as node12 is approaching end of life in April. This PR adds the plumbing to warn users when they run node12 actions, so that they can update their actions to node16, or update to use the latest version. When this goes live in production, it will be accompanied by a blogpost describing how to migrate in more detail, along with a transition period to update actions.

Users should be warned when running actions that use node 12 because of its end of life: https://nodejs.org/en/about/releases/
Warnings:
![image](https://user-images.githubusercontent.com/31069338/158768345-0266cccd-a485-4c75-9396-a3fff74e9ac5.png)

Long Warnings:
![image](https://user-images.githubusercontent.com/31069338/158768378-ce83e5bd-b5c3-4c5b-8b3d-b765eea808da.png)
