### PR TITLE
run.sh installs SIGINT and SIGTERM traps to gracefully stop runner

### DIFF
--- a/src/Misc/layoutroot/run.sh
+++ b/src/Misc/layoutroot/run.sh
@@ -9,11 +9,22 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
     [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
 # run the helper process which keep the listener alive
 while :;
 do
+    # Set job control
+    set -m
+    # On SIGINT or SIGTERM, send SIGINT to Runner.Listener
+    trap "pkill -2 Runner.Listener" INT TERM
+
     cp -f "$DIR"/run-helper.sh.template "$DIR"/run-helper.sh
-    "$DIR"/run-helper.sh $*
+    "$DIR"/run-helper.sh $* &
+    PID=$!
+    wait $PID
+    trap - INT TERM
+    wait $PID
+
     returnCode=$?
     if [[ $returnCode -eq 2 ]]; then
         echo "Restarting runner..."

--- a/src/Misc/layoutroot/run.sh
+++ b/src/Misc/layoutroot/run.sh
@@ -53,8 +53,8 @@ runWithManualTrap() {
     done
 }
 
-if [[ $RUNNER_MANUALLY_TRAP_SIG == "true" ]]; then
-    runWithManualTrap
+if [[ -z "$RUNNER_MANUALLY_TRAP_SIG" ]]; then
+   run
 else
-    run
+    runWithManualTrap
 fi


### PR DESCRIPTION
When the runner is started in a Docker container, run.sh does not propagate a signal to shut down the runner gracefully. A workaround with `dumb-init` for example was used to propagate signals to shut down the runner gracefully.

This change should install SIGINT and SIGTERM traps, and sends the INT to the `run-helper.sh` that will propagate it to the `Runner.Listener`.