### PR TITLE
283 Backport: Ci fix to use windows-2019 over windows-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           devScript: ./dev.sh
 
         - runtime: win-x64
-          os: windows-latest
+          os: windows-2019
           devScript: ./dev
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           devScript: ./dev.sh
 
         - runtime: win-x64
-          os: windows-latest
+          os: windows-2019
           devScript: ./dev
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This pr changes the workflows to match the `main` branch, where we use windows-2019 over windows 2022 as windows 2019 has the required dotnet framework 4.5 dependency we need to run successfully.

Partial backport of this [commit](https://github.com/actions/runner/commit/715bb7cca8947c205034e9d33698359e011686ec), just the workflow changes.

Otherwise we fail with an [error](https://github.com/actions/runner/actions/runs/3092049254) like

```
EXEC : Testhost process exited with error : It was not possible to find any compatible framework version [D:\a\runner\runner\src\dir.proj]
  The framework 'Microsoft.NETCore.App', version '6.0.5' was not found.
    - The following frameworks were found:
        5.0.17 at [C:\Users\runneradmin\AppData\Local\Microsoft\dotnet\shared\Microsoft.NETCore.App]
  You can resolve the problem by installing the specified framework and/or SDK.
  The specified framework can be found at:
    - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=6.0.5&arch=x[64](https://github.com/actions/runner/actions/runs/3092049254/jobs/5002869104#step:6:65)&rid=win10-x64
  . Please check the diagnostic logs for more information.
  Results File: D:\a\runner\runner\src\Test\TestResults\runneradmin_fv-az177-7[67](https://github.com/actions/runner/actions/runs/3092049254/jobs/5002869104#step:6:68)_2022-09-20_17_15_21.trx
```