### PR TITLE
Using VssHttpClient instead of RawHttpClient

### DIFF
--- a/src/Sdk/WebApi/WebApi/ResultsHttpClient.cs
+++ b/src/Sdk/WebApi/WebApi/ResultsHttpClient.cs
@@ -6,11 +6,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using GitHub.Services.Results.Contracts;
 using System.Net.Http.Formatting;
-using Sdk.WebApi.WebApi;
+using GitHub.Services.WebApi;
 
 namespace GitHub.Services.Results.Client
 {
-    public class ResultsHttpClient : RawHttpClientBase
+    public class ResultsHttpClient : VssHttpClientBase
     {
         public ResultsHttpClient(
             Uri baseUrl,


### PR DESCRIPTION
In order to take advantage of the proxy and ssl cert logic, we will use `VssHttpClientBase` instead of `RawHttpClientBase` for the time being since the vss client is production ready.