### PR TITLE
Remove unused imports

### DIFF
--- a/src/Runner.Common/ActionCommand.cs
+++ b/src/Runner.Common/ActionCommand.cs
@@ -1,4 +1,3 @@
-﻿using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using System;
 using System.Collections.Generic;

--- a/src/Runner.Common/ActionResult.cs
+++ b/src/Runner.Common/ActionResult.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace GitHub.Runner.Common
 {
     public enum ActionResult

--- a/src/Runner.Common/CommandLineParser.cs
+++ b/src/Runner.Common/CommandLineParser.cs
@@ -1,4 +1,3 @@
-﻿using GitHub.Runner.Common.Util;
 using System;
 using System.Collections.Generic;
 using GitHub.DistributedTask.Logging;

--- a/src/Runner.Common/ConfigurationStore.cs
+++ b/src/Runner.Common/ConfigurationStore.cs
@@ -1,4 +1,3 @@
-﻿using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using System;
 using System.IO;

--- a/src/Runner.Common/ExtensionManager.cs
+++ b/src/Runner.Common/ExtensionManager.cs
@@ -1,4 +1,3 @@
-﻿using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using System;
 using System.Collections.Concurrent;

--- a/src/Runner.Common/HostTraceListener.cs
+++ b/src/Runner.Common/HostTraceListener.cs
@@ -1,4 +1,3 @@
-﻿using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using System;
 using System.Diagnostics;

--- a/src/Runner.Common/JobNotification.cs
+++ b/src/Runner.Common/JobNotification.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.IO;
-using System.IO.Pipes;
+using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace GitHub.Runner.Common

--- a/src/Runner.Common/JobServer.cs
+++ b/src/Runner.Common/JobServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -13,7 +13,6 @@ using GitHub.Runner.Sdk;
 using GitHub.Services.Common;
 using GitHub.Services.WebApi;
 using GitHub.Services.WebApi.Utilities.Internal;
-using Newtonsoft.Json;
 
 namespace GitHub.Runner.Common
 {

--- a/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
+++ b/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
@@ -1,13 +1,11 @@
-﻿using GitHub.DistributedTask.WebApi;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Listener;
 using GitHub.Runner.Listener.Configuration;
 using GitHub.Runner.Common.Util;
 using GitHub.Services.WebApi;
 using Moq;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;

--- a/src/Test/L0/Listener/RunnerL0.cs
+++ b/src/Test/L0/Listener/RunnerL0.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.DistributedTask.WebApi;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Listener;
 using GitHub.Runner.Listener.Configuration;
 using Moq;
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Xunit;
 using GitHub.Services.WebApi;
 using Pipelines = GitHub.DistributedTask.Pipelines;
-using GitHub.Runner.Common.Util;
 
 namespace GitHub.Runner.Common.Tests.Listener
 {

--- a/src/Test/L0/PagingLoggerL0.cs
+++ b/src/Test/L0/PagingLoggerL0.cs
@@ -1,4 +1,3 @@
-﻿using GitHub.Runner.Common.Util;
 using Moq;
 using System;
 using System.IO;

--- a/src/Test/L0/ProcessInvokerL0.cs
+++ b/src/Test/L0/ProcessInvokerL0.cs
@@ -1,11 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using GitHub.Runner.Common.Util;
 using System.Threading.Channels;
 using GitHub.Runner.Sdk;
 using System.Linq;

--- a/src/Test/L0/ServiceControlManagerL0.cs
+++ b/src/Test/L0/ServiceControlManagerL0.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
-using GitHub.Runner.Common;
 using GitHub.Runner.Listener.Configuration;
 using Xunit;
 

--- a/src/Test/L0/Util/ArgUtilL0.cs
+++ b/src/Test/L0/Util/ArgUtilL0.cs
@@ -1,4 +1,3 @@
-﻿using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using System;
 using Xunit;

--- a/src/Test/L0/Util/UrlUtilL0.cs
+++ b/src/Test/L0/Util/UrlUtilL0.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using GitHub.Runner.Common.Util;
+using System;
 using GitHub.Runner.Sdk;
 using Xunit;
 

--- a/src/Test/L0/Util/VssUtilL0.cs
+++ b/src/Test/L0/Util/VssUtilL0.cs
@@ -1,10 +1,6 @@
-﻿using GitHub.Runner.Common.Util;
 using GitHub.Services.Common;
 using System;
-using System.Collections.Generic;
-using System.Net.Http.Headers;
 using Xunit;
-using System.Text.RegularExpressions;
 using GitHub.Runner.Sdk;
 
 namespace GitHub.Runner.Common.Tests.Util

--- a/src/Test/L0/Worker/Expressions/ConditionFunctionsL0.cs
+++ b/src/Test/L0/Worker/Expressions/ConditionFunctionsL0.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Runtime.CompilerServices;
 using GitHub.DistributedTask.Expressions2;
 using GitHub.DistributedTask.ObjectTemplating;
 using GitHub.DistributedTask.Pipelines.ObjectTemplating;
-using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Worker;
 using GitHub.Runner.Worker.Expressions;
 using Moq;
@@ -121,8 +119,8 @@ namespace GitHub.Runner.Common.Tests.Worker.Expressions
 
                 var executionContext = InitializeExecutionContext(hc);
                 executionContext.Setup(x => x.GetGitHubContext("action_status")).Returns(actionStatus.ToString());
-                executionContext.Setup( x=> x.IsEmbedded).Returns(true);
-                executionContext.Setup( x=> x.Stage).Returns(ActionRunStage.Main);
+                executionContext.Setup(x => x.IsEmbedded).Returns(true);
+                executionContext.Setup(x => x.Stage).Returns(ActionRunStage.Main);
 
                 _jobContext.Status = jobStatus;
 
@@ -181,8 +179,8 @@ namespace GitHub.Runner.Common.Tests.Worker.Expressions
 
                 var executionContext = InitializeExecutionContext(hc);
                 executionContext.Setup(x => x.GetGitHubContext("action_status")).Returns(actionStatus.ToString());
-                executionContext.Setup( x=> x.IsEmbedded).Returns(true);
-                executionContext.Setup( x=> x.Stage).Returns(ActionRunStage.Main);
+                executionContext.Setup(x => x.IsEmbedded).Returns(true);
+                executionContext.Setup(x => x.Stage).Returns(ActionRunStage.Main);
 
                 _jobContext.Status = jobStatus;
 

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.DistributedTask.WebApi;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Worker;
 using Moq;
 using System;
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xunit;
 using System.Threading;
-using GitHub.DistributedTask.ObjectTemplating.Tokens;
 using Pipelines = GitHub.DistributedTask.Pipelines;
 
 namespace GitHub.Runner.Common.Tests.Worker

--- a/src/Test/L0/Worker/JobRunnerL0.cs
+++ b/src/Test/L0/Worker/JobRunnerL0.cs
@@ -1,14 +1,12 @@
-﻿using GitHub.DistributedTask.WebApi;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Worker;
 using Moq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xunit;
 using System.Threading;
-using System.Collections.ObjectModel;
 using Pipelines = GitHub.DistributedTask.Pipelines;
 
 namespace GitHub.Runner.Common.Tests.Worker

--- a/src/Test/L0/Worker/OutputManagerL0.cs
+++ b/src/Test/L0/Worker/OutputManagerL0.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/src/Test/L0/Worker/StepHostL0.cs
+++ b/src/Test/L0/Worker/StepHostL0.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -7,9 +7,6 @@ using Xunit;
 using GitHub.Runner.Worker;
 using GitHub.Runner.Worker.Handlers;
 using GitHub.Runner.Worker.Container;
-using GitHub.DistributedTask.Pipelines.ContextData;
-using System.Linq;
-using GitHub.DistributedTask.Pipelines;
 using GitHub.DistributedTask.WebApi;
 
 namespace GitHub.Runner.Common.Tests.Worker

--- a/src/Test/L0/Worker/VariablesL0.cs
+++ b/src/Test/L0/Worker/VariablesL0.cs
@@ -1,6 +1,4 @@
-﻿using GitHub.DistributedTask.WebApi;
-using GitHub.Runner.Common.Util;
-using GitHub.Runner.Sdk;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Worker;
 using System.Collections.Generic;
 using System.Globalization;


### PR DESCRIPTION
I have decided to clean up the runner code a bit. First batch are imports - I didn't commit all 500 modified files and decided to do it gradually, so you will see more PRs with removed code in the future. 😃 
Sometimes the formatter removes the 'using' line and adds it again - it is still a mystery to me why it happens.