### PR TITLE
which handles broken symlink & unit test added (#2150)

### DIFF
--- a/src/Runner.Sdk/Util/WhichUtil.cs
+++ b/src/Runner.Sdk/Util/WhichUtil.cs
@@ -60,7 +60,7 @@ namespace GitHub.Runner.Sdk
                             trace?.Verbose(ex.ToString());
                         }
 
-                        if (matches != null && matches.Length > 0 && IsSymlinkValid(matches.First()))
+                        if (matches != null && matches.Length > 0 && IsPathValid(matches.First()))
                         {
                             trace?.Info($"Location: '{matches.First()}'");
                             return matches.First();
@@ -86,7 +86,7 @@ namespace GitHub.Runner.Sdk
                             for (int i = 0; i < pathExtSegments.Length; i++)
                             {
                                 string fullPath = Path.Combine(pathSegment, $"{command}{pathExtSegments[i]}");
-                                if (matches.Any(p => p.Equals(fullPath, StringComparison.OrdinalIgnoreCase)) && IsSymlinkValid(matches.First()))
+                                if (matches.Any(p => p.Equals(fullPath, StringComparison.OrdinalIgnoreCase)) && IsPathValid(fullPath))
                                 {
                                     trace?.Info($"Location: '{fullPath}'");
                                     return fullPath;
@@ -105,7 +105,7 @@ namespace GitHub.Runner.Sdk
                         trace?.Verbose(ex.ToString());
                     }
 
-                    if (matches != null && matches.Length > 0 && IsSymlinkValid(matches.First()))
+                    if (matches != null && matches.Length > 0 && IsPathValid(matches.First()))
                     {
                         trace?.Info($"Location: '{matches.First()}'");
                         return matches.First();
@@ -130,11 +130,10 @@ namespace GitHub.Runner.Sdk
         }
 
         // checks if the file is a symlink and if the symlink`s target exists.
-        private static bool IsSymlinkValid(string path)
+        private static bool IsPathValid(string path)
         {
             var fileInfo = new FileInfo(path);
-            return fileInfo.LinkTarget == null || File.Exists(fileInfo.LinkTarget)
-            return true;
+            return fileInfo.LinkTarget == null || File.Exists(fileInfo.LinkTarget);
         }
     }
 }

--- a/src/Runner.Sdk/Util/WhichUtil.cs
+++ b/src/Runner.Sdk/Util/WhichUtil.cs
@@ -133,7 +133,7 @@ namespace GitHub.Runner.Sdk
         private static bool IsSymlinkValid(string path)
         {
             var fileInfo = new FileInfo(path);
-            if (fileInfo.LinkTarget != null && !File.Exists(fileInfo.LinkTarget)) return false;
+            return fileInfo.LinkTarget == null || File.Exists(fileInfo.LinkTarget)
             return true;
         }
     }

--- a/src/Runner.Sdk/Util/WhichUtil.cs
+++ b/src/Runner.Sdk/Util/WhichUtil.cs
@@ -60,7 +60,7 @@ namespace GitHub.Runner.Sdk
                             trace?.Verbose(ex.ToString());
                         }
 
-                        if (matches != null && matches.Length > 0 && IsPathValid(matches.First()))
+                        if (matches != null && matches.Length > 0 && IsPathValid(matches.First(), trace))
                         {
                             trace?.Info($"Location: '{matches.First()}'");
                             return matches.First();
@@ -86,7 +86,7 @@ namespace GitHub.Runner.Sdk
                             for (int i = 0; i < pathExtSegments.Length; i++)
                             {
                                 string fullPath = Path.Combine(pathSegment, $"{command}{pathExtSegments[i]}");
-                                if (matches.Any(p => p.Equals(fullPath, StringComparison.OrdinalIgnoreCase)) && IsPathValid(fullPath))
+                                if (matches.Any(p => p.Equals(fullPath, StringComparison.OrdinalIgnoreCase)) && IsPathValid(fullPath, trace))
                                 {
                                     trace?.Info($"Location: '{fullPath}'");
                                     return fullPath;
@@ -105,7 +105,7 @@ namespace GitHub.Runner.Sdk
                         trace?.Verbose(ex.ToString());
                     }
 
-                    if (matches != null && matches.Length > 0 && IsPathValid(matches.First()))
+                    if (matches != null && matches.Length > 0 && IsPathValid(matches.First(), trace))
                     {
                         trace?.Info($"Location: '{matches.First()}'");
                         return matches.First();
@@ -130,10 +130,12 @@ namespace GitHub.Runner.Sdk
         }
 
         // checks if the file is a symlink and if the symlink`s target exists.
-        private static bool IsPathValid(string path)
+        private static bool IsPathValid(string path, ITraceWriter trace = null)
         {
             var fileInfo = new FileInfo(path);
-            return fileInfo.LinkTarget == null || File.Exists(fileInfo.LinkTarget);
+            if(fileInfo.LinkTarget == null || File.Exists(fileInfo.LinkTarget)) return true;
+            trace?.Info($"the target '{fileInfo.LinkTarget}' of the symbolic link '{path}', does not exist");
+            return false;
         }
     }
 }

