### PR TITLE
Job Started / Job Completed hooks should not use the `defaults.working-directory`

### DIFF
--- a/src/Runner.Worker/Handlers/ScriptHandler.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandler.cs
@@ -153,7 +153,8 @@ namespace GitHub.Runner.Worker.Handlers
             string workingDirectory = null;
             if (!Inputs.TryGetValue("workingDirectory", out workingDirectory))
             {
-                if (string.IsNullOrEmpty(ExecutionContext.ScopeName) && ExecutionContext.Global.JobDefaults.TryGetValue("run", out var runDefaults))
+                // Don't use job level working directories for hooks
+                if (IsActionStep && string.IsNullOrEmpty(ExecutionContext.ScopeName) && ExecutionContext.Global.JobDefaults.TryGetValue("run", out var runDefaults))
                 {
                     if (runDefaults.TryGetValue("working-directory", out workingDirectory))
                     {


### PR DESCRIPTION
Resolves #1808 