### PR TITLE
No longer trace 'ex' twice, only further up in the callstack.

### DIFF
--- a/src/Runner.Worker/Container/ContainerHooks/ContainerHookManager.cs
+++ b/src/Runner.Worker/Container/ContainerHooks/ContainerHookManager.cs
@@ -174,8 +174,7 @@ namespace GitHub.Runner.Worker.Container.ContainerHooks
             }
             catch (Exception ex)
             {
-                Trace.Error(ex);
-                throw new Exception($"Custom container implementation failed with error: {ex.Message} Please contact your self hosted runner administrator.", ex);
+                throw new Exception($"Executing the custom container implementation failed. Please contact your self hosted runner administrator.", ex);
             }
         }
 


### PR DESCRIPTION
Running `exit 122` via bash:

Hook exception: ![image](https://user-images.githubusercontent.com/31069338/174090125-52058ecc-3ab0-4a2a-94fa-7d9b72abe056.png)

Docker (runner-native) exception: 
![image](https://user-images.githubusercontent.com/31069338/174090234-d993fa9e-1d0e-4fe5-b944-1067aeeb81c0.png)

