### PR TITLE
Update dependencies list to support Ubuntu 22.04

### DIFF
--- a/docs/start/envlinux.md
+++ b/docs/start/envlinux.md
@@ -34,7 +34,7 @@ The `installdependencies.sh` script should install all required dependencies on 
 
 Debian based OS (Debian, Ubuntu, Linux Mint)
 
-- liblttng-ust0
+- liblttng-ust1 or liblttng-ust0
 - libkrb5-3
 - zlib1g
 - libssl1.1, libssl1.0.2 or libssl1.0.0

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -66,7 +66,7 @@ then
             fi
         fi
 
-        $apt_get update && $apt_get install -y liblttng-ust0 libkrb5-3 zlib1g
+        $apt_get update && $apt_get install -y libkrb5-3 zlib1g
         if [ $? -ne 0 ]
         then
             echo "'$apt_get' failed with exit code '$?'"
@@ -93,6 +93,14 @@ then
                 fi
             fi
         }
+
+        apt_get_with_fallbacks liblttng-ust1 liblttng-ust0
+        if [ $? -ne 0 ]
+        then
+            echo "'$apt_get' failed with exit code '$?'"
+            print_errormessage
+            exit 1
+        fi
 
         apt_get_with_fallbacks libssl1.1$ libssl1.0.2$ libssl1.0.0$
         if [ $? -ne 0 ]


### PR DESCRIPTION
Fixes problem mentioned in 
- https://github.com/actions/runner/pull/1585
- https://github.com/actions/runner/issues/1584
- https://github.com/actions/runner/issues/1941

using already supported method (apt_get_with_fallbacks -function)