### PR TITLE
Revert bash and sh `-e` filePath escape

### DIFF
--- a/src/Runner.Worker/Handlers/ScriptHandlerHelpers.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandlerHelpers.cs
@@ -13,8 +13,8 @@ namespace GitHub.Runner.Worker.Handlers
             ["cmd"] = "/D /E:ON /V:OFF /S /C \"CALL \"{0}\"\"",
             ["pwsh"] = "-command \". '{0}'\"",
             ["powershell"] = "-command \". '{0}'\"",
-            ["bash"] = "--noprofile --norc -e -o pipefail '{0}'",
-            ["sh"] = "-e '{0}'",
+            ["bash"] = "--noprofile --norc -e -o pipefail {0}",
+            ["sh"] = "-e {0}",
             ["python"] = "{0}"
         };
 


### PR DESCRIPTION
It generated invalid arguments for `System.Diagnostic.Process` when the `bash` command itself was an argument as well, for example:

```
_proc.StartInfo.FileName = "/usr/bin/docker";
_proc.StartInfo.Arguments = "exec -i --workdir /__w/container-hook-e2e/container-hook-e2e 47105c66144d8809d9fa2bce9a58ea0564cd14def0ae7952cd6231fba3576db1 sh -e '/__w/_temp/fd086560-cb92-4f3b-a99c-35a6b7b1bbdb.sh'";
```

`sh` here would look for a literal path containing a single quote, which doesn't exist.

