### PR TITLE
Display full job name and nested workflow details in log

### DIFF
--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -318,12 +318,13 @@ namespace GitHub.Runner.Worker
 
                     if (message.Variables.TryGetValue("system.workflowFileFullPath", out VariableValue workflowFileFullPath))
                     {
-                        context.Output($"uses: {workflowFileFullPath.Value}");
-                        var inputs = message.ContextData["inputs"].AssertDictionary("inputs");
-                        if (inputs.Any()) {
-                            context.Output("with:");
-                            foreach(var input in inputs) {
-                                context.Output($"  {input.Key}: {input.Value}");
+                        if (message.ContextData.TryGetValue("inputs", out var pipelineContextData)) {
+                            var inputs = pipelineContextData.AssertDictionary("inputs");
+                            if (inputs.Any()) {
+                                context.Output("with:");
+                                foreach(var input in inputs) {
+                                    context.Output($"  {input.Key}: {input.Value}");
+                                }
                             }
                         }
                         

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -324,7 +324,6 @@ namespace GitHub.Runner.Worker
                             var inputs = pipelineContextData.AssertDictionary("inputs");
                             if (inputs.Any()) {
                                 context.Output($"##[group] inputs");
-                                context.Output("with:");
                                 foreach(var input in inputs) {
                                     context.Output($"  {input.Key}: {input.Value}");
                                 }

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -316,8 +316,9 @@ namespace GitHub.Runner.Worker
                         }
                     }
 
-                    if (!string.IsNullOrWhiteSpace(message.DataWorkflowFilePathRaw)) {
-                        context.Output($"uses: {message.DataWorkflowFilePathRaw}");
+                    if (message.Variables.TryGetValue("system.workflowFileFullPath", out VariableValue workflowFileFullPath))
+                    {
+                        context.Output($"uses: {workflowFileFullPath.Value}");
                         var inputs = message.ContextData["inputs"].AssertDictionary("inputs");
                         if (inputs.Any()) {
                             context.Output("with:");

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -322,16 +322,19 @@ namespace GitHub.Runner.Worker
                         if (message.ContextData.TryGetValue("inputs", out var pipelineContextData))
                         {
                             var inputs = pipelineContextData.AssertDictionary("inputs");
-                            if (inputs.Any()) {
+                            if (inputs.Any()) 
+                            {
                                 context.Output($"##[group] inputs");
-                                foreach(var input in inputs) {
+                                foreach(var input in inputs) 
+                                {
                                     context.Output($"  {input.Key}: {input.Value}");
                                 }
                                 context.Output("##[endgroup]");
                             }
                         }
 
-                        if (!string.IsNullOrWhiteSpace(message.JobDisplayName)) {
+                        if (!string.IsNullOrWhiteSpace(message.JobDisplayName)) 
+                        {
                             context.Output($"Complete job name: {message.JobDisplayName}");
                         }
                     }

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -326,10 +326,10 @@ namespace GitHub.Runner.Worker
                                 context.Output($"  {input.Key}: {input.Value}");
                             }
                         }
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(message.JobDisplayName)) {
-                        context.Output($"Complete job name: {message.JobDisplayName}");
+                        
+                        if (!string.IsNullOrWhiteSpace(message.JobDisplayName)) {
+                            context.Output($"Complete job name: {message.JobDisplayName}");
+                        }
                     }
 
                     var intraActionStates = new Dictionary<Guid, Dictionary<string, string>>();

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -316,6 +316,21 @@ namespace GitHub.Runner.Worker
                         }
                     }
 
+                    if (!string.IsNullOrWhiteSpace(message.DataWorkflowFilePathRaw)) {
+                        context.Output($"uses: {message.DataWorkflowFilePathRaw}");
+                        var inputs = message.ContextData["inputs"].AssertDictionary("inputs");
+                        if (inputs.Any()) {
+                            context.Output("with:");
+                            foreach(var input in inputs) {
+                                context.Output($"  {input.Key}: {input.Value}");
+                            }
+                        }
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(message.JobDisplayName)) {
+                        context.Output($"Complete job name: {message.JobDisplayName}");
+                    }
+
                     var intraActionStates = new Dictionary<Guid, Dictionary<string, string>>();
                     foreach (var preStep in prepareResult.PreStepTracker)
                     {

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -331,7 +331,7 @@ namespace GitHub.Runner.Worker
                             }
                         }
 
-                         if (!string.IsNullOrWhiteSpace(message.JobDisplayName)) {
+                        if (!string.IsNullOrWhiteSpace(message.JobDisplayName)) {
                             context.Output($"Complete job name: {message.JobDisplayName}");
                         }
                     }

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -318,17 +318,20 @@ namespace GitHub.Runner.Worker
 
                     if (message.Variables.TryGetValue("system.workflowFileFullPath", out VariableValue workflowFileFullPath))
                     {
+                        context.Output($"uses: {workflowFileFullPath.Value}");
                         if (message.ContextData.TryGetValue("inputs", out var pipelineContextData)) {
                             var inputs = pipelineContextData.AssertDictionary("inputs");
                             if (inputs.Any()) {
+                                context.Output($"##[group] inputs");
                                 context.Output("with:");
                                 foreach(var input in inputs) {
                                     context.Output($"  {input.Key}: {input.Value}");
                                 }
+                                context.Output("##[endgroup]");
                             }
                         }
-                        
-                        if (!string.IsNullOrWhiteSpace(message.JobDisplayName)) {
+
+                         if (!string.IsNullOrWhiteSpace(message.JobDisplayName)) {
                             context.Output($"Complete job name: {message.JobDisplayName}");
                         }
                     }

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -318,7 +318,7 @@ namespace GitHub.Runner.Worker
 
                     if (message.Variables.TryGetValue("system.workflowFileFullPath", out VariableValue workflowFileFullPath))
                     {
-                        context.Output($"uses: {workflowFileFullPath.Value}");
+                        context.Output($"Uses: {workflowFileFullPath.Value}");
                         if (message.ContextData.TryGetValue("inputs", out var pipelineContextData))
                         {
                             var inputs = pipelineContextData.AssertDictionary("inputs");

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -325,7 +325,7 @@ namespace GitHub.Runner.Worker
                             if (inputs.Any()) 
                             {
                                 context.Output($"##[group] inputs");
-                                foreach(var input in inputs) 
+                                foreach (var input in inputs) 
                                 {
                                     context.Output($"  {input.Key}: {input.Value}");
                                 }

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -319,7 +319,8 @@ namespace GitHub.Runner.Worker
                     if (message.Variables.TryGetValue("system.workflowFileFullPath", out VariableValue workflowFileFullPath))
                     {
                         context.Output($"uses: {workflowFileFullPath.Value}");
-                        if (message.ContextData.TryGetValue("inputs", out var pipelineContextData)) {
+                        if (message.ContextData.TryGetValue("inputs", out var pipelineContextData))
+                        {
                             var inputs = pipelineContextData.AssertDictionary("inputs");
                             if (inputs.Any()) {
                                 context.Output($"##[group] inputs");

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -324,7 +324,7 @@ namespace GitHub.Runner.Worker
                             var inputs = pipelineContextData.AssertDictionary("inputs");
                             if (inputs.Any()) 
                             {
-                                context.Output($"##[group] inputs");
+                                context.Output($"##[group] Inputs");
                                 foreach (var input in inputs) 
                                 {
                                     context.Output($"  {input.Key}: {input.Value}");

--- a/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
+++ b/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
@@ -184,13 +184,6 @@ namespace GitHub.DistributedTask.Pipelines
             private set;
         }
 
-        [DataMember(EmitDefaultValue = false)]
-        public string DataWorkflowFilePathRaw
-        {
-            get;
-            private set;
-        }
-
         /// <summary>
         /// Gets the collection of mask hints
         /// </summary>

--- a/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
+++ b/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
@@ -42,8 +42,7 @@ namespace GitHub.DistributedTask.Pipelines
             IList<String> fileTable,
             TemplateToken jobOutputs,
             IList<TemplateToken> defaults,
-            ActionsEnvironmentReference actionsEnvironment,
-            string dataWorkflowFilePathRaw)
+            ActionsEnvironmentReference actionsEnvironment)
         {
             this.MessageType = JobRequestMessageTypes.PipelineAgentJobRequest;
             this.Plan = plan;
@@ -57,7 +56,6 @@ namespace GitHub.DistributedTask.Pipelines
             this.Workspace = workspaceOptions;
             this.JobOutputs = jobOutputs;
             this.ActionsEnvironment = actionsEnvironment;
-            this.DataWorkflowFilePathRaw = dataWorkflowFilePathRaw;
             m_variables = new Dictionary<String, VariableValue>(variables, StringComparer.OrdinalIgnoreCase);
             m_maskHints = new List<MaskHint>(maskHints);
             m_steps = new List<JobStep>(steps);

--- a/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
+++ b/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
@@ -42,7 +42,8 @@ namespace GitHub.DistributedTask.Pipelines
             IList<String> fileTable,
             TemplateToken jobOutputs,
             IList<TemplateToken> defaults,
-            ActionsEnvironmentReference actionsEnvironment)
+            ActionsEnvironmentReference actionsEnvironment
+            string dataWorkflowFilePathRaw)
         {
             this.MessageType = JobRequestMessageTypes.PipelineAgentJobRequest;
             this.Plan = plan;
@@ -56,6 +57,7 @@ namespace GitHub.DistributedTask.Pipelines
             this.Workspace = workspaceOptions;
             this.JobOutputs = jobOutputs;
             this.ActionsEnvironment = actionsEnvironment;
+            this.DataWorkflowFilePathRaw = dataWorkflowFilePathRaw;
             m_variables = new Dictionary<String, VariableValue>(variables, StringComparer.OrdinalIgnoreCase);
             m_maskHints = new List<MaskHint>(maskHints);
             m_steps = new List<JobStep>(steps);
@@ -179,13 +181,6 @@ namespace GitHub.DistributedTask.Pipelines
 
         [DataMember(EmitDefaultValue = false)]
         public WorkspaceOptions Workspace
-        {
-            get;
-            private set;
-        }
-
-        [DataMember(EmitDefaultValue = false)]
-        public string JobWorkflowRef
         {
             get;
             private set;

--- a/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
+++ b/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
@@ -42,7 +42,7 @@ namespace GitHub.DistributedTask.Pipelines
             IList<String> fileTable,
             TemplateToken jobOutputs,
             IList<TemplateToken> defaults,
-            ActionsEnvironmentReference actionsEnvironment
+            ActionsEnvironmentReference actionsEnvironment,
             string dataWorkflowFilePathRaw)
         {
             this.MessageType = JobRequestMessageTypes.PipelineAgentJobRequest;

--- a/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
+++ b/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
@@ -184,6 +184,20 @@ namespace GitHub.DistributedTask.Pipelines
             private set;
         }
 
+        [DataMember(EmitDefaultValue = false)]
+        public string JobWorkflowRef
+        {
+            get;
+            private set;
+        }
+
+        [DataMember(EmitDefaultValue = false)]
+        public string DataWorkflowFilePathRaw
+        {
+            get;
+            private set;
+        }
+
         /// <summary>
         /// Gets the collection of mask hints
         /// </summary>


### PR DESCRIPTION
This forms part of the work being done for the nested workflow feature. Jobs that are nested more than 1 level in depth have their job name truncated in the UI. The change displays the full job name as well as the calling workflow ref and inputs that were passed in, in the UI and raw logs 

Complete job name:
![image](https://user-images.githubusercontent.com/20206630/183572349-0416ade7-6276-4860-91ba-bb0d1af328b7.png)

Calling workflow ref with inputs:
![image](https://user-images.githubusercontent.com/20206630/185856633-63ce7954-1b6b-4a05-9389-e086808ddd38.png)
Expanded:
![image](https://user-images.githubusercontent.com/20206630/185856670-28ee033c-b098-4d5c-aeef-7eb6a6a8aab0.png)


Raw logs:
![image](https://user-images.githubusercontent.com/20206630/185855411-27622aac-bd1b-42f2-a229-58a791c02f86.png)

actions-dotnet change: https://github.com/github/actions-dotnet/pull/12910

Closes: https://github.com/github/c2c-actions-policy/issues/580
Epic: https://github.com/github/c2c-actions-policy/issues/399