### PR TITLE
Add generateServiceConfig option for configure command

### DIFF
--- a/src/Runner.Common/ConfigurationStore.cs
+++ b/src/Runner.Common/ConfigurationStore.cs
@@ -77,14 +77,15 @@ namespace GitHub.Runner.Common
                 Uri accountUri = new(this.ServerUrl);
                 string repoOrOrgName = string.Empty;
 
-                if (accountUri.Host.EndsWith(".githubusercontent.com", StringComparison.OrdinalIgnoreCase))
+                if (accountUri.Host.EndsWith(".githubusercontent.com", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(this.GitHubUrl))
                 {
                     Uri gitHubUrl = new(this.GitHubUrl);
 
                     // Use the "NWO part" from the GitHub URL path
                     repoOrOrgName = gitHubUrl.AbsolutePath.Trim('/');
                 }
-                else
+
+                if (string.IsNullOrEmpty(repoOrOrgName))
                 {
                     repoOrOrgName = accountUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
                 }

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -128,6 +128,7 @@ namespace GitHub.Runner.Common
                     public static readonly string Check = "check";
                     public static readonly string Commit = "commit";
                     public static readonly string Ephemeral = "ephemeral";
+                    public static readonly string GenerateServiceConfig = "generateServiceConfig";
                     public static readonly string Help = "help";
                     public static readonly string Replace = "replace";
                     public static readonly string DisableUpdate = "disableupdate";

--- a/src/Runner.Listener/CommandSettings.cs
+++ b/src/Runner.Listener/CommandSettings.cs
@@ -34,6 +34,7 @@ namespace GitHub.Runner.Listener
                 {
                     Constants.Runner.CommandLine.Flags.DisableUpdate,
                     Constants.Runner.CommandLine.Flags.Ephemeral,
+                    Constants.Runner.CommandLine.Flags.GenerateServiceConfig,
                     Constants.Runner.CommandLine.Flags.Replace,
                     Constants.Runner.CommandLine.Flags.RunAsService,
                     Constants.Runner.CommandLine.Flags.Unattended,
@@ -79,11 +80,14 @@ namespace GitHub.Runner.Listener
         // Flags.
         public bool Check => TestFlag(Constants.Runner.CommandLine.Flags.Check);
         public bool Commit => TestFlag(Constants.Runner.CommandLine.Flags.Commit);
+        public bool DisableUpdate => TestFlag(Constants.Runner.CommandLine.Flags.DisableUpdate);
+        public bool Ephemeral => TestFlag(Constants.Runner.CommandLine.Flags.Ephemeral);
+        public bool GenerateServiceConfig => TestFlag(Constants.Runner.CommandLine.Flags.GenerateServiceConfig);
         public bool Help => TestFlag(Constants.Runner.CommandLine.Flags.Help);
         public bool Unattended => TestFlag(Constants.Runner.CommandLine.Flags.Unattended);
         public bool Version => TestFlag(Constants.Runner.CommandLine.Flags.Version);
-        public bool Ephemeral => TestFlag(Constants.Runner.CommandLine.Flags.Ephemeral);
-        public bool DisableUpdate => TestFlag(Constants.Runner.CommandLine.Flags.DisableUpdate);
+        
+        
 
         // Keep this around since customers still relies on it
         public bool RunOnce => TestFlag(Constants.Runner.CommandLine.Flags.Once);

--- a/src/Runner.Listener/CommandSettings.cs
+++ b/src/Runner.Listener/CommandSettings.cs
@@ -86,8 +86,6 @@ namespace GitHub.Runner.Listener
         public bool Help => TestFlag(Constants.Runner.CommandLine.Flags.Help);
         public bool Unattended => TestFlag(Constants.Runner.CommandLine.Flags.Unattended);
         public bool Version => TestFlag(Constants.Runner.CommandLine.Flags.Version);
-        
-        
 
         // Keep this around since customers still relies on it
         public bool RunOnce => TestFlag(Constants.Runner.CommandLine.Flags.Once);

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -91,11 +91,11 @@ namespace GitHub.Runner.Listener.Configuration
                 }
 
                 RunnerSettings settings = _store.GetSettings();
-                var serviceControlManager = HostContext.GetService<ILinuxServiceControlManager>();
 
                 Trace.Info($"generate service config for runner: {settings.AgentId}");
-                serviceControlManager.GenerateScripts(settings);
-                
+                var controlManager = HostContext.GetService<ILinuxServiceControlManager>();
+                controlManager.GenerateScripts(settings);
+
                 return;
 #else
                 throw new NotSupportedException("--generateServiceConfig is only supported on Linux.");

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -82,9 +82,10 @@ namespace GitHub.Runner.Listener.Configuration
 
             Trace.Info(nameof(ConfigureAsync));
 
-#if OS_LINUX
+
             if (command.GenerateServiceConfig)
             {
+#if OS_LINUX
                 if (!IsConfigured())
                 {
                     throw new InvalidOperationException("--generateServiceConfig requires that the runner is already configured. For configuring a new runner as a service, run './config.sh'.");
@@ -93,8 +94,13 @@ namespace GitHub.Runner.Listener.Configuration
                 RunnerSettings _runnerSettings = new();
                 var _serviceControlManager = HostContext.GetService<ILinuxServiceControlManager>();
                 _serviceControlManager.GenerateScripts(_runnerSettings);
-            }
+                
+                return;
+#else
+                throw new InvalidOperationException("--generateServiceConfig is only supported in Linux.");
 #endif
+            }
+
 
             if (IsConfigured())
             {

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -93,7 +93,7 @@ namespace GitHub.Runner.Listener.Configuration
                 RunnerSettings settings = _store.GetSettings();
                 var serviceControlManager = HostContext.GetService<ILinuxServiceControlManager>();
 
-                Trace.Info($"generate service config for runner: {settings.RunnerId}");
+                Trace.Info($"generate service config for runner: {settings.AgentId}");
                 serviceControlManager.GenerateScripts(settings);
                 
                 return;

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -97,7 +97,7 @@ namespace GitHub.Runner.Listener.Configuration
                 
                 return;
 #else
-                throw new InvalidOperationException("--generateServiceConfig is only supported in Linux.");
+                throw new NotSupportedException("--generateServiceConfig is only supported in Linux.");
 #endif
             }
 

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -93,7 +93,7 @@ namespace GitHub.Runner.Listener.Configuration
                 RunnerSettings settings = _store.GetSettings();
                 var serviceControlManager = HostContext.GetService<ILinuxServiceControlManager>();
 
-                Trace.Info($"generate service config for runner: {setting.RunnerId}");
+                Trace.Info($"generate service config for runner: {settings.RunnerId}");
                 serviceControlManager.GenerateScripts(settings);
                 
                 return;

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -89,14 +89,15 @@ namespace GitHub.Runner.Listener.Configuration
                 {
                     throw new InvalidOperationException("--generateServiceConfig requires that the runner is already configured. For configuring a new runner as a service, run './config.sh'.");
                 }
-                // generate service config script for OSX and Linux, GenerateScripts() will no-opt on windows.
+
+                Trace.Info($"generate service config for runner: {setting.RunnerId}");
                 RunnerSettings settings = _store.GetSettings();
                 var serviceControlManager = HostContext.GetService<ILinuxServiceControlManager>();
                 serviceControlManager.GenerateScripts(settings);
                 
                 return;
 #else
-                throw new NotSupportedException("--generateServiceConfig is only supported in Linux.");
+                throw new NotSupportedException("--generateServiceConfig is only supported on Linux.");
 #endif
             }
 

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -90,9 +90,10 @@ namespace GitHub.Runner.Listener.Configuration
                     throw new InvalidOperationException("--generateServiceConfig requires that the runner is already configured. For configuring a new runner as a service, run './config.sh'.");
                 }
 
