### PR TITLE
Make timeout for `hashFiles()` configureable

### DIFF
--- a/src/Runner.Worker/Expressions/HashFilesFunction.cs
+++ b/src/Runner.Worker/Expressions/HashFilesFunction.cs
@@ -13,7 +13,7 @@ namespace GitHub.Runner.Worker.Expressions
 {
     public sealed class HashFilesFunction : Function
     {
-        private const int _hashFileTimeoutSeconds = 120;
+        private int _hashFileTimeoutSeconds = 120;
 
         protected sealed override Object EvaluateCore(
             EvaluationContext context,


### PR DESCRIPTION
As reported here https://github.com/actions/runner/issues/1840, in scenarios where a lot of files need to be hashed to build up a cache, the process running `hashFiles()` may run into the fixed 120 second timeout and be cancelled prematurely.

This pull request introduces a new parameter `--timeout=` that is mean to be passed the same way as the already existing optional parameter `--follow-symbolic-links`.

Example configuration for actions/cache:
```
- uses: actions/cache@v3
  with:
    key: ${{ runner.os }}-${{ hashFiles('--timeout=600', '**') }}
```

## Points of discussion:
- It may be controversial to pass a parameter that affects the timeout of a process like this, as it is not *directly* related to the hashFiles() command itself, but rather to how it is run. If you see an alternative way of injecting such a parameter, please let me know.
- For this, I removed `firstParameter` and the connected logic. Instead, the logic now looks for if a parameter name starts with 
`--` and tries to match one of the two expected parameters. Please let me know if you strongly feel the logic that these parameters need to be first is needed, I will then put something in.
- There are two different exceptions thrown for when the timeout number could not be parsed (e.g. a string passed), and when it was empty. This could be made into one more generic exception to handle and explain both.