### PR TITLE
Re-add file size check prior to reading file

### DIFF
--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -182,6 +182,14 @@ namespace GitHub.Runner.Worker
                     return;
                 }
 
+                if (fileSize > AttachmentSizeLimit)
+                {
+                    context.Error(String.Format(Constants.Runner.UnsupportedSummarySize, AttachmentSizeLimit / 1024, fileSize / 1024));
+                    Trace.Info($"Step Summary file ({filePath}) is too large ({fileSize} bytes); skipping attachment upload");
+
+                    return;
+                }
+
                 Trace.Verbose($"Step Summary file exists: {filePath} and has a file size of {fileSize} bytes");
                 var scrubbedFilePath = filePath + "-scrubbed";
 

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -218,14 +218,6 @@ namespace GitHub.Runner.Worker
                 }
                 else
                 {
-                    if (fileSize > AttachmentSizeLimit)
-                    {
-                        context.Error(String.Format(Constants.Runner.UnsupportedSummarySize, AttachmentSizeLimit / 1024, fileSize / 1024));
-                        Trace.Info($"Step Summary file ({filePath}) is too large ({fileSize} bytes); skipping attachment upload");
-
-                        return;
-                    }
-
                     Trace.Info($"Queueing file ({filePath}) for attachment upload ({attachmentName})");
                     // Attachments must be added to the parent context (job), not the current context (step)
                     context.Root.QueueAttachFile(ChecksAttachmentType.StepSummary, attachmentName, scrubbedFilePath);


### PR DESCRIPTION
The job hangs when uploading a large summary file since we had moved a file size check to another location. We suspect it has to do with `MaskSecrets` reading the file, but we will re-add the check to fix the issue for the time being.

Prior to the change:
![SCR-20221216-hue](https://user-images.githubusercontent.com/9900117/208158712-6f005d51-90e6-46a3-9869-74bea204ac86.png)

After the change:
![SCR-20221216-hul](https://user-images.githubusercontent.com/9900117/208158730-03afee0b-5fc7-4391-92af-530c7c9219c1.png)
