### PR TITLE
Added configurable SkipTempDirectoryCleanup to improve ephemeral runner cleanup performance

### DIFF
--- a/src/Runner.Common/ConfigurationStore.cs
+++ b/src/Runner.Common/ConfigurationStore.cs
@@ -51,6 +51,9 @@ namespace GitHub.Runner.Common
         [DataMember(EmitDefaultValue = false)]
         public string MonitorSocketAddress { get; set; }
 
+        [DataMember(EmitDefaultValue = false)]
+        public bool SkipTempDirectoryCleanup { get; set; }
+
         [IgnoreDataMember]
         public bool IsHostedServer
         {


### PR DESCRIPTION
As discussed in #1929, scenarios when runner is ephemeral I added `SkipTempDirectoryCleanup` to `RunnerSettings` to allow operators to avoid having to delete the temp directory, leaving the cleanup to the underlying host after ephemeral runner tears down (as is often the case with containerized runners).