### PR TITLE
Save original, pre-parsed string from workflow input for the user's custom volume mounts 

### DIFF
--- a/src/Runner.Worker/Container/ContainerInfo.cs
+++ b/src/Runner.Worker/Container/ContainerInfo.cs
@@ -1,16 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using GitHub.Runner.Common.Util;
 using GitHub.Runner.Common;
 using GitHub.Runner.Sdk;
 using Pipelines = GitHub.DistributedTask.Pipelines;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace GitHub.Runner.Worker.Container
 {
     public class ContainerInfo
     {
-        private IDictionary<string, string> _userMountVolumes;
         private List<MountVolume> _mountVolumes;
         private IDictionary<string, string> _userPortMappings;
         private List<PortMapping> _portMappings;
@@ -68,8 +68,7 @@ namespace GitHub.Runner.Worker.Container
             {
                 foreach (var volume in container.Volumes)
                 {
-                    UserMountVolumes[volume] = volume;
-                    MountVolumes.Add(new MountVolume(volume));
+                    MountVolumes.Add(new MountVolume(volume, true));
                 }
             }
 
@@ -104,19 +103,20 @@ namespace GitHub.Runner.Worker.Container
                 return _environmentVariables;
             }
         }
-
-        public IDictionary<string, string> UserMountVolumes
+        public ReadOnlyCollection<MountVolume> UserMountVolumes
         {
             get
             {
-                if (_userMountVolumes == null)
-                {
-                    _userMountVolumes = new Dictionary<string, string>();
-                }
-                return _userMountVolumes;
+                return MountVolumes.Where(v => !string.IsNullOrEmpty(v.UserProvidedValue)).ToList().AsReadOnly();
             }
         }
-
+        public ReadOnlyCollection<MountVolume> SystemMountVolumes
+        {
+            get
+            {
+                return MountVolumes.Where(v => string.IsNullOrEmpty(v.UserProvidedValue)).ToList().AsReadOnly();
+            }
+        }
         public List<MountVolume> MountVolumes
         {
             get
@@ -260,16 +260,25 @@ namespace GitHub.Runner.Worker.Container
 
     public class MountVolume
     {
+        public string UserProvidedValue { get; set; }
         public MountVolume(string sourceVolumePath, string targetVolumePath, bool readOnly = false)
         {
             this.SourceVolumePath = sourceVolumePath;
             this.TargetVolumePath = targetVolumePath;
             this.ReadOnly = readOnly;
         }
-
         public MountVolume(string fromString)
         {
             ParseVolumeString(fromString);
+        }
+
+        public MountVolume(string fromString, bool isUserProvided)
+        {
+            ParseVolumeString(fromString);
+            if (isUserProvided)
+            {
+                UserProvidedValue = fromString;
+            }
         }
 
         private void ParseVolumeString(string volume)

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -192,13 +192,12 @@ namespace GitHub.Runner.Worker
             {
                 Trace.Info($"User provided port: {port.Value}");
             }
-            foreach (var volume in container.UserMountVolumes)
+            foreach (var mount in container.MountVolumes.Where(v => !string.IsNullOrEmpty(v.UserProvidedValue)))
             {
-                Trace.Info($"User provided volume: {volume.Value}");
-                var mount = new MountVolume(volume.Value);
+                Trace.Info($"User provided volume: {mount.UserProvidedValue}");
                 if (string.Equals(mount.SourceVolumePath, "/", StringComparison.OrdinalIgnoreCase))
                 {
-                    executionContext.Warning($"Volume mount {volume.Value} is going to mount '/' into the container which may cause file ownership change in the entire file system and cause Actions Runner to lose permission to access the disk.");
+                    executionContext.Warning($"Volume mount {mount.UserProvidedValue} is going to mount '/' into the container which may cause file ownership change in the entire file system and cause Actions Runner to lose permission to access the disk.");
                 }
             }
 


### PR DESCRIPTION
We can later use this original, pre-parsed string for logging and to separate mountvolumes coming from the user vs runner defaults.