### PR TITLE
Update Actions Summary limit to 1MiB

### DIFF
--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -266,7 +266,7 @@ namespace GitHub.Runner.Worker
 
     public sealed class CreateStepSummaryCommand : RunnerService, IFileCommandExtension
     {
-        private const int _attachmentSizeLimit = 1024 * 1024;
+        public const int AttachmentSizeLimit = 1024 * 1024;
 
         public string ContextName => "step_summary";
         public string FilePrefix => "step_summary_";
@@ -296,9 +296,9 @@ namespace GitHub.Runner.Worker
                     return;
                 }
 
-                if (fileSize > _attachmentSizeLimit)
+                if (fileSize > AttachmentSizeLimit)
                 {
-                    context.Error(String.Format(Constants.Runner.UnsupportedSummarySize, _attachmentSizeLimit / 1024, fileSize / 1024));
+                    context.Error(String.Format(Constants.Runner.UnsupportedSummarySize, AttachmentSizeLimit / 1024, fileSize / 1024));
                     Trace.Info($"Step Summary file ({filePath}) is too large ({fileSize} bytes); skipping attachment upload");
 
                     return;

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -15,7 +15,7 @@ namespace GitHub.Runner.Worker
     {
         void InitializeFiles(IExecutionContext context, ContainerInfo container);
         void ProcessFiles(IExecutionContext context, ContainerInfo container);
-    
+
     }
 
     public sealed class FileCommandManager : RunnerService, IFileCommandManager
@@ -57,7 +57,7 @@ namespace GitHub.Runner.Worker
                 TryDeleteFile(newPath);
                 File.Create(newPath).Dispose();
 
-                var pathToSet = container != null ? container.TranslateToContainerPath(newPath) : newPath; 
+                var pathToSet = container != null ? container.TranslateToContainerPath(newPath) : newPath;
                 context.SetGitHubContext(fileCommand.ContextName, pathToSet);
             }
         }
@@ -66,7 +66,7 @@ namespace GitHub.Runner.Worker
         {
             foreach (var fileCommand in _commandExtensions)
             {
-                try 
+                try
                 {
                     fileCommand.ProcessCommand(context, Path.Combine(_fileCommandDirectory, fileCommand.FilePrefix + _fileSuffix),container);
                 }
@@ -266,7 +266,7 @@ namespace GitHub.Runner.Worker
 
     public sealed class CreateStepSummaryCommand : RunnerService, IFileCommandExtension
     {
-        private const int _attachmentSizeLimit = 128 * 1024;
+        private const int _attachmentSizeLimit = 1024 * 1024;
 
         public string ContextName => "step_summary";
         public string FilePrefix => "step_summary_";

--- a/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
+++ b/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
@@ -33,7 +33,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             using (var hostContext = Setup(featureFlagState: "false"))
             {
                 var stepSummaryFile = Path.Combine(_rootDirectory, "feature-off");
-                
+
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
                 _jobExecutionContext.Complete();
 
@@ -117,7 +117,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             using (var hostContext = Setup())
             {
                 var stepSummaryFile = Path.Combine(_rootDirectory, "empty-file");
-                File.WriteAllBytes(stepSummaryFile, new byte[128 * 1024 + 1]);
+                File.WriteAllBytes(stepSummaryFile, new byte[CreateStepSummaryCommand.AttachmentSizeLimit + 1]);
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
                 _jobExecutionContext.Complete();


### PR DESCRIPTION
We have seen users already hit 128KiB limit in limited beta.  In order to have a better user experience, we are relaxing the limit to 1MiB per step summary.  