### PR TITLE
Initialize container manager based on whether the ContainerHooksPath is  set

### DIFF
--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -33,8 +33,14 @@ namespace GitHub.Runner.Worker
         public override void Initialize(IHostContext hostContext)
         {
             base.Initialize(hostContext);
-            _dockerManager = HostContext.GetService<IDockerCommandManager>();
-            _containerHookManager = HostContext.GetService<IContainerHookManager>();
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.Hooks.ContainerHooksPath)))
+            {
+                _dockerManager = HostContext.GetService<IDockerCommandManager>();
+            }
+            else
+            {
+                _containerHookManager = HostContext.GetService<IContainerHookManager>();
+            }
         }
 
         public async Task StartContainersAsync(IExecutionContext executionContext, object data)

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -38,8 +38,17 @@ namespace GitHub.Runner.Worker.Handlers
             // Update the env dictionary.
             AddInputsToEnvironment();
 
-            var dockerManager = HostContext.GetService<IDockerCommandManager>();
-            var containerHookManager = HostContext.GetService<IContainerHookManager>();
+            IDockerCommandManager dockerManager = null;
+            IContainerHookManager containerHookManager = null;
+            if (FeatureManager.IsContainerHooksEnabled(ExecutionContext.Global.Variables))
+            {
+                containerHookManager = HostContext.GetService<IContainerHookManager>();
+            }
+            else
+            {
+                dockerManager = HostContext.GetService<IDockerCommandManager>();
+            }
+
             string dockerFile = null;
 
             // container image haven't built/pull


### PR DESCRIPTION
When the operation provider is called, it initializes both the dockerManager and the containerHookManager.
The dockerManager will call `which` on docker, which can cause initialization to fail. 

The fix should relax the docker cli dependency if the runner is going to use container hooks.

Related to the issue in runner-container-hooks: https://github.com/actions/runner-container-hooks/issues/30