-                Trace.Info($"generate service config for runner: {setting.RunnerId}");
                 RunnerSettings settings = _store.GetSettings();
                 var serviceControlManager = HostContext.GetService<ILinuxServiceControlManager>();
+
+                Trace.Info($"generate service config for runner: {setting.RunnerId}");
                 serviceControlManager.GenerateScripts(settings);
                 
                 return;

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -82,7 +82,6 @@ namespace GitHub.Runner.Listener.Configuration
 
             Trace.Info(nameof(ConfigureAsync));
 
-
             if (command.GenerateServiceConfig)
             {
 #if OS_LINUX
@@ -91,16 +90,15 @@ namespace GitHub.Runner.Listener.Configuration
                     throw new InvalidOperationException("--generateServiceConfig requires that the runner is already configured. For configuring a new runner as a service, run './config.sh'.");
                 }
                 // generate service config script for OSX and Linux, GenerateScripts() will no-opt on windows.
-                RunnerSettings _runnerSettings = new();
-                var _serviceControlManager = HostContext.GetService<ILinuxServiceControlManager>();
-                _serviceControlManager.GenerateScripts(_runnerSettings);
+                RunnerSettings settings = _store.GetSettings();
+                var serviceControlManager = HostContext.GetService<ILinuxServiceControlManager>();
+                serviceControlManager.GenerateScripts(settings);
                 
                 return;
 #else
                 throw new NotSupportedException("--generateServiceConfig is only supported in Linux.");
 #endif
             }
