### PR TITLE
Made worker logs available to stdout

### DIFF
--- a/src/Runner.Common/Terminal.cs
+++ b/src/Runner.Common/Terminal.cs
@@ -18,7 +18,7 @@ namespace GitHub.Runner.Common
         string ReadSecret();
         void Write(string message, ConsoleColor? colorCode = null);
         void WriteLine();
-        void WriteLine(string line, ConsoleColor? colorCode = null);
+        void WriteLine(string line, ConsoleColor? colorCode = null, bool skipTracing = false);
         void WriteError(Exception ex);
         void WriteError(string line);
         void WriteSection(string message);
@@ -116,9 +116,12 @@ namespace GitHub.Runner.Common
 
         // Do not add a format string overload. Terminal messages are user facing and therefore
         // should be localized. Use the Loc method in the StringUtil class.
-        public void WriteLine(string line, ConsoleColor? colorCode = null)
+        public void WriteLine(string line, ConsoleColor? colorCode = null, bool skipTracing = false)
         {
-            Trace.Info($"WRITE LINE: {line}");
+            if (!skipTracing)
+            {
+                Trace.Info($"WRITE LINE: {line}");
+            }
             if (!Silent)
             {
                 if (colorCode != null)

--- a/src/Runner.Listener/JobDispatcher.cs
+++ b/src/Runner.Listener/JobDispatcher.cs
@@ -512,14 +512,14 @@ namespace GitHub.Runner.Listener
                             var completedTask = await Task.WhenAny(renewJobRequest, workerProcessTask, Task.Delay(-1, jobRequestCancellationToken));
                             if (completedTask == workerProcessTask)
                             {
+                                var detailInfo = string.Join(Environment.NewLine, workerOutput);
+                                Trace.Info(detailInfo);
                                 // worker finished successfully, complete job request with result, attach unhandled exception reported by worker, stop renew lock, job has finished.
                                 int returnCode = await workerProcessTask;
                                 Trace.Info($"Worker finished for job {message.JobId}. Code: " + returnCode);
 
-                                string detailInfo = null;
                                 if (!TaskResultUtil.IsValidReturnCode(returnCode))
                                 {
-                                    detailInfo = string.Join(Environment.NewLine, workerOutput);
                                     Trace.Info($"Return code {returnCode} indicate worker encounter an unhandled exception or app crash, attach worker stdout/stderr to JobRequest result.");
 
                                     var jobServer = HostContext.GetService<IJobServer>();


### PR DESCRIPTION
Solves the Worker part needed for https://github.com/github/c2c-actions-runtime/issues/2065

Console sample
<img width="1296" alt="Screenshot 2022-12-08 at 19 15 17" src="https://user-images.githubusercontent.com/11218015/206534819-f24ba2e2-beb0-40fb-8f7a-676409f62b4c.png">

Runner logs file sample
<img width="1214" alt="Screenshot 2022-12-08 at 19 15 54" src="https://user-images.githubusercontent.com/11218015/206534928-03acc377-c8c5-4eff-a17c-bb98c31972e6.png">

Worker logs file sample
<img width="1293" alt="Screenshot 2022-12-08 at 19 17 14" src="https://user-images.githubusercontent.com/11218015/206535014-2af6d189-ef20-4a56-9a42-9cbfbed6bbe0.png">

