### PR TITLE
Feedstream websocket: set user agent

### DIFF
--- a/src/Runner.Common/JobServer.cs
+++ b/src/Runner.Common/JobServer.cs
@@ -2,6 +2,7 @@ using GitHub.DistributedTask.WebApi;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.WebSockets;
 using System.Text;
@@ -169,6 +170,10 @@ namespace GitHub.Runner.Common
                     Trace.Info($"Creating websocket client ..." + feedStreamUrl);
                     this._websocketClient = new ClientWebSocket();
                     this._websocketClient.Options.SetRequestHeader("Authorization", $"Bearer {accessToken}");
+                    var userAgent = HostContext.UserAgents;
+                    var userAgentStrings = userAgent.Select(x => x.ToString());
+                    this._websocketClient.Options.SetRequestHeader("User-Agent", string.Join(" ", userAgentStrings));
+
                     this._websocketConnectTask = ConnectWebSocketClient(feedStreamUrl, delay);
                 }
                 else


### PR DESCRIPTION
Part of https://github.com/github/c2c-actions-service/issues/2906

We aren't setting user agent for websocket requests. Since we don't go through `vssf` layers.

This PR will send the user agent, eventually it would be something like:

```
GitHubActionsRunner-osx-x64/2.289.2 ClientId/ac8320a3-2b5d-4224-b9ac-36aed664839b RunnerId/65 GroupId/1 CommitSHA/4145a8c2bb76a25927acd779977a4f9faa393666 
```

Is there a better way to get the user agent?