### PR TITLE
add job_name to github context

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -741,6 +741,7 @@ namespace GitHub.Runner.Worker
             {
                 githubContext["job"] = new StringContextData(githubJob);
             }
+            githubContext["job_name"] = new StringContextData(message.JobDisplayName);
             var githubDictionary = ExpressionValues["github"].AssertDictionary("github");
             foreach (var pair in githubDictionary)
             {

--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -21,6 +21,7 @@ namespace GitHub.Runner.Worker
             "graphql_url",
             "head_ref",
             "job",
+            "job_name",
             "path",
             "ref_name",
             "ref_protected",

--- a/src/Test/L0/Worker/ExecutionContextL0.cs
+++ b/src/Test/L0/Worker/ExecutionContextL0.cs
@@ -776,6 +776,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 inputGithubContext["run_id"] = new StringContextData("2033211332");
                 inputGithubContext["workflow"] = new StringContextData("Name of Workflow");
                 inputGithubContext["workspace"] = new StringContextData("/home/username/Projects/work/runner/_layout/_work/step-order/step-order");
+                inputGithubContext["job_name"] = new StringContextData("Name of Job");
                 inputeRunnerContext["temp"] = new StringContextData("/home/username/Projects/work/runner/_layout/_work/_temp");
                 inputeRunnerContext["tool_cache"] = new StringContextData("/home/username/Projects/work/runner/_layout/_work/_tool");
 
@@ -814,6 +815,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 expectedGithubContext["workflow"] = new StringContextData("Name of Workflow");
                 expectedGithubContext["workspace"] = new StringContextData("/__w/step-order/step-order");
                 expectedGithubContext["event"] = expectedGithubEvent;
+                expectedGithubContext["job_name"] = new StringContextData("Name of Job");
                 expectedRunnerContext["temp"] = new StringContextData("/__w/_temp");
                 expectedRunnerContext["tool_cache"] = new StringContextData("/__w/_tool");
 


### PR DESCRIPTION
this is for the context https://github.community/t/get-current-job-name-within-the-workflow/255214

`message.JobDisplayName` will contain `jobs.<job_id>.name` if present otherwise `jobs.<job_id>`