### PR TITLE
Change the auth challenge 401 to be verbose trace.

### DIFF
--- a/src/Sdk/Common/Common/Diagnostics/VssHttpEventSource.cs
+++ b/src/Sdk/Common/Common/Diagnostics/VssHttpEventSource.cs
@@ -352,6 +352,18 @@ namespace GitHub.Services.Common.Diagnostics
         }
 
         [NonEvent]
+        public void AuthenticationFailedOnFirstRequest(
+            VssTraceActivity activity,
+            HttpResponseMessage response)
+        {
+            if (IsEnabled())
+            {
+                SetActivityId(activity);
+                WriteMessageEvent((Int32)response.StatusCode, response.Headers.ToString(), this.AuthenticationFailedOnFirstRequest);
+            }
+        }
+
+        [NonEvent]
         public void IssuedTokenProviderCreated(
             VssTraceActivity activity,
             IssuedTokenProvider provider)
@@ -451,7 +463,7 @@ namespace GitHub.Services.Common.Diagnostics
         [NonEvent]
         public void IssuedTokenInvalidated(
             VssTraceActivity activity,
-            IssuedTokenProvider provider, 
+            IssuedTokenProvider provider,
             IssuedToken token)
         {
             if (IsEnabled())
@@ -813,7 +825,7 @@ namespace GitHub.Services.Common.Diagnostics
         [Event(31, Keywords = Keywords.Authentication, Level = EventLevel.Warning, Task = Tasks.Authentication, Opcode = EventOpcode.Info, Message = "Retrieving an AAD auth token took a long time ({0} seconds)")]
         public void AuthorizationDelayed(string timespan)
         {
-            if(IsEnabled(EventLevel.Warning, Keywords.Authentication))
+            if (IsEnabled(EventLevel.Warning, Keywords.Authentication))
             {
                 WriteEvent(31, timespan);
             }
@@ -825,6 +837,17 @@ namespace GitHub.Services.Common.Diagnostics
             if (IsEnabled(EventLevel.Informational, Keywords.Authentication))
             {
                 WriteEvent(32, aadCorrelationId);
+            }
+        }
+
+        [Event(33, Keywords = Keywords.Authentication, Level = EventLevel.Verbose, Task = Tasks.HttpRequest, Message = "Authentication failed on first request with status code {0}.%n{1}")]
+        private void AuthenticationFailedOnFirstRequest(
+            Int32 statusCode,
+            String headers)
+        {
+            if (IsEnabled(EventLevel.Verbose, Keywords.Authentication))
+            {
+                WriteEvent(33, statusCode, headers);
             }
         }
 

--- a/src/Sdk/Common/Common/VssHttpMessageHandler.cs
+++ b/src/Sdk/Common/Common/VssHttpMessageHandler.cs
@@ -251,7 +251,14 @@ namespace GitHub.Services.Common
 
                         // Invalidate the token and ensure that we have the correct token provider for the challenge
                         // which we just received
-                        VssHttpEventSource.Log.AuthenticationFailed(traceActivity, response);
+                        if (retries < m_maxAuthRetries)
+                        {
+                            VssHttpEventSource.Log.AuthenticationFailed(traceActivity, response);
+                        }
+                        else
+                        {
+                            VssHttpEventSource.Log.AuthenticationFailedOnFirstRequest(traceActivity, response);
+                        }
 
                         if (provider != null)
                         {


### PR DESCRIPTION
When the runner's OAuth token expired and needs a refresh, we log the following warning to the runner diag log.

```
[2022-07-25 17:34:28Z WARN GitHubActionsService] Authentication failed on first request with status code 401.
WWW-Authenticate: Bearer
Strict-Transport-Security: max-age=2592000
X-TFS-ProcessId: 994a3e77-7bca-4c4c-81e7-e72c37958c93
ActivityId: 74581e5a-cc7c-44c1-b42b-16ffab259bae
X-TFS-Session: 3865f3e2-07e8-4776-9ab5-bf3879b101be
X-VSS-E2EID: ccfcd2f9-2720-4519-a1e9-36405a46c125
X-VSS-SenderDeploymentId: 6bfa0b85-0342-b826-1c9f-bc636d8425af
X-TFS-ServiceError: The+user+%27System%3aPublicAccess%3baaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa%27+is+not+authorized+to+access+this+resource.
X-VSS-S2STargetService: 0000005A-0000-8888-8000-000000000000/visualstudio.com
X-Cache: CONFIG_NOCACHE
X-MSEdge-Ref: Ref A: CB6CE181CB5F4B41ACF055B51FB17F6C Ref B: ASHEDGE1308 Ref C: 2022-07-25T17:34:28Z
Date: Mon, 25 Jul 2022 17:34:28 GMT
Transfer-Encoding: chunked
```

This is not helpful to our customers other than creating confusion to make them think the runner is experiencing auth issue.

I am moving the particular trace into `verbose` from `warning` to avoid confusion.