### PR TITLE
Increase maximal issue count from 10 to 100

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -114,7 +114,7 @@ namespace GitHub.Runner.Worker
 
     public sealed class ExecutionContext : RunnerService, IExecutionContext
     {
-        private const int _maxIssueCount = 10;
+        private const int _maxIssueCount = 100;
         private const int _throttlingDelayReportThreshold = 10 * 1000; // Don't report throttling with less than 10 seconds delay
         private const int _maxIssueMessageLength = 4096; // Don't send issue with huge message since we can't forward them from actions to check annotation.
         private const int _maxIssueCountInTelemetry = 3; // Only send the first 3 issues to telemetry


### PR DESCRIPTION
In my opinion, the [problem matcher](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) is an underrated feature (e.g. not documented [here](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions)) that is currently limited by the number of issues that are reported. This change removes this limitation and will thus greatly improve the problem matcher feature.