### PR TITLE
Capture telemetry when git errors on unsafe repository.

### DIFF
--- a/src/Runner.Worker/Handlers/OutputManager.cs
+++ b/src/Runner.Worker/Handlers/OutputManager.cs
@@ -151,6 +151,11 @@ namespace GitHub.Runner.Worker.Handlers
                 }
             }
 
+            if (line.Contains("fatal: unsafe repository", StringComparison.OrdinalIgnoreCase))
+            {
+                _executionContext.StepTelemetry.ErrorMessages.Add(line);
+            }
+
             // Regular output
             _executionContext.Output(line);
         }

--- a/src/Test/L0/Worker/OutputManagerL0.cs
+++ b/src/Test/L0/Worker/OutputManagerL0.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
 using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker;
 using GitHub.Runner.Worker.Container;
@@ -937,6 +937,19 @@ namespace GitHub.Runner.Common.Tests.Worker
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void CaptureTelemetryForGitUnsafeRepository()
+        {
+            using (Setup())
+            using (_outputManager)
+            {
+                Process("fatal: unsafe repository ('/github/workspace' is owned by someone else)");
+                Assert.Contains("fatal: unsafe repository ('/github/workspace' is owned by someone else)", _executionContext.Object.StepTelemetry.ErrorMessages);
+            }
+        }
+
         private TestHostContext Setup(
             [CallerMemberName] string name = "",
             IssueMatchersConfig matchers = null,
@@ -962,6 +975,8 @@ namespace GitHub.Runner.Common.Tests.Worker
                     Variables = _variables,
                     WriteDebug = true,
                 });
+            _executionContext.Setup(x => x.StepTelemetry)
+                .Returns(new DTWebApi.ActionsStepTelemetry());
             _executionContext.Setup(x => x.GetMatchers())
                 .Returns(matchers?.Matchers ?? new List<IssueMatcherConfig>());
             _executionContext.Setup(x => x.Add(It.IsAny<OnMatcherChanged>()))


### PR DESCRIPTION
A recent [Git release](https://github.blog/2022-04-12-git-security-vulnerability-announced/) has an enforcement check on the repository folder's ownership.

This may break workflow run when customers are using containers within their job that have some interaction with the local git repository (push commit, etc) since the mapped in `github_workspace` will have different owner, (root inside container and regular user on the runner machine).

We are collecting telemetry in order to provide feedback to the `git` maintainer.