### PR TITLE
Mark run as Cancelled/Failed upon HostContext.RunnerShutdownToken state

### DIFF
--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -134,8 +134,10 @@ namespace GitHub.Runner.Worker
                             // Test the condition again. The job was cancelled after the condition was originally evaluated.
                             jobCancelRegister = jobContext.CancellationToken.Register(() =>
                             {
-                                // Mark job as cancelled
-                                jobContext.Result = TaskResult.Canceled;
+                                // Mark job as Cancelled or Failed depending on HostContext shutdown token's cancellation
+                                jobContext.Result = HostContext.RunnerShutdownToken.IsCancellationRequested
+                                                    ? TaskResult.Failed
+                                                    : TaskResult.Canceled;
                                 jobContext.JobContext.Status = jobContext.Result?.ToActionResult();
 
                                 step.ExecutionContext.Debug($"Re-evaluate condition on job cancellation for step: '{step.DisplayName}'.");
@@ -173,8 +175,10 @@ namespace GitHub.Runner.Worker
                         {
                             if (jobContext.Result != TaskResult.Canceled)
                             {
-                                // Mark job as cancelled
-                                jobContext.Result = TaskResult.Canceled;
+                                // Mark job as Cancelled or Failed depending on HostContext shutdown token's cancellation
+                                jobContext.Result = HostContext.RunnerShutdownToken.IsCancellationRequested
+                                    ? TaskResult.Failed
+                                    : TaskResult.Canceled;
                                 jobContext.JobContext.Status = jobContext.Result?.ToActionResult();
                             }
                         }


### PR DESCRIPTION
github/c2c-actions-support#883

- Currently when Actions Runner shuts down for any `ShutdownReason`, Workflow Run ends as `Cancelled`.
- `ShutdownReason.OperatingSystemShutdown` only occurs for Windows platform, and shutdown causes on other platforms are hard to detect accurately.
- **Requirement Change**
    - **✅ SAME:** User Cancellation from the GitHub UI remains the same ➡️ `TaskResult.Cancelled`.
    - **⚠️ CHANGE:** Mark Workflow Run as `TaskResult.Failed` after receiving a runner shutdown signal (**e.g.,** `SIGTERM`)
        - This `TaskResult.Failed` state can only be occur if the Runner process can report its shutdown state back to the Actions Service **successfully** before exiting.
        - I coded this behavior change by depending on the `HostContext.RunnerShutdownToken.IsCancellationRequested` when the Runner process receives a `Ctrl-C` or `Ctrl-Break` signal. It will only be able to report back to the Actions Service upon `SIGTERM` as `SIGKILL` will be immediate, and won't allow graceful shutdown.
    - If Runner process exiting due to `Ctrl-C` SIGTERM by user manually ➡️ `TaskResult.Failed`