### PR TITLE
Allow the container.image to be empty

### DIFF
--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -220,6 +220,11 @@ namespace GitHub.Runner.Worker
                         {
                             var networkAlias = pair.Key;
                             var serviceContainer = pair.Value;
+                            if (serviceContainer == null)
+                            {
+                                context.Output($"The service '{networkAlias}' will not be started because the container definition has an empty image.");
+                                continue;
+                            }
                             jobContext.Global.ServiceContainers.Add(new Container.ContainerInfo(HostContext, serviceContainer, false, networkAlias));
                         }
                     }

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -233,7 +233,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             return result;
         }
 
-        internal static JobContainer ConvertToContainer(
+        internal static JobContainer ConvertToJobContainer(
             TemplateContext context,
             TemplateToken value,
             bool allowExpressions = false)
@@ -341,14 +341,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             foreach (var servicePair in servicesMapping)
             {
                 var networkAlias = servicePair.Key.AssertString("services key").Value;
-                var container = ConvertToContainer(context, servicePair.Value);
-
-                if (container == null)
-                {
-                    context.TraceWriter.Info($"An image was not found in the container definition for service with key '${ networkAlias }'. This service will not be started.");
-                    continue;
-                }
-
+                var container = ConvertToJobContainer(context, servicePair.Value);
                 result.Add(new KeyValuePair<String, JobContainer>(networkAlias, container));
             }
 

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -326,9 +326,15 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
 
         internal static List<KeyValuePair<String, JobContainer>> ConvertToJobServiceContainers(
             TemplateContext context,
-            TemplateToken services)
+            TemplateToken services,
+            bool allowExpressions = false)
         {
             var result = new List<KeyValuePair<String, JobContainer>>();
+
+            if (allowExpressions && services.Traverse().Any(x => x is ExpressionToken))
+            {
+                return result;
+            }
 
             var servicesMapping = services.AssertMapping("services");
 

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -316,6 +316,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
 
             if (String.IsNullOrEmpty(result.Image))
             {
+                context.TraceWriter.Info($"Container image is empty, no jobContainer will be started.");
                 return null;
             }
 

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -248,7 +248,6 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             {
                 if (String.IsNullOrEmpty(containerLiteral.Value))
                 {
-                    context.TraceWriter.Info($"Container value is empty, ignoring.");
                     return null;
                 }
 
@@ -317,7 +316,6 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
 
             if (String.IsNullOrEmpty(result.Image))
             {
-                context.TraceWriter.Info($"Container image is empty, ignoring.");
                 return null;
             }
 

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -248,6 +248,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             {
                 if (String.IsNullOrEmpty(containerLiteral.Value))
                 {
+                    context.TraceWriter.Info($"Container value is empty, this container will not be started.");
                     return null;
                 }
 
@@ -316,7 +317,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
 
             if (String.IsNullOrEmpty(result.Image))
             {
-                context.TraceWriter.Info($"Container image is empty, no jobContainer will be started.");
+                context.TraceWriter.Info($"Container image is empty, this container will not be started.");
                 return null;
             }
 
@@ -335,6 +336,13 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             {
                 var networkAlias = servicePair.Key.AssertString("services key").Value;
                 var container = ConvertToContainer(context, servicePair.Value);
+
+                if (container == null)
+                {
+                    context.TraceWriter.Info($"Service container with key ${ networkAlias } cannot be parsed, this container will not be started.");
+                    continue;
+                }
+
                 result.Add(new KeyValuePair<String, JobContainer>(networkAlias, container));
             }
 

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -325,15 +325,9 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
 
         internal static List<KeyValuePair<String, JobContainer>> ConvertToJobServiceContainers(
             TemplateContext context,
-            TemplateToken services,
-            bool allowExpressions = false)
+            TemplateToken services)
         {
             var result = new List<KeyValuePair<String, JobContainer>>();
-
-            if (allowExpressions && services.Traverse().Any(x => x is ExpressionToken))
-            {
-                return result;
-            }
 
             var servicesMapping = services.AssertMapping("services");
 

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -248,7 +248,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             {
                 if (String.IsNullOrEmpty(containerLiteral.Value))
                 {
-                    context.TraceWriter.Info($"Container value is empty, this container will not be started.");
+                    context.TraceWriter.Info($"Container value is empty, ignoring.");
                     return null;
                 }
 
@@ -317,7 +317,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
 
             if (String.IsNullOrEmpty(result.Image))
             {
-                context.TraceWriter.Info($"Container image is empty, this container will not be started.");
+                context.TraceWriter.Info($"Container image is empty, ignoring.");
                 return null;
             }
 
@@ -339,7 +339,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
 
                 if (container == null)
                 {
-                    context.TraceWriter.Info($"Service container with key ${ networkAlias } cannot be parsed, this container will not be started.");
+                    context.TraceWriter.Info($"An image was not found in the container definition for service with key '${ networkAlias }'. This service will not be started.");
                     continue;
                 }
 

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -233,7 +233,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             return result;
         }
 
-        internal static JobContainer ConvertToJobContainer(
+        internal static JobContainer ConvertToContainer(
             TemplateContext context,
             TemplateToken value,
             bool allowExpressions = false)
@@ -340,7 +340,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
             foreach (var servicePair in servicesMapping)
             {
                 var networkAlias = servicePair.Key.AssertString("services key").Value;
-                var container = ConvertToJobContainer(context, servicePair.Value);
+                var container = ConvertToContainer(context, servicePair.Value);
                 result.Add(new KeyValuePair<String, JobContainer>(networkAlias, container));
             }
 

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -316,7 +316,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
 
             if (String.IsNullOrEmpty(result.Image))
             {
-                context.Error(value, "Container image cannot be empty");
+                return null;
             }
 
             return result;

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateEvaluator.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateEvaluator.cs
@@ -230,10 +230,6 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                     token = TemplateEvaluator.Evaluate(context, PipelineTemplateConstants.Container, token, 0, null, omitHeader: true);
                     context.Errors.Check();
                     result = PipelineTemplateConverter.ConvertToJobContainer(context, token);
-                    if (result == null)
-                    {
-                        context.TraceWriter.Info("A job container was requested in the job definition but the container image value was empty. The job will run without a job container.");
-                    }
                 }
                 catch (Exception ex) when (!(ex is TemplateValidationException))
                 {

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateEvaluator.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateEvaluator.cs
@@ -229,7 +229,11 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                 {
                     token = TemplateEvaluator.Evaluate(context, PipelineTemplateConstants.Container, token, 0, null, omitHeader: true);
                     context.Errors.Check();
-                    result = PipelineTemplateConverter.ConvertToJobContainer(context, token);
+                    result = PipelineTemplateConverter.ConvertToContainer(context, token);
+                    if (result == null)
+                    {
+                        context.TraceWriter.Info("A job container was requested in the job definition but the container image value was empty. The job will run without a job container.");
+                    }
                 }
                 catch (Exception ex) when (!(ex is TemplateValidationException))
                 {

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateEvaluator.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateEvaluator.cs
@@ -229,7 +229,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                 {
                     token = TemplateEvaluator.Evaluate(context, PipelineTemplateConstants.Container, token, 0, null, omitHeader: true);
                     context.Errors.Check();
-                    result = PipelineTemplateConverter.ConvertToContainer(context, token);
+                    result = PipelineTemplateConverter.ConvertToJobContainer(context, token);
                     if (result == null)
                     {
                         context.TraceWriter.Info("A job container was requested in the job definition but the container image value was empty. The job will run without a job container.");

--- a/src/Sdk/DTPipelines/workflow-v1.0.json
+++ b/src/Sdk/DTPipelines/workflow-v1.0.json
@@ -415,21 +415,8 @@
       ],
       "one-of": [
         "non-empty-string",
-        "services-container-mapping"
+        "container-mapping"
       ]
-    },
-
-    "services-container-mapping": {
-      "mapping": {
-        "properties": {
-          "image": "non-empty-string",
-          "options": "non-empty-string",
-          "env": "container-env",
-          "ports": "sequence-of-non-empty-string",
-          "volumes": "sequence-of-non-empty-string",
-          "credentials": "container-registry-credentials"
-        }
-      }
     },
 
     "container-registry-credentials": {

--- a/src/Sdk/DTPipelines/workflow-v1.0.json
+++ b/src/Sdk/DTPipelines/workflow-v1.0.json
@@ -414,7 +414,7 @@
         "vars"
       ],
       "one-of": [
-        "non-empty-string",
+        "string",
         "container-mapping"
       ]
     },

--- a/src/Sdk/DTPipelines/workflow-v1.0.json
+++ b/src/Sdk/DTPipelines/workflow-v1.0.json
@@ -381,7 +381,7 @@
     "container-mapping": {
       "mapping": {
         "properties": {
-          "image": "non-empty-string",
+          "image": "string",
           "options": "non-empty-string",
           "env": "container-env",
           "ports": "sequence-of-non-empty-string",
@@ -415,8 +415,21 @@
       ],
       "one-of": [
         "non-empty-string",
-        "container-mapping"
+        "services-container-mapping"
       ]
+    },
+
+    "services-container-mapping": {
+      "mapping": {
+        "properties": {
+          "image": "non-empty-string",
+          "options": "non-empty-string",
+          "env": "container-env",
+          "ports": "sequence-of-non-empty-string",
+          "volumes": "sequence-of-non-empty-string",
+          "credentials": "container-registry-credentials"
+        }
+      }
     },
 
     "container-registry-credentials": {


### PR DESCRIPTION
coauthor: @fhammerl 

Allow the job container image to be empty. No job container will be started. Logged when the secret ACTIONS_RUNNER_DEBUG is set to true
Allow the service image to be empty. No service will be started. Logged when the secret ACTIONS_RUNNER_DEBUG is set to true 

An example with a job container:
```
jobs:
...
runs-on: ubuntu-latest
    container: 
      image: ${{ matrix.docker-image }}
```
If the expression ${{ matrix.docker-image }} evaluates to an empty string, the job will still execute without the job container.
Closes https://github.com/actions/runner/pull/2025


Tests / log changes:

#L51 #L52
![image](https://user-images.githubusercontent.com/31069338/199275752-835bd566-687d-4f0f-8d98-73b7f9cd0ba0.png)



