### PR TITLE
Validate packages hash before uploading to github release in CD workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,17 @@ jobs:
           console.log(releaseNote)
           core.setOutput('version', runnerVersion);
           core.setOutput('note', releaseNote);
+
+    - name: Validate Packages HASH
+      working-directory: _package
+      run: |
+        ls -l
+        echo "${{needs.build.outputs.win-x64-sha}}  actions-runner-win-x64-${{ steps.releaseNote.outputs.version }}.zip" | shasum -a 256 -c
+        echo "${{needs.build.outputs.osx-x64-sha}}  actions-runner-osx-x64-${{ steps.releaseNote.outputs.version }}.tar.gz" | shasum -a 256 -c
+        echo "${{needs.build.outputs.linux-x64-sha}}  actions-runner-linux-x64-${{ steps.releaseNote.outputs.version }}.tar.gz" | shasum -a 256 -c
+        echo "${{needs.build.outputs.linux-arm-sha}}  actions-runner-linux-arm-${{ steps.releaseNote.outputs.version }}.tar.gz" | shasum -a 256 -c
+        echo "${{needs.build.outputs.linux-arm64-sha}}  actions-runner-linux-arm64-${{ steps.releaseNote.outputs.version }}.tar.gz" | shasum -a 256 -c
+
     # Create GitHub release
     - uses: actions/create-release@master
       id: createRelease


### PR DESCRIPTION
To avoid future recurrence of https://github.com/actions/runner/issues/1719, we are going to validate the runner package checksum before uploading to GitHub releases.

More context:

The runner release is created by executing workflow `.github/workflows/release.yml`

The workflow mainly has 3 stages:
- Check 
    - some pre-release validation
- Build
    - compile and create runner packages for all platforms
    - calculate SHA256 for all created `tar.gz`/`zip`
    - upload all `tar.gz` and `zip` as workflow artifact
- Release
    - download workflow artifacts created by the `Build` stage
    - generate release note
    - **(NEW) Validate checksum of all downloaded `tar.gz` and `zip` with SHA256 from the `Build` stage**
    - create a GitHub release and upload runner packages as release assets.

If the validation failed, the release process will stop.
Ex:
<img width="1295" alt="image" src="https://user-images.githubusercontent.com/1750815/157804188-7a8c3598-3931-4b50-8d45-43ee3d0795c0.png">
