### PR TITLE
Validate lines and columns for Annotations

### DIFF
--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -585,6 +585,8 @@ namespace GitHub.Runner.Worker
 
         public void ProcessCommand(IExecutionContext context, string inputLine, ActionCommand command, ContainerInfo container)
         {
+            ValidateLinesAndColumns(command, context);
+        
             command.Properties.TryGetValue(IssueCommandProperties.File, out string file);
             command.Properties.TryGetValue(IssueCommandProperties.Line, out string line);
             command.Properties.TryGetValue(IssueCommandProperties.Column, out string column);


### PR DESCRIPTION
Found a bug/omission from an earlier PR: https://github.com/actions/runner/pull/1175

Resolves: https://github.com/github/c2c-actions-checks/issues/745

---

`ValidateLinesAndColumns` isn't called anywhere 😄 

https://github.com/actions/runner/blob/cba19c4d7e1cf8071a4b4f7e24de98eb3d0e6d0f/src/Runner.Worker/ActionCommandManager.cs#L648

There are a bunch of really good tests, but other than that it's dead code that we should use: https://github.com/search?q=repo%3Aactions%2Frunner%20ValidateLinesAndColumns&type=code

https://github.com/actions/runner/blob/cba19c4d7e1cf8071a4b4f7e24de98eb3d0e6d0f/src/Test/L0/Worker/ActionCommandManagerL0.cs#L275-L351 

This will fix some really weird issues where providing an invalid combination can cause a run to never be updated to completed in the UI when we later validate and create annotations

---

Testing locally with this following workflow:

```
jobs:
  build2:
    runs-on: [ self-hosted ]
    steps:
    - name: Create Buggy Annotation
      run: |
        echo ::error file=README.md,line=2,endLine=1::This will fail and the run will stay in progress
```

Before it would crash and the run would continuously stay in-progress, but afterwards it's successful and in the logs you can see

<img width="840" alt="image" src="https://user-images.githubusercontent.com/16109154/186512261-4876290a-4692-432d-bdfd-e7dc27b6f4e6.png">
