### PR TITLE
Use Global.Variables instead of JobContext and include action path/ref in the message.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 # https://editorconfig.org/
 
 [*]
+charset = utf-8 # Set default charset to utf-8
 insert_final_newline = true # ensure all files end with a single newline
 trim_trailing_whitespace = true # attempt to remove trailing whitespace on save
 

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -139,22 +139,23 @@ namespace GitHub.Runner.Worker.Handlers
             if (Data.NodeVersion == "node12" && (ExecutionContext.Global.Variables.GetBoolean(Constants.Runner.Features.Node12Warning) ?? false))
             {
                 var repoAction = Action as RepositoryPathReference;
-                var warningActions = new List<string>();
+                var warningActions = new HashSet<string>();
                 if (ExecutionContext.Global.Variables.TryGetValue("Node12ActionsWarnings", out var node12Warnings))
                 {
-                    warningActions = StringUtil.ConvertFromJson<List<string>>(node12Warnings);
+                    warningActions = StringUtil.ConvertFromJson<HashSet<string>>(node12Warnings);
                 }
 
+                var repoActionFullName = "";
                 if (string.IsNullOrEmpty(repoAction.Name))
                 {
-                    warningActions.Add(repoAction.Path); // local actions don't have a 'Name'
+                    repoActionFullName = repoAction.Path; // local actions don't have a 'Name'
                 }
                 else
                 {
-                    var repoActionFullName = $"{repoAction.Name}/{repoAction.Path ?? string.Empty}".TrimEnd('/');
-                    warningActions.Add($"{repoActionFullName}@{repoAction.Ref}");
+                    repoActionFullName = $"{repoAction.Name}/{repoAction.Path ?? string.Empty}".TrimEnd('/') + $"@{repoAction.Ref}";
                 }
 
+                warningActions.Add(repoActionFullName);
                 ExecutionContext.Global.Variables.Set("Node12ActionsWarnings", StringUtil.ConvertToJson(warningActions));
             }
 

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -258,9 +258,9 @@ namespace GitHub.Runner.Worker
                 }
             }
 
-            if (jobContext.JobContext.ContainsKey("Node12ActionsWarnings"))
+            if (jobContext.Global.Variables.TryGetValue("Node12ActionsWarnings", out var node12Warnings))
             {
-                var actions = string.Join(", ", jobContext.JobContext["Node12ActionsWarnings"].AssertArray("Node12ActionsWarnings").Select(action => action.ToString()));
+                var actions = string.Join(", ", StringUtil.ConvertFromJson<List<string>>(node12Warnings));
                 jobContext.Warning(string.Format(Constants.Runner.Node12DetectedAfterEndOfLife, actions));
             }
 

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -260,7 +260,7 @@ namespace GitHub.Runner.Worker
 
             if (jobContext.Global.Variables.TryGetValue("Node12ActionsWarnings", out var node12Warnings))
             {
-                var actions = string.Join(", ", StringUtil.ConvertFromJson<List<string>>(node12Warnings));
+                var actions = string.Join(", ", StringUtil.ConvertFromJson<HashSet<string>>(node12Warnings));
                 jobContext.Warning(string.Format(Constants.Runner.Node12DetectedAfterEndOfLife, actions));
             }
 

--- a/src/Runner.Worker/Variables.cs
+++ b/src/Runner.Worker/Variables.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Runner.Worker/Variables.cs
+++ b/src/Runner.Worker/Variables.cs
@@ -2,9 +2,9 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using GitHub.DistributedTask.WebApi;
 using GitHub.DistributedTask.Logging;
 using GitHub.DistributedTask.Pipelines.ContextData;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Common;
 using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
@@ -134,6 +134,12 @@ namespace GitHub.Runner.Worker
             }
 
             return null;
+        }
+
+        public void Set(string name, string val)
+        {
+            ArgUtil.NotNullOrEmpty(name, nameof(name));
+            _variables[name] = new Variable(name, val, false);
         }
 
         public bool TryGetValue(string name, out string val)


### PR DESCRIPTION
We should not use `JobContext` for carrying runner internal data.

![image](https://user-images.githubusercontent.com/1750815/197287615-7d0b89c9-c095-496d-a7d8-72143894e93a.png)
