### PR TITLE
Save record order for annotation links when creating issues

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -550,10 +550,12 @@ namespace GitHub.Runner.Worker
                 issue.Message = issue.Message[.._maxIssueMessageLength];
             }
 
+            // Tracking the line number (logFileLineNumber) and step number (stepNumber) for each issue that gets created
+            // Actions UI from the run summary page use both values to easily link to an exact locations in logs where annotations originate from
+            issue.Data["stepNumber"] = _record.Order != null ? _record.Order.ToString() : "0"; 
+
             if (issue.Type == IssueType.Error)
             {
-                // tracking line number for each issue in log file
-                // log UI use this to navigate from issue to log
                 if (!string.IsNullOrEmpty(logMessage))
                 {
                     long logLineNumber = Write(WellKnownTags.Error, logMessage);
@@ -569,8 +571,6 @@ namespace GitHub.Runner.Worker
             }
             else if (issue.Type == IssueType.Warning)
             {
-                // tracking line number for each issue in log file
-                // log UI use this to navigate from issue to log
                 if (!string.IsNullOrEmpty(logMessage))
                 {
                     long logLineNumber = Write(WellKnownTags.Warning, logMessage);
@@ -586,9 +586,6 @@ namespace GitHub.Runner.Worker
             }
             else if (issue.Type == IssueType.Notice)
             {
-
-                // tracking line number for each issue in log file
-                // log UI use this to navigate from issue to log
                 if (!string.IsNullOrEmpty(logMessage))
                 {
                     long logLineNumber = Write(WellKnownTags.Notice, logMessage);


### PR DESCRIPTION
Part of https://github.com/github/c2c-actions-checks/issues/52

The end goal of this change is to be able to link annotations to exact step and log lines from the run summary page

![image](https://user-images.githubusercontent.com/16109154/157735441-8be4fda9-280a-483c-a78c-a2963d144978.png)

Right now they just point to the log page but we want to expand the exact step and scroll to the exact line that each annotation originates from when clicked on. We have the line number already via `logFileLineNumber` but we also need to save the step information

Tested this with
- Annotations from pre steps
- Annotations from post steps
- Annotations from composite actions
- Annotations from normal log lines

There was a potential problem with the timeline record order not being sequential so the numbers can go from something like `1,2,3,4,5,8,12,15` . However this is not a concern and we can reliably use the timeline record order as the step number since we have the same information saved already when we render steps in the Actions UI.