### PR TITLE
Enable running jobs in windows docker containers

### DIFF
--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -162,6 +162,12 @@ namespace GitHub.Runner.Worker.Container
                 {
                     // Named Docker volume / host bind mount
                     volumeArg = $"-v \"{volume.SourceVolumePath.Replace("\"", "\\\"")}\":\"{volume.TargetVolumePath.Replace("\"", "\\\"")}\"";
+#if OS_WINDOWS
+                    if (!Directory.Exists(volume.SourceVolumePath))
+                    {
+                        Directory.CreateDirectory(volume.SourceVolumePath);
+                    }
+#endif
                 }
                 if (volume.ReadOnly)
                 {
@@ -333,9 +339,9 @@ namespace GitHub.Runner.Worker.Container
                 }
             };
 
-            if (!Constants.Runner.Platform.Equals(Constants.OSPlatform.Linux))
+            if (!(Constants.Runner.Platform.Equals(Constants.OSPlatform.Linux) || (Constants.Runner.Platform.Equals(Constants.OSPlatform.Windows) && Constants.Runner.PlatformArchitecture.Equals(Constants.Architecture.X64))))
             {
-                throw new NotSupportedException("Container operations are only supported on Linux runners");
+                throw new NotSupportedException("Container operations are only supported on Linux or 64 bit Windows server runners");
             }
             return await processInvoker.ExecuteAsync(
                             workingDirectory: HostContext.GetDirectory(WellKnownDirectory.Work),
@@ -395,9 +401,9 @@ namespace GitHub.Runner.Worker.Container
             processInvoker.ErrorDataReceived += stderrDataReceived;
 
 
-            if (!Constants.Runner.Platform.Equals(Constants.OSPlatform.Linux))
+            if (!(Constants.Runner.Platform.Equals(Constants.OSPlatform.Linux) || (Constants.Runner.Platform.Equals(Constants.OSPlatform.Windows) && Constants.Runner.PlatformArchitecture.Equals(Constants.Architecture.X64))))
             {
-                throw new NotSupportedException("Container operations are only supported on Linux runners");
+                throw new NotSupportedException("Container operations are only supported on Linux or 64 bit Windows server runners");
             }
             return await processInvoker.ExecuteAsync(
                 workingDirectory: context.GetGitHubContext("workspace"),
@@ -426,9 +432,9 @@ namespace GitHub.Runner.Worker.Container
                 context.Output(message.Data);
             };
 
-            if (!Constants.Runner.Platform.Equals(Constants.OSPlatform.Linux))
+            if (!(Constants.Runner.Platform.Equals(Constants.OSPlatform.Linux) || (Constants.Runner.Platform.Equals(Constants.OSPlatform.Windows) && Constants.Runner.PlatformArchitecture.Equals(Constants.Architecture.X64))))
             {
-                throw new NotSupportedException("Container operations are only supported on Linux runners");
+                throw new NotSupportedException("Container operations are only supported on Linux or 64 bit Windows server runners");
             }
             return await processInvoker.ExecuteAsync(
                 workingDirectory: workingDirectory ?? context.GetGitHubContext("workspace"),

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -35,9 +35,9 @@ namespace GitHub.Runner.Worker
         public async Task StartContainersAsync(IExecutionContext executionContext, object data)
         {
             Trace.Entering();
-            if (!Constants.Runner.Platform.Equals(Constants.OSPlatform.Linux))
+            if (!(Constants.Runner.Platform.Equals(Constants.OSPlatform.Linux) || (Constants.Runner.Platform.Equals(Constants.OSPlatform.Windows) && Constants.Runner.PlatformArchitecture.Equals(Constants.Architecture.X64))))
             {
-                throw new NotSupportedException("Container operations are only supported on Linux runners");
+                throw new NotSupportedException("Container operations are only supported on Linux or 64 bit Windows server runners");
             }
             ArgUtil.NotNull(executionContext, nameof(executionContext));
             List<ContainerInfo> containers = data as List<ContainerInfo>;
@@ -256,18 +256,33 @@ namespace GitHub.Runner.Worker
 
                 var tempHomeDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Temp), "_github_home");
                 Directory.CreateDirectory(tempHomeDirectory);
+#if OS_WINDOWS
+                container.MountVolumes.Add(new MountVolume(tempHomeDirectory, "C:\\ghhome"));
+                container.AddPathTranslateMapping(tempHomeDirectory, "C:\\ghhome");
+#else
                 container.MountVolumes.Add(new MountVolume(tempHomeDirectory, "/github/home"));
                 container.AddPathTranslateMapping(tempHomeDirectory, "/github/home");
+#endif
                 container.ContainerEnvironmentVariables["HOME"] = container.TranslateToContainerPath(tempHomeDirectory);
 
                 var tempWorkflowDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Temp), "_github_workflow");
                 Directory.CreateDirectory(tempWorkflowDirectory);
+#if OS_WINDOWS
+                container.MountVolumes.Add(new MountVolume(tempWorkflowDirectory, "C:\\ghworkflow"));
+                container.AddPathTranslateMapping(tempWorkflowDirectory, "C:\\ghworkflow");
+#else
                 container.MountVolumes.Add(new MountVolume(tempWorkflowDirectory, "/github/workflow"));
                 container.AddPathTranslateMapping(tempWorkflowDirectory, "/github/workflow");
+#endif
 
                 container.ContainerWorkDirectory = container.TranslateToContainerPath(workingDirectory);
+#if OS_WINDOWS
+                //container.ContainerEntryPoint = "ping";
+                container.ContainerEntryPointArgs = "\"ping\" \"-t\" \"localhost\"";
+#else
                 container.ContainerEntryPoint = "tail";
                 container.ContainerEntryPointArgs = "\"-f\" \"/dev/null\"";
+#endif
             }
 
             container.ContainerId = await _dockerManager.DockerCreate(executionContext, container);


### PR DESCRIPTION
Should solve #1402

This was tested with 
* Server: Windows Server 2019
* Container: `mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019` based (running MSVC 2017 build tools)