### PR TITLE
Subtract 1 from logFileLineNumber annotations

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -567,7 +567,7 @@ namespace GitHub.Runner.Worker
             {
                 if (!string.IsNullOrEmpty(logMessage))
                 {
-                    long logLineNumber = Write(WellKnownTags.Error, logMessage);
+                    long logLineNumber = Write(WellKnownTags.Error, logMessage) - 1;
                     issue.Data["logFileLineNumber"] = logLineNumber.ToString();
                 }
 
@@ -582,7 +582,7 @@ namespace GitHub.Runner.Worker
             {
                 if (!string.IsNullOrEmpty(logMessage))
                 {
-                    long logLineNumber = Write(WellKnownTags.Warning, logMessage);
+                    long logLineNumber = Write(WellKnownTags.Warning, logMessage) - 1;
                     issue.Data["logFileLineNumber"] = logLineNumber.ToString();
                 }
 
@@ -597,7 +597,7 @@ namespace GitHub.Runner.Worker
             {
                 if (!string.IsNullOrEmpty(logMessage))
                 {
-                    long logLineNumber = Write(WellKnownTags.Notice, logMessage);
+                    long logLineNumber = Write(WellKnownTags.Notice, logMessage) - 1;
                     issue.Data["logFileLineNumber"] = logLineNumber.ToString();
                 }
 


### PR DESCRIPTION
For https://github.com/github/c2c-actions-checks/issues/52

When annotations are written, the `logLineNumber` is off by one because the total number of lines is returned as opposed to the actual line number the line was written to. The important line is `totalLines = _logger.TotalLines + 1;` and `return totalLines`

https://github.com/actions/runner/blob/628f462ab709492bf03b149468ef18415f9bc1bb/src/Runner.Worker/ExecutionContext.cs#L804-L824

Currently `logFileLineNumber` is not used anywhere in the backend, but once we start linking to the exact annotation position in the logs then this number needs to be correct. We could just subtract 1 in the backend or when generating links, but I figured we could do this correctly here before the feature is shipped as this is the source of the location and it should be right.

I tested this with just a simple run:

```
      - name: Run a multi-line script
        run: |
          echo ::error:: hi there
          echo ::warning:: this is a warning
```

![image](https://user-images.githubusercontent.com/16109154/168157718-70f60e8a-9f48-47d3-8230-2b312dff1b7d.png)

I added the following block:

```
                    long logLineNumber = Write(WellKnownTags.Warning, logMessage);
                    Trace.Info("Current line number is {0}", logLineNumber);
```

And I see output like this:

```
[2022-05-12 19:42:01Z VERB JobServerQueue] Enqueue web console line queue: ##[warning] this is a warning
[2022-05-12 19:42:01Z INFO ExecutionContext] Current line number is 7
```