### PR TITLE
Remove job summary feature flag

### DIFF
--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -275,12 +275,6 @@ namespace GitHub.Runner.Worker
 
         public void ProcessCommand(IExecutionContext context, string filePath, ContainerInfo container)
         {
-            if (!context.Global.Variables.GetBoolean("DistributedTask.UploadStepSummary") ?? true)
-            {
-                Trace.Info("Step Summary is disabled; skipping attachment upload");
-                return;
-            }
-
             if (String.IsNullOrEmpty(filePath) || !File.Exists(filePath))
             {
                 Trace.Info($"Step Summary file ({filePath}) does not exist; skipping attachment upload");

--- a/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
+++ b/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
@@ -28,23 +28,6 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public void CreateStepSummaryCommand_FeatureDisabled()
-        {
-            using (var hostContext = Setup(featureFlagState: "false"))
-            {
-                var stepSummaryFile = Path.Combine(_rootDirectory, "feature-off");
-
-                _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
-                _jobExecutionContext.Complete();
-
-                _jobServerQueue.Verify(x => x.QueueFileUpload(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never());
-                Assert.Equal(0, _issues.Count);
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Worker")]
         public void CreateStepSummaryCommand_FileNull()
         {
             using (var hostContext = Setup())
@@ -199,7 +182,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             File.WriteAllText(path, contentStr, encoding);
         }
 
-        private TestHostContext Setup([CallerMemberName] string name = "", string featureFlagState = "true")
+        private TestHostContext Setup([CallerMemberName] string name = "")
         {
             var hostContext = new TestHostContext(this, name);
 
@@ -241,7 +224,6 @@ namespace GitHub.Runner.Common.Tests.Worker
             _variables = new Variables(hostContext, new Dictionary<string, VariableValue>
                 {
                     { "MySecretName", new VariableValue("My secret value", true) },
-                    { "DistributedTask.UploadStepSummary", featureFlagState },
                 });
 
             // Directory for test data


### PR DESCRIPTION
Part of: https://github.com/github/c2c-actions-checks/issues/547

Since we shipped job summaries, let's remove the FF from the runner so GHES customers can also get the feature.