### PR TITLE
Fix Composite annotations not appearing as expected

### DIFF
--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -413,6 +413,12 @@ namespace GitHub.Runner.Worker.Handlers
 
                 // Update context
                 step.ExecutionContext.UpdateGlobalStepsContext();
+
+                // Update annotations
+                foreach (var issue in step.ExecutionContext.EmbeddedIssues)
+                {
+                    ExecutionContext.AddIssueToTimelineRecord(issue);
+                }
             }
         }
 


### PR DESCRIPTION
### Description

This PR fixes an issue where timeline records for composite steps were being sent up to the server. They weren't intended to do that, but the `addIssue` function would send them up. To remedy this, we now keep track of issues on composite execution contexts, and combine them in the composite action handler. We also split out the addIssue function, so we don't repeat the validation logic.


See this [linked ticket](https://github.com/actions/runner/issues/1742) for how to reproduce