### PR TITLE
Try enforcing required

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1159,6 +1159,8 @@ namespace GitHub.Runner.Worker
         public ActionExecutionData Execution { get; set; }
 
         public Dictionary<String, String> Deprecated { get; set; }
+
+        public Dictionary<String, bool> Required { get; set; }
     }
 
     public enum ActionExecutionType

--- a/src/Runner.Worker/ActionManifestManager.cs
+++ b/src/Runner.Worker/ActionManifestManager.cs
@@ -59,7 +59,7 @@ namespace GitHub.Runner.Worker
             ActionDefinitionData actionDefinition = new ActionDefinitionData();
 
             // Clean up file name real quick
-            // Instead of using Regex which can be computationally expensive, 
+            // Instead of using Regex which can be computationally expensive,
             // we can just remove the # of characters from the fileName according to the length of the basePath
             string basePath = HostContext.GetDirectory(WellKnownDirectory.Actions);
             string fileRelativePath = manifestFile;
@@ -533,6 +533,14 @@ namespace GitHub.Runner.Worker
                         }
                         var message = metadata.Value.AssertString("input deprecationMessage");
                         actionDefinition.Deprecated.Add(inputName.Value, message.Value);
+                    }
+                    else if (string.Equals(metadataName, "required", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (actionDefinition.Required == null)
+                        {
+                            actionDefinition.Required = new Dictionary<String, bool>();
+                        }
+                        actionDefinition.Required.Add(inputName.Value, string.Equals(metadata.Value, "true", StringComparison.OrdinalIgnoreCase));
                     }
                 }
 

--- a/src/Runner.Worker/ActionRunner.cs
+++ b/src/Runner.Worker/ActionRunner.cs
@@ -216,6 +216,10 @@ namespace GitHub.Runner.Worker
                     if (!inputs.ContainsKey(key))
                     {
                         inputs[key] = manifestManager.EvaluateDefaultInput(ExecutionContext, key, input.Value);
+                        if (inputs.Required?.TryGetValue(key) && !inputs[key])
+                        {
+                            ExecutionContext.Error(String.Format("Input '{0}' is required and was not provided.", input.Key));
+                        }
                     }
                 }
             }

--- a/src/Test/L0/Worker/ActionManifestManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManifestManagerL0.cs
@@ -670,7 +670,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             {
                 Teardown();
             }
-        }        
+        }
 
         [Fact]
         [Trait("Level", "L0")]


### PR DESCRIPTION
I'm hoping this could address #1070

But I can't figure out how to write a test for it based on the current testing bits.

It'd be conceptually easy to have a proper action file, roughly:
https://github.com/actions/runner/blob/be9632302ceef50bfb36ea998cea9c94c75e5d4d/src/Test/TestData/nodeaction.yml
minus:
https://github.com/actions/runner/blob/be9632302ceef50bfb36ea998cea9c94c75e5d4d/src/Test/TestData/nodeaction.yml#L8-L9
And then have a workflow which referenced that action, but didn't provide a `greeting`.

But, I can't figure out how to go from where the C# unit tests are to a point that would either do that, or do the equivalent of that...