### PR TITLE
Add retry logic around getting job messages from broker

### DIFF
--- a/src/Runner.Common/RunServer.cs
+++ b/src/Runner.Common/RunServer.cs
@@ -98,7 +98,7 @@ namespace GitHub.Runner.Common
                     if (currentRetryAttempt < maxRetryAttempts)
                     {
                         var backOff = BackoffTimerHelper.GetRandomBackoff(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15));
-                        Trace.Warning($"Back off {backOff.TotalSeconds} seconds before retry.");
+                        Trace.Warning($"Back off {backOff.TotalSeconds} seconds before next retry. {maxRetryAttempts - currentRetryAttempt} attempt left.");
                         currentRetryAttempt++;
                         await Task.Delay(backOff, cancellationToken);
                     }

--- a/src/Runner.Common/RunServer.cs
+++ b/src/Runner.Common/RunServer.cs
@@ -83,7 +83,7 @@ namespace GitHub.Runner.Common
                                                         )
         {
             var retryCount = 0;
-            while (retryCount < maxRetryAttemptsCount)
+            do
             {
                 retryCount++;
                 cancellationToken.ThrowIfCancellationRequested();
@@ -99,7 +99,7 @@ namespace GitHub.Runner.Common
                     Trace.Warning($"Back off {backOff.TotalSeconds} seconds before next retry. {maxRetryAttemptsCount - retryCount} attempt left.");
                     await Task.Delay(backOff, cancellationToken);
                 }
-            }
+            } while (retryCount < maxRetryAttemptsCount);
             
             Trace.Error("Code should be unreachable.");
             return default;

--- a/src/Runner.Common/RunServer.cs
+++ b/src/Runner.Common/RunServer.cs
@@ -78,12 +78,12 @@ namespace GitHub.Runner.Common
         }
 
         private async Task<T> RetryRequest<T>(Func<Task<T>> func,
-                                                        CancellationToken cancellationToken,
-                                                        int maxRetryAttemptsCount = 5
-                                                        )
+                                              CancellationToken cancellationToken,
+                                              int maxRetryAttemptsCount = 5
+                                             )
         {
             var retryCount = 0;
-            do
+            while (true)
             {
                 retryCount++;
                 cancellationToken.ThrowIfCancellationRequested();
@@ -99,10 +99,7 @@ namespace GitHub.Runner.Common
                     Trace.Warning($"Back off {backOff.TotalSeconds} seconds before next retry. {maxRetryAttemptsCount - retryCount} attempt left.");
                     await Task.Delay(backOff, cancellationToken);
                 }
-            } while (retryCount < maxRetryAttemptsCount);
-            
-            Trace.Error("Code should be unreachable.");
-            return default;
+            }
         }
     }
 }

--- a/src/Runner.Common/RunServer.cs
+++ b/src/Runner.Common/RunServer.cs
@@ -91,6 +91,7 @@ namespace GitHub.Runner.Common
                 {
                     return await func();
                 }
+                // TODO: Add handling of non-retriable exceptions: https://github.com/github/actions-broker/issues/122
                 catch (Exception ex) when (retryCount < maxRetryAttemptsCount)
                 {
                     Trace.Error("Catch exception during get full job message");

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -476,7 +476,7 @@ namespace GitHub.Runner.Listener
 
                                     var runServer = HostContext.CreateService<IRunServer>();
                                     await runServer.ConnectAsync(new Uri(settings.ServerUrl), creds);
-                                    var jobMessage = await runServer.GetJobMessageAsync(messageRef.RunnerRequestId, HostContext.RunnerShutdownToken);
+                                    var jobMessage = await runServer.GetJobMessageAsync(messageRef.RunnerRequestId, messageQueueLoopTokenSource.Token);
 
                                     jobDispatcher.Run(jobMessage, runOnce);
                                     if (runOnce)

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -476,7 +476,7 @@ namespace GitHub.Runner.Listener
 
                                     var runServer = HostContext.CreateService<IRunServer>();
                                     await runServer.ConnectAsync(new Uri(settings.ServerUrl), creds);
-                                    var jobMessage = await runServer.GetJobMessageAsync(messageRef.RunnerRequestId);
+                                    var jobMessage = await runServer.GetJobMessageAsync(messageRef.RunnerRequestId, HostContext.RunnerShutdownToken);
 
                                     jobDispatcher.Run(jobMessage, runOnce);
                                     if (runOnce)

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -475,7 +475,6 @@ namespace GitHub.Runner.Listener
                                     var credMgr = HostContext.GetService<ICredentialManager>();
                                     var creds = credMgr.LoadCredentials();
 
-                                    // todo: add retries https://github.com/github/actions-broker/issues/49
                                     var runServer = HostContext.CreateService<IRunServer>();
                                     await runServer.ConnectAsync(new Uri(settings.ServerUrl), creds);
                                     Pipelines.AgentJobRequestMessage jobMessage = null;

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -11,7 +11,6 @@ using GitHub.Runner.Common;
 using GitHub.Runner.Listener.Check;
 using GitHub.Runner.Listener.Configuration;
 using GitHub.Runner.Sdk;
-using GitHub.Services.Common;
 using GitHub.Services.WebApi;
 using Pipelines = GitHub.DistributedTask.Pipelines;
 

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -477,35 +477,7 @@ namespace GitHub.Runner.Listener
 
                                     var runServer = HostContext.CreateService<IRunServer>();
                                     await runServer.ConnectAsync(new Uri(settings.ServerUrl), creds);
-                                    Pipelines.AgentJobRequestMessage jobMessage = null;
-
-                                    var remainingRetryLimitTime = TimeSpan.FromMinutes(5);
-                                    while (true)
-                                    {
-                                        try
-                                        {
-                                            jobMessage = await runServer.GetJobMessageAsync(messageRef.RunnerRequestId);
-                                            break;
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            Trace.Error("Catch exception during get full job message");
-                                            Trace.Error(ex);
-
-                                            if (remainingRetryLimitTime > TimeSpan.Zero)
-                                            {
-                                                var backOff = BackoffTimerHelper.GetRandomBackoff(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15));
-                                                Trace.Warning($"Back off {backOff.TotalSeconds} seconds before retry.");
-                                                remainingRetryLimitTime -= backOff;
-                                                await Task.Delay(backOff);
-                                            }
-                                            else
-                                            {
-                                                Trace.Info("Retry time limit exceeded. Abandoning getting message");
-                                                throw;
-                                            }
-                                        }
-                                    }
+                                    var jobMessage = await runServer.GetJobMessageAsync(messageRef.RunnerRequestId);
 
                                     jobDispatcher.Run(jobMessage, runOnce);
                                     if (runOnce)


### PR DESCRIPTION
Add retry logic for Broker flow aroung getting messages.
Retries are executed for ~5 minuts and then abandoned.
Issue: https://github.com/github/actions-broker/issues/49