--- a/src/Runner.Sdk/Util/WhichUtil.cs
+++ b/src/Runner.Sdk/Util/WhichUtil.cs
@@ -133,7 +133,8 @@ namespace GitHub.Runner.Sdk
         private static bool IsPathValid(string path, ITraceWriter trace = null)
         {
             var fileInfo = new FileInfo(path);
-            if(fileInfo.LinkTarget == null || File.Exists(fileInfo.LinkTarget)) return true;
+            var linkTargetFullPath = fileInfo.Directory?.FullName + Path.DirectorySeparatorChar + fileInfo.LinkTarget;
+            if(fileInfo.LinkTarget == null || File.Exists(linkTargetFullPath) || File.Exists(fileInfo.LinkTarget)) return true;
             trace?.Info($"the target '{fileInfo.LinkTarget}' of the symbolic link '{path}', does not exist");
             return false;
         }

--- a/src/Runner.Sdk/Util/WhichUtil.cs
+++ b/src/Runner.Sdk/Util/WhichUtil.cs
@@ -60,7 +60,7 @@ namespace GitHub.Runner.Sdk
                             trace?.Verbose(ex.ToString());
                         }
 
-                        if (matches != null && matches.Length > 0)
+                        if (matches != null && matches.Length > 0 && IsSymlinkValid(matches.First()))
                         {
                             trace?.Info($"Location: '{matches.First()}'");
                             return matches.First();
@@ -86,7 +86,7 @@ namespace GitHub.Runner.Sdk
                             for (int i = 0; i < pathExtSegments.Length; i++)
                             {
                                 string fullPath = Path.Combine(pathSegment, $"{command}{pathExtSegments[i]}");
-                                if (matches.Any(p => p.Equals(fullPath, StringComparison.OrdinalIgnoreCase)))
+                                if (matches.Any(p => p.Equals(fullPath, StringComparison.OrdinalIgnoreCase)) && IsSymlinkValid(matches.First()))
                                 {
                                     trace?.Info($"Location: '{fullPath}'");
                                     return fullPath;
@@ -105,7 +105,7 @@ namespace GitHub.Runner.Sdk
                         trace?.Verbose(ex.ToString());
                     }
 
-                    if (matches != null && matches.Length > 0)
+                    if (matches != null && matches.Length > 0 && IsSymlinkValid(matches.First()))
                     {
                         trace?.Info($"Location: '{matches.First()}'");
                         return matches.First();
@@ -127,6 +127,14 @@ namespace GitHub.Runner.Sdk
             }
 
             return null;
+        }
+
+        // checks if the file is a symlink and if the symlink`s target exists.
+        private static bool IsSymlinkValid(string path)
+        {
+            var fileInfo = new FileInfo(path);
+            if (fileInfo.LinkTarget != null && !File.Exists(fileInfo.LinkTarget)) return false;
+            return true;
         }
     }
 }

--- a/src/Test/L0/Util/WhichUtilL0.cs
+++ b/src/Test/L0/Util/WhichUtilL0.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.Runner.Common.Util;
+using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using System;
 using System.IO;
@@ -87,6 +87,43 @@ namespace GitHub.Runner.Common.Tests.Util
 
                 // Assert.
                 Assert.Equal(gitPath, gitPath2);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void WhichThrowsWhenSymlinkBroken()
