### PR TITLE
Support pass runner JitConfig as arg.

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -90,6 +90,7 @@ namespace GitHub.Runner.Common
                 public static class Args
                 {
                     public static readonly string Auth = "auth";
+                    public static readonly string JitConfig = "jitconfig";
                     public static readonly string Labels = "labels";
                     public static readonly string MonitorSocketAddress = "monitorsocketaddress";
                     public static readonly string Name = "name";

--- a/src/Runner.Listener/CommandSettings.cs
+++ b/src/Runner.Listener/CommandSettings.cs
@@ -39,6 +39,7 @@ namespace GitHub.Runner.Listener
                     Constants.Runner.CommandLine.Flags.RunAsService,
                     Constants.Runner.CommandLine.Flags.Unattended,
                     Constants.Runner.CommandLine.Args.Auth,
+                    Constants.Runner.CommandLine.Args.JitConfig,
                     Constants.Runner.CommandLine.Args.Labels,
                     Constants.Runner.CommandLine.Args.MonitorSocketAddress,
                     Constants.Runner.CommandLine.Args.Name,
@@ -211,6 +212,12 @@ namespace GitHub.Runner.Listener
                 description: "How would you like to authenticate?",
                 defaultValue: defaultValue,
                 validator: Validators.AuthSchemeValidator);
+        }
+
+        public string GetJitConfig()
+        {
+            return GetArg(
+                name: Constants.Runner.CommandLine.Args.JitConfig);
         }
 
         public string GetRunnerName()


### PR DESCRIPTION
Allow runner starts with a jitconfig base64 string.

Ex: `./run.sh --jitconfig eyIucnVubmVyIjoiZXlKQloyVnVkRWxrSWpvaU15SXNJa0ZuWlc1MFRtRnRaU0k2SWpFNE9XRTVOamt6TFRnNFlUZ3ROR013WXkxaVkyVTFMVE15WlRVMk16Z3pabVZoTkNJc0lsQnZiMnhKWkNJNklqRWlMQ0pRYjI5c1RtRnRaU0k2Ym5Wc2JDd2lVMlZ5ZG1WeVZYSnNJam9p......`