-
 
             if (IsConfigured())
             {

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -81,6 +81,21 @@ namespace GitHub.Runner.Listener.Configuration
             _term.WriteLine("--------------------------------------------------------------------------------");
 
             Trace.Info(nameof(ConfigureAsync));
+
+#if OS_LINUX
+            if (command.GenerateServiceConfig)
+            {
+                if (!IsConfigured())
+                {
+                    throw new InvalidOperationException("--generateServiceConfig requires that the runner is already configured. For configuring a new runner as a service, run './config.sh'.");
+                }
+                // generate service config script for OSX and Linux, GenerateScripts() will no-opt on windows.
+                RunnerSettings _runnerSettings = new();
+                var _serviceControlManager = HostContext.GetService<ILinuxServiceControlManager>();
+                _serviceControlManager.GenerateScripts(_runnerSettings);
+            }
+#endif
+
             if (IsConfigured())
             {
                 throw new InvalidOperationException("Cannot configure the runner because it is already configured. To reconfigure the runner, run 'config.cmd remove' or './config.sh remove' first.");

--- a/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
+++ b/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
@@ -235,6 +235,7 @@ namespace GitHub.Runner.Common.Tests.Listener.Configuration
             }
         }
 
+#if OS_LINUX
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "ConfigurationManagement")]
@@ -269,7 +270,7 @@ namespace GitHub.Runner.Common.Tests.Listener.Configuration
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "ConfigurationManagement")]
-        public async Task ConfigureRunnerServiceCreatesServiceFileOnLinux()
+        public async Task ConfigureRunnerServiceCreatesService()
         {
             using (TestHostContext tc = CreateTestContext())
             {
@@ -288,13 +289,13 @@ namespace GitHub.Runner.Common.Tests.Listener.Configuration
                        "--generateServiceConfig",
                     });
                 trace.Info("Constructed");
+
                 _store.Setup(x => x.IsConfigured()).Returns(true);
 
                 trace.Info("Ensuring service generation mode fails when on un-configured runners");
-                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => configManager.ConfigureAsync(command));
-
-                Assert.Contains("requires that the runner is already configured", ex.Message);
+                await configManager.ConfigureAsync(command);
             }
         }
+#endif
     }
 }

--- a/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
+++ b/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
@@ -295,7 +295,7 @@ namespace GitHub.Runner.Common.Tests.Listener.Configuration
                 trace.Info("Ensuring service generation mode fails when on un-configured runners");
                 await configManager.ConfigureAsync(command);
 
-                _runnerServer.Verify(x => x.GenerateScripts(It.IsAny<RunnerSettings>()), Times.Once);
+                _serviceControlManager.Verify(x => x.GenerateScripts(It.IsAny<RunnerSettings>()), Times.Once);
             }
         }
 #endif


### PR DESCRIPTION
For runners that are already configured but need to add systemd services after the fact, a new command option is added to generate the file only. Once generated, `./svc.sh install` and other commands will be available.

This also adds support for falling back to the tenant name in the Actions URL in cases when the GitHub URL is not provided, such as for our hosted larger runners.