+        {
+            using TestHostContext hc = new TestHostContext(this);
+            // Arrange
+            Tracing trace = hc.GetTrace();
+            string oldValue = Environment.GetEnvironmentVariable(PathUtil.PathVariable);
+            string newValue = oldValue + Path.GetTempPath();
+            Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
+
+            string brokenSymlink = Path.GetTempPath() + "broken-symlink.exe";
+            string target = "no-such-file-cf7e351f";
+            File.CreateSymbolicLink(brokenSymlink, target);
+
+            // Act.
+            try
+            {
+                WhichUtil.Which("broken-symlink", require: true, trace: trace);
+                throw new Exception("which should have thrown");
+            }
+
+            // Assert
+            catch (FileNotFoundException ex)
+            {
+                Assert.Equal("broken-symlink", ex.FileName);
+            }
+
+            // Cleanup
+            finally
+            {
+                File.Delete(brokenSymlink);
+                Environment.SetEnvironmentVariable(PathUtil.PathVariable, oldValue);
             }
         }
     }

--- a/src/Test/L0/Util/WhichUtilL0.cs
+++ b/src/Test/L0/Util/WhichUtilL0.cs
@@ -95,8 +95,8 @@ namespace GitHub.Runner.Common.Tests.Util
         [Trait("Category", "Common")]
         public void WhichThrowsWhenSymlinkBroken()
         {
-            using TestHostContext hc = new TestHostContext(this);
             // Arrange
+            using TestHostContext hc = new TestHostContext(this);
             Tracing trace = hc.GetTrace();
             string oldValue = Environment.GetEnvironmentVariable(PathUtil.PathVariable);
             string newValue = oldValue + Path.GetTempPath();
@@ -107,24 +107,14 @@ namespace GitHub.Runner.Common.Tests.Util
             File.CreateSymbolicLink(brokenSymlink, target);
 
             // Act.
-            try
-            {
-                WhichUtil.Which("broken-symlink", require: true, trace: trace);
-                throw new Exception("which should have thrown");
-            }
+            var exception = Assert.Throws<FileNotFoundException>(()=>WhichUtil.Which("broken-symlink", require: true, trace: trace));
 
             // Assert
-            catch (FileNotFoundException ex)
-            {
-                Assert.Equal("broken-symlink", ex.FileName);
-            }
+            Assert.Equal("broken-symlink", exception.FileName);
 
             // Cleanup
-            finally
-            {
-                File.Delete(brokenSymlink);
-                Environment.SetEnvironmentVariable(PathUtil.PathVariable, oldValue);
-            }
+            File.Delete(brokenSymlink);
+            Environment.SetEnvironmentVariable(PathUtil.PathVariable, oldValue);
         }
     }
 }

--- a/src/Test/L0/Util/WhichUtilL0.cs
+++ b/src/Test/L0/Util/WhichUtilL0.cs
@@ -99,17 +99,18 @@ namespace GitHub.Runner.Common.Tests.Util
             using TestHostContext hc = new TestHostContext(this);
             Tracing trace = hc.GetTrace();
             string oldValue = Environment.GetEnvironmentVariable(PathUtil.PathVariable);
-            string newValue = oldValue + Path.GetTempPath();
+            string newValue = oldValue + @$";{Path.GetTempPath()}";
             Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
-            string symlink = Path.GetTempPath() + "symlink.exe";
-            string target = Path.GetTempPath() + "target.exe";
+            string symlinkName = $"symlink-{Guid.NewGuid()}";
+            string symlink = Path.GetTempPath() + $"{symlinkName}.exe" ;
+            string target = Path.GetTempPath() + $"target-{Guid.NewGuid()}.exe";
 
             using (File.Create(target))
             {
                 File.CreateSymbolicLink(symlink, target);
 
                 // Act.
-                var result = WhichUtil.Which("symlink", require: true, trace: trace);
+                var result = WhichUtil.Which(symlinkName, require: true, trace: trace);
 
                 // Assert
                 Assert.True(!string.IsNullOrEmpty(result) && File.Exists(result), $"Unable to find symlink through: {nameof(WhichUtil.Which)}");
@@ -133,11 +134,11 @@ namespace GitHub.Runner.Common.Tests.Util
             using TestHostContext hc = new TestHostContext(this);
             Tracing trace = hc.GetTrace();
             string oldValue = Environment.GetEnvironmentVariable(PathUtil.PathVariable);
-            string newValue = oldValue + Path.GetTempPath();
+            string newValue = oldValue + @$";{Path.GetTempPath()}";
             Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
-            string symlinkName = "symlink.exe";
-            string symlink = Path.GetTempPath() + symlinkName;
-            string targetName = "target.exe";
+            string symlinkName = $"symlink-{Guid.NewGuid()}";
+            string symlink = Path.GetTempPath() + $"{symlinkName}.exe";
+            string targetName = $"target-{Guid.NewGuid()}.exe";
             string target = Path.GetTempPath() + targetName;
 
             using (File.Create(target))
@@ -145,7 +146,7 @@ namespace GitHub.Runner.Common.Tests.Util
                 File.CreateSymbolicLink(symlink, targetName);
 
                 // Act.
-                var result = WhichUtil.Which("symlink", require: true, trace: trace);
+                var result = WhichUtil.Which(symlinkName, require: true, trace: trace);
 
                 // Assert
                 Assert.True(!string.IsNullOrEmpty(result) && File.Exists(result), $"Unable to find {symlinkName} through: {nameof(WhichUtil.Which)}");
@@ -169,15 +170,16 @@ namespace GitHub.Runner.Common.Tests.Util
             string newValue = oldValue + Path.GetTempPath();
             Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
 
-            string brokenSymlink = Path.GetTempPath() + "broken-symlink.exe";
+            string brokenSymlinkName = $"broken-symlink-{Guid.NewGuid()}";
+            string brokenSymlink = Path.GetTempPath() + $"{brokenSymlinkName}.exe";
             string target = "no-such-file-cf7e351f";
             File.CreateSymbolicLink(brokenSymlink, target);
 
             // Act.
-            var exception = Assert.Throws<FileNotFoundException>(()=>WhichUtil.Which("broken-symlink", require: true, trace: trace));
+            var exception = Assert.Throws<FileNotFoundException>(()=>WhichUtil.Which(brokenSymlinkName, require: true, trace: trace));
 
             // Assert
-            Assert.Equal("broken-symlink", exception.FileName);
+            Assert.Equal(brokenSymlinkName, exception.FileName);
 
             // Cleanup
             File.Delete(brokenSymlink);

--- a/src/Test/L0/Util/WhichUtilL0.cs
+++ b/src/Test/L0/Util/WhichUtilL0.cs
@@ -93,6 +93,73 @@ namespace GitHub.Runner.Common.Tests.Util
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
+        public void WhichHandlesSymlinkToTargetFullPath()
+        {
+            // Arrange
+            using TestHostContext hc = new TestHostContext(this);
+            Tracing trace = hc.GetTrace();
+            string oldValue = Environment.GetEnvironmentVariable(PathUtil.PathVariable);
+            string newValue = oldValue + Path.GetTempPath();
+            Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
+            string symlink = Path.GetTempPath() + "symlink.exe";
+            string target = Path.GetTempPath() + "target.exe";
+
+            using (File.Create(target))
+            {
+                File.CreateSymbolicLink(symlink, target);
+
+                // Act.
+                var result = WhichUtil.Which("symlink", require: true, trace: trace);
+
+                // Assert
+                Assert.True(!string.IsNullOrEmpty(result) && File.Exists(result), $"Unable to find symlink through: {nameof(WhichUtil.Which)}");
+
+            }
+
+
+            // Cleanup
+            File.Delete(symlink);
+            File.Delete(target);
+            Environment.SetEnvironmentVariable(PathUtil.PathVariable, oldValue);
+
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void WhichHandlesSymlinkToTargetRelativePath()
+        {
+            // Arrange
+            using TestHostContext hc = new TestHostContext(this);
+            Tracing trace = hc.GetTrace();
+            string oldValue = Environment.GetEnvironmentVariable(PathUtil.PathVariable);
+            string newValue = oldValue + Path.GetTempPath();
+            Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
+            string symlinkName = "symlink.exe";
+            string symlink = Path.GetTempPath() + symlinkName;
+            string targetName = "target.exe";
+            string target = Path.GetTempPath() + targetName;
+
+            using (File.Create(target))
+            {
+                File.CreateSymbolicLink(symlink, targetName);
+
+                // Act.
+                var result = WhichUtil.Which("symlink", require: true, trace: trace);
+
+                // Assert
+                Assert.True(!string.IsNullOrEmpty(result) && File.Exists(result), $"Unable to find {symlinkName} through: {nameof(WhichUtil.Which)}");
+            }
+
+            // Cleanup
+            File.Delete(symlink);
+            File.Delete(target);
+            Environment.SetEnvironmentVariable(PathUtil.PathVariable, oldValue);
+
+        }
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
         public void WhichThrowsWhenSymlinkBroken()
         {
             // Arrange

--- a/src/Test/L0/Util/WhichUtilL0.cs
+++ b/src/Test/L0/Util/WhichUtilL0.cs
@@ -99,11 +99,20 @@ namespace GitHub.Runner.Common.Tests.Util
             using TestHostContext hc = new TestHostContext(this);
             Tracing trace = hc.GetTrace();
             string oldValue = Environment.GetEnvironmentVariable(PathUtil.PathVariable);
+#if OS_WINDOWS
             string newValue = oldValue + @$";{Path.GetTempPath()}";
-            Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
             string symlinkName = $"symlink-{Guid.NewGuid()}";
-            string symlink = Path.GetTempPath() + $"{symlinkName}.exe" ;
+            string symlink = Path.GetTempPath() + $"{symlinkName}.exe";
             string target = Path.GetTempPath() + $"target-{Guid.NewGuid()}.exe";
+#else
+            string newValue = oldValue + @$":{Path.GetTempPath()}";
+            string symlinkName = $"symlink-{Guid.NewGuid()}";
+            string symlink = Path.GetTempPath() + $"{symlinkName}";
+            string target = Path.GetTempPath() + $"target-{Guid.NewGuid()}";
+#endif
+
+            Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
+
 
             using (File.Create(target))
             {
@@ -134,12 +143,21 @@ namespace GitHub.Runner.Common.Tests.Util
             using TestHostContext hc = new TestHostContext(this);
             Tracing trace = hc.GetTrace();
             string oldValue = Environment.GetEnvironmentVariable(PathUtil.PathVariable);
+#if OS_WINDOWS
             string newValue = oldValue + @$";{Path.GetTempPath()}";
-            Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
             string symlinkName = $"symlink-{Guid.NewGuid()}";
             string symlink = Path.GetTempPath() + $"{symlinkName}.exe";
             string targetName = $"target-{Guid.NewGuid()}.exe";
             string target = Path.GetTempPath() + targetName;
+#else
+            string newValue = oldValue + @$":{Path.GetTempPath()}";
+            string symlinkName = $"symlink-{Guid.NewGuid()}";
+            string symlink = Path.GetTempPath() + $"{symlinkName}";
+            string targetName = $"target-{Guid.NewGuid()}";
+            string target = Path.GetTempPath() + targetName;
+#endif
+            Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
+
 
             using (File.Create(target))
             {
@@ -167,12 +185,21 @@ namespace GitHub.Runner.Common.Tests.Util
             using TestHostContext hc = new TestHostContext(this);
             Tracing trace = hc.GetTrace();
             string oldValue = Environment.GetEnvironmentVariable(PathUtil.PathVariable);
-            string newValue = oldValue + Path.GetTempPath();
-            Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
 
+#if OS_WINDOWS
+            string newValue = oldValue + @$";{Path.GetTempPath()}";
             string brokenSymlinkName = $"broken-symlink-{Guid.NewGuid()}";
             string brokenSymlink = Path.GetTempPath() + $"{brokenSymlinkName}.exe";
+#else
+            string newValue = oldValue + @$":{Path.GetTempPath()}";
+            string brokenSymlinkName = $"broken-symlink-{Guid.NewGuid()}";
+            string brokenSymlink = Path.GetTempPath() + $"{brokenSymlinkName}";
+#endif
+
+
             string target = "no-such-file-cf7e351f";
+            Environment.SetEnvironmentVariable(PathUtil.PathVariable, newValue);
+
             File.CreateSymbolicLink(brokenSymlink, target);
 
             // Act.


### PR DESCRIPTION
## pull request related to issue #2150 
if there is a match from $PATH of some `command`, there is a check if the match is a symbolic link, if so we also look at the target. if the target does not exist we ignore it.

a sort of integration test is added which `WhichThrowsWhenSymlinkBroken` which temporarily creates a symlink that targets  a non-existent file  `"no-such-file-cf7e351f"` and also adds to $PATH  environment variable the directory of the temporary symlink (which is created at `Path.GetTempPath()`  )