### PR TITLE
Issue 1739: Fixing null reference exception during configuring runner with invalid repo URL or token

### DIFF
--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -642,8 +642,9 @@ namespace GitHub.Runner.Listener.Configuration
 
                             if(response.StatusCode == System.Net.HttpStatusCode.NotFound)
                             {
-                                _term.WriteError("Invalid repository URL or register token");
-                                return StringUtil.ConvertFromJson<GitHubRunnerRegisterToken>(errorResponse);
+                                // No need to retry
+                                retryCount = 3;
+                                throw new Exception("Invalid repository URL or register token");
                             }
                             else
                             {
@@ -712,8 +713,9 @@ namespace GitHub.Runner.Listener.Configuration
 
                             if(response.StatusCode == System.Net.HttpStatusCode.NotFound)
                             {
-                                _term.WriteError("Invalid repository URL or register token");
-                                return StringUtil.ConvertFromJson<GitHubAuthResult>(errorResponse);
+                                // No need to retry
+                                retryCount = 3;
+                                throw new Exception("Invalid repository URL or register token");
                             }
                             else
                             {


### PR DESCRIPTION
The problem was that the runner crasher with null reference exception during configuring with invalid repository URL or register token.

Closes #1739

After this change, the runner will not crash with a null reference exception but will exit with an appropriate error message.