### PR TITLE
Include step context name and start/finish time in step telemetry

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -369,6 +369,7 @@ namespace GitHub.Runner.Worker
             child.StepTelemetry.StepId = recordId;
             child.StepTelemetry.Stage = stage.ToString();
             child.StepTelemetry.IsEmbedded = isEmbedded;
+            child.StepTelemetry.StepContextName = child.GetFullyQualifiedContextName();;
 
             return child;
         }

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -369,7 +369,7 @@ namespace GitHub.Runner.Worker
             child.StepTelemetry.StepId = recordId;
             child.StepTelemetry.Stage = stage.ToString();
             child.StepTelemetry.IsEmbedded = isEmbedded;
-            child.StepTelemetry.StepContextName = child.GetFullyQualifiedContextName();;
+            child.StepTelemetry.StepContextName = child.GetFullyQualifiedContextName(); ;
 
             return child;
         }
@@ -960,6 +960,8 @@ namespace GitHub.Runner.Worker
                         _record.StartTime != null)
                     {
                         StepTelemetry.ExecutionTimeInSeconds = (int)Math.Ceiling((_record.FinishTime - _record.StartTime)?.TotalSeconds ?? 0);
+                        StepTelemetry.StartTime = _record.StartTime;
+                        StepTelemetry.FinishTime = _record.FinishTime;
                     }
 
                     if (!IsEmbedded &&

--- a/src/Sdk/DTWebApi/WebApi/ActionsStepTelemetry.cs
+++ b/src/Sdk/DTWebApi/WebApi/ActionsStepTelemetry.cs
@@ -31,6 +31,9 @@ namespace GitHub.DistributedTask.WebApi
         public Guid StepId { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
+        public string StepContextName { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
         public bool? HasRunsStep { get; set; }
 
         [DataMember(EmitDefaultValue = false)]

--- a/src/Sdk/DTWebApi/WebApi/ActionsStepTelemetry.cs
+++ b/src/Sdk/DTWebApi/WebApi/ActionsStepTelemetry.cs
@@ -61,6 +61,12 @@ namespace GitHub.DistributedTask.WebApi
         public int? ExecutionTimeInSeconds { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
+        public DateTime? StartTime { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public DateTime? FinishTime { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
         public string ContainerHookData { get; set; }
     }
 }


### PR DESCRIPTION
We want to have a human-readable string to distinct steps using the same action within a job.