### PR TITLE
Add proxy authentication and buffer request for WinHttpHandler

### DIFF
--- a/src/Sdk/Common/Common/RawClientHttpRequestSettings.cs
+++ b/src/Sdk/Common/Common/RawClientHttpRequestSettings.cs
@@ -184,8 +184,32 @@ namespace GitHub.Services.Common
             return settings;
         }
 
+        /// <summary>
+        /// Gets or sets the maximum size allowed for response content buffering.
+        /// </summary>
+        [DefaultValue(c_defaultContentBufferSize)]
+        public Int32 MaxContentBufferSize
+        {
+            get
+            {
+                return m_maxContentBufferSize;
+            }
+            set
+            {
+                ArgumentUtility.CheckForOutOfRange(value, nameof(value), 0, c_maxAllowedContentBufferSize);
+                m_maxContentBufferSize = value;
+            }
+        }
+
         private static Lazy<RawClientHttpRequestSettings> s_defaultSettings
             = new Lazy<RawClientHttpRequestSettings>(ConstructDefaultSettings);
+
+        private Int32 m_maxContentBufferSize;
+        // We will buffer a maximum of 1024MB in the message handler
+        private const Int32 c_maxAllowedContentBufferSize = 1024 * 1024 * 1024;
+
+        // We will buffer, by default, up to 512MB in the message handler
+        private const Int32 c_defaultContentBufferSize = 1024 * 1024 * 512;
 
         private const Int32 c_defaultMaxRetry = 3;
         private static readonly TimeSpan s_defaultTimeout = TimeSpan.FromSeconds(100); //default WebAPI timeout

--- a/src/Sdk/Common/Common/RawHttpMessageHandler.cs
+++ b/src/Sdk/Common/Common/RawHttpMessageHandler.cs
@@ -120,6 +120,7 @@ namespace GitHub.Services.Common
             Boolean succeeded = false;
             HttpResponseMessageWrapper responseWrapper;
 
+            Boolean lastResponseDemandedProxyAuth = false;
             Int32 retries = m_maxAuthRetries;
             try
             {
@@ -138,7 +139,13 @@ namespace GitHub.Services.Common
 
                     // Let's start with sending a token
                     IssuedToken token = await m_tokenProvider.GetTokenAsync(null, tokenSource.Token).ConfigureAwait(false);
-                    ApplyToken(request, token);
+                    ApplyToken(request, token, applyICredentialsToWebProxy: lastResponseDemandedProxyAuth);
+
+                    // The WinHttpHandler will chunk any content that does not have a computed length which is
+                    // not what we want. By loading into a buffer up-front we bypass this behavior and there is
+                    // no difference in the normal HttpClientHandler behavior here since this is what they were
+                    // already doing.
+                    await BufferRequestContentAsync(request, tokenSource.Token).ConfigureAwait(false);
 
                     // ConfigureAwait(false) enables the continuation to be run outside any captured
                     // SyncronizationContext (such as ASP.NET's) which keeps things from deadlocking...
@@ -147,7 +154,8 @@ namespace GitHub.Services.Common
                     responseWrapper = new HttpResponseMessageWrapper(response);
 
                     var isUnAuthorized = responseWrapper.StatusCode == HttpStatusCode.Unauthorized;
-                    if (!isUnAuthorized)
+                    lastResponseDemandedProxyAuth = responseWrapper.StatusCode == HttpStatusCode.ProxyAuthenticationRequired;
+                    if (!isUnAuthorized && !lastResponseDemandedProxyAuth)
                     {
                         // Validate the token after it has been successfully authenticated with the server.
                         m_tokenProvider?.ValidateToken(token, responseWrapper);
@@ -211,15 +219,42 @@ namespace GitHub.Services.Common
             }
         }
 
+       private static async Task BufferRequestContentAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.Content != null &&
+                request.Headers.TransferEncodingChunked != true)
+            {
+                Int64? contentLength = request.Content.Headers.ContentLength;
+                if (contentLength == null)
+                {
+                    await request.Content.LoadIntoBufferAsync().EnforceCancellation(cancellationToken).ConfigureAwait(false);
+                }
+
+                // Explicitly turn off chunked encoding since we have computed the request content size
+                request.Headers.TransferEncodingChunked = false;
+            }
+        }
+
         private void ApplyToken(
             HttpRequestMessage request,
-            IssuedToken token)
+            IssuedToken token,
+            bool applyICredentialsToWebProxy = false)
         {
             switch (token)
             {
                 case null:
                     return;
                 case ICredentials credentialsToken:
+                    if (applyICredentialsToWebProxy)
+                    {
+                        HttpClientHandler httpClientHandler = m_transportHandler as HttpClientHandler;
+                        if (httpClientHandler != null && httpClientHandler.Proxy != null)
+                        {
+                            httpClientHandler.Proxy.Credentials = credentialsToken;
+                        }
+                    }
                     m_credentialWrapper.InnerCredentials = credentialsToken;
                     break;
                 default:

--- a/src/Sdk/Common/Common/VssHttpMessageHandler.cs
+++ b/src/Sdk/Common/Common/VssHttpMessageHandler.cs
@@ -16,7 +16,7 @@ namespace GitHub.Services.Common
     public class VssHttpMessageHandler : HttpMessageHandler
     {
         /// <summary>
-        /// Initializes a new <c>VssHttpMessageHandler</c> instance with default credentials and request 
+        /// Initializes a new <c>VssHttpMessageHandler</c> instance with default credentials and request
         /// settings.
         /// </summary>
         public VssHttpMessageHandler()
@@ -25,7 +25,7 @@ namespace GitHub.Services.Common
         }
 
         /// <summary>
-        /// Initializes a new <c>VssHttpMessageHandler</c> instance with the specified credentials and request 
+        /// Initializes a new <c>VssHttpMessageHandler</c> instance with the specified credentials and request
         /// settings.
         /// </summary>
         /// <param name="credentials">The credentials which should be used</param>
@@ -38,7 +38,7 @@ namespace GitHub.Services.Common
         }
 
         /// <summary>
-        /// Initializes a new <c>VssHttpMessageHandler</c> instance with the specified credentials and request 
+        /// Initializes a new <c>VssHttpMessageHandler</c> instance with the specified credentials and request
         /// settings.
         /// </summary>
         /// <param name="credentials">The credentials which should be used</param>
@@ -211,14 +211,14 @@ namespace GitHub.Services.Common
 
                     traceInfo?.TraceBufferedRequestTime();
 
-                    // ConfigureAwait(false) enables the continuation to be run outside any captured 
+                    // ConfigureAwait(false) enables the continuation to be run outside any captured
                     // SyncronizationContext (such as ASP.NET's) which keeps things from deadlocking...
                     response = await m_messageInvoker.SendAsync(request, tokenSource.Token).ConfigureAwait(false);
 
                     traceInfo?.TraceRequestSendTime();
 
                     // Now buffer the response content if configured to do so. In general we will be buffering
-                    // the response content in this location, except in the few cases where the caller has 
+                    // the response content in this location, except in the few cases where the caller has
                     // specified HttpCompletionOption.ResponseHeadersRead.
                     // Trace content type in case of error
                     await BufferResponseContentAsync(request, response, () => $"[ContentType: {response.Content.GetType().Name}]", tokenSource.Token).ConfigureAwait(false);
@@ -235,7 +235,7 @@ namespace GitHub.Services.Common
                             provider.ValidateToken(token, responseWrapper);
                         }
 
-                        // Make sure that once we can authenticate with the service that we turn off the 
+                        // Make sure that once we can authenticate with the service that we turn off the
                         // Expect100Continue behavior to increase performance.
                         this.ExpectContinue = false;
                         succeeded = true;
@@ -281,8 +281,8 @@ namespace GitHub.Services.Common
                         }
 
                         // If the user has already tried once but still unauthorized, stop retrying. The main scenario for this condition
-                        // is a user typed in a valid credentials for a hosted account but the associated identity does not have 
-                        // access. We do not want to continually prompt 3 times without telling them the failure reason. In the 
+                        // is a user typed in a valid credentials for a hosted account but the associated identity does not have
+                        // access. We do not want to continually prompt 3 times without telling them the failure reason. In the
                         // next release we should rethink about presenting user the failure and options between retries.
                         IEnumerable<String> headerValues;
                         Boolean hasAuthenticateError =
@@ -489,7 +489,7 @@ namespace GitHub.Services.Common
                 httpClientHandler.AllowAutoRedirect = settings.AllowAutoRedirect;
                 httpClientHandler.ClientCertificateOptions = ClientCertificateOption.Manual;
                 //Setting httpClientHandler.UseDefaultCredentials to false in .Net Core, clears httpClientHandler.Credentials if
-                //credentials is already set to defaultcredentials. Therefore httpClientHandler.Credentials must be 
+                //credentials is already set to defaultcredentials. Therefore httpClientHandler.Credentials must be
                 //set after httpClientHandler.UseDefaultCredentials.
                 httpClientHandler.UseDefaultCredentials = false;
                 httpClientHandler.Credentials = defaultCredentials;

--- a/src/Sdk/Common/Common/VssHttpRequestSettings.cs
+++ b/src/Sdk/Common/Common/VssHttpRequestSettings.cs
@@ -102,7 +102,7 @@ namespace GitHub.Services.Common
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not HttpClientHandler should follow redirect on outgoing requests. 
+        /// Gets or sets a value indicating whether or not HttpClientHandler should follow redirect on outgoing requests.
         /// </summary>
         public Boolean AllowAutoRedirect
         {
@@ -111,7 +111,7 @@ namespace GitHub.Services.Common
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not compression should be used on outgoing requests. 
+        /// Gets or sets a value indicating whether or not compression should be used on outgoing requests.
         /// The default value is true.
         /// </summary>
         [DefaultValue(true)]


### PR DESCRIPTION
Adding proxy authentication and request buffering support to `RawHttpMessageHandler`, based on code from `VssHttpMessageHandler`.