### PR TITLE
allow service account to bypass password prompt during configure command

### DIFF
--- a/src/Runner.Listener/Configuration/NativeWindowsServiceHelper.cs
+++ b/src/Runner.Listener/Configuration/NativeWindowsServiceHelper.cs
@@ -376,7 +376,8 @@ namespace GitHub.Runner.Listener.Configuration
 
             return sid.Equals(networkServiceSid) ||
                    sid.Equals(localServiceSid) ||
-                   sid.Equals(localSystemSid);
+                   sid.Equals(localSystemSid) ||
+                   accountName.EndsWith('$');
         }
 
         public bool IsValidCredential(string domain, string userName, string logonPassword)


### PR DESCRIPTION
This change will allow a service account to be entered as the configured username and bypass the password prompt.