### PR TITLE
Expose GITHUB_JOB_DISPLAY_NAME in the environment

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -749,6 +749,10 @@ namespace GitHub.Runner.Worker
             {
                 githubContext["job"] = new StringContextData(githubJob);
             }
+            if (!string.IsNullOrEmpty(message.JobDisplayName))
+            {
+                githubContext["job_display_name"] = new StringContextData(message.JobDisplayName);
+            }
             var githubDictionary = ExpressionValues["github"].AssertDictionary("github");
             foreach (var pair in githubDictionary)
             {

--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -21,6 +21,7 @@ namespace GitHub.Runner.Worker
             "graphql_url",
             "head_ref",
             "job",
+            "job_display_name",
             "output",
             "path",
             "ref_name",


### PR DESCRIPTION
Hello 👋 I've been working a bit with GitHub Actions and the GitHub REST API and was finding it, in some cases, challenging to align the jobs that are running with the jobs that are returned in the API. One such reason is because there's a mismatch where the API returns the job's database identifier and display name, but the runner only has the YAML key for the job. By exposing the job display name, this will help get _closer_ to being able to line up a job running via the Actions runner to a job returned in the API (albeit not perfectly, as job display names need not be unique; separately, I've opened an issue with GitHub support to see if it'd be possible to return the YAML key in the API).

I'm happy to make changes/improvements/consider alternatives here, but this was a first pass (following similar work done in https://github.com/actions/runner/pull/366) that I was hoping could spark some conversation. I'd really _prefer_ to have the job ID in the environment so I could make this API call from an action, but I suspect there's an architectural reason precluding that:

```sh
gh api repos/{owner}/{repo}/actions/jobs/{job_id}
```

**Some screenshots of this working**:

<img width="467" alt="Screen Shot 2022-11-01 at 12 48 35 PM" src="https://user-images.githubusercontent.com/6563105/199291250-529b6a2a-4e4c-48e1-9e30-e4a55c993215.png">
<img width="474" alt="Screen Shot 2022-11-01 at 12 48 24 PM" src="https://user-images.githubusercontent.com/6563105/199291238-a5526049-fc12-448b-8329-15c9d16a0e0e.png">
