### PR TITLE
Add Release branches to pull request spec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
     - '**.md'
   pull_request:
     branches:
-    - '*'
+    - '**'
     paths-ignore:
     - '**.md'
 


### PR DESCRIPTION
The `*` globspec matches all characters besides `/` so it doesn't run on our release branches like `releases/m293`. This change makes it so that it does run against those branches.

See the [globspec cheat sheet](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)