### PR TITLE
Use header of redirect instead of parsing content

### DIFF
--- a/src/Test/L0/Listener/SelfUpdaterL0.cs
+++ b/src/Test/L0/Listener/SelfUpdaterL0.cs
@@ -65,7 +65,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                     }
                     else
                     {
-                        throw new Exception("A runner version could not be parsed. Please check the redirect location of 'https://github.com/actions/runner/releases/latest'");
+                        throw new Exception("The latest runner version could not be determined so a download URL could not be generated for it. Please check the location header of the redirect response of 'https://github.com/actions/runner/releases/latest'");
                     }
                 }
             }

--- a/src/Test/L0/Listener/SelfUpdaterL0.cs
+++ b/src/Test/L0/Listener/SelfUpdaterL0.cs
@@ -65,7 +65,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                     }
                     else
                     {
-                        throw new Exception("A runner version could not be parsed. Please check the redirect location of 'https://github.com/actions/runner/releases/latest'")
+                        throw new Exception("A runner version could not be parsed. Please check the redirect location of 'https://github.com/actions/runner/releases/latest'");
                     }
                 }
             }

--- a/src/Test/L0/Listener/SelfUpdaterL0.cs
+++ b/src/Test/L0/Listener/SelfUpdaterL0.cs
@@ -50,7 +50,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://github.com/actions/runner/releases/latest"));
                 if (response.StatusCode == System.Net.HttpStatusCode.Redirect)
                 {
-                    var redirect = await response.Content.ReadAsStringAsync();
+                    var redirect = response.Headers.Location.ToString();
                     Regex regex = new Regex(@"/runner/releases/tag/v(?<version>\d+\.\d+\.\d+)");
                     var match = regex.Match(redirect);
                     if (match.Success)

--- a/src/Test/L0/Listener/SelfUpdaterL0.cs
+++ b/src/Test/L0/Listener/SelfUpdaterL0.cs
@@ -50,9 +50,9 @@ namespace GitHub.Runner.Common.Tests.Listener
                 var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://github.com/actions/runner/releases/latest"));
                 if (response.StatusCode == System.Net.HttpStatusCode.Redirect)
                 {
-                    var redirect = response.Headers.Location.ToString();
+                    var redirectUrl = response.Headers.Location.ToString();
                     Regex regex = new Regex(@"/runner/releases/tag/v(?<version>\d+\.\d+\.\d+)");
-                    var match = regex.Match(redirect);
+                    var match = regex.Match(redirectUrl);
                     if (match.Success)
                     {
                         latestVersion = match.Groups["version"].Value;
@@ -62,6 +62,10 @@ namespace GitHub.Runner.Common.Tests.Listener
 #else
                         _packageUrl = $"https://github.com/actions/runner/releases/download/v{latestVersion}/actions-runner-{BuildConstants.RunnerPackage.PackageName}-{latestVersion}.zip";
 #endif
+                    }
+                    else
+                    {
+                        throw new Exception("A runner version could not be parsed. Please check the redirect location of 'https://github.com/actions/runner/releases/latest'")
                     }
                 }
             }


### PR DESCRIPTION
https://github.com/actions/runner/actions/runs/2269618499 <--- Fixes failing update L0s 

The url on which these tests depend (`https://github.com/actions/runner/releases/latest`) returns a redirect response. 

This response used to have the redirect location in the responsebody, but that was patched out recently.

We should rely on the 'Location' HttpHeader value to get the redirect value.