### PR TITLE
Remove local runner config files with `--local` option

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -131,6 +131,7 @@ namespace GitHub.Runner.Common
                     public static readonly string Ephemeral = "ephemeral";
                     public static readonly string GenerateServiceConfig = "generateServiceConfig";
                     public static readonly string Help = "help";
+                    public static readonly string Local = "local";
                     public static readonly string Replace = "replace";
                     public static readonly string DisableUpdate = "disableupdate";
                     public static readonly string Once = "once"; // Keep this around since customers still relies on it

--- a/src/Runner.Listener/CommandSettings.cs
+++ b/src/Runner.Listener/CommandSettings.cs
@@ -56,7 +56,8 @@ namespace GitHub.Runner.Listener
                 new string[]
                 {
                     Constants.Runner.CommandLine.Args.Token,
-                    Constants.Runner.CommandLine.Args.PAT
+                    Constants.Runner.CommandLine.Args.PAT,
+                    Constants.Runner.CommandLine.Flags.Local
                 },
             // Valid run flags and args
             [Constants.Runner.CommandLine.Commands.Run] =
@@ -86,6 +87,7 @@ namespace GitHub.Runner.Listener
         public bool Help => TestFlag(Constants.Runner.CommandLine.Flags.Help);
         public bool Unattended => TestFlag(Constants.Runner.CommandLine.Flags.Unattended);
         public bool Version => TestFlag(Constants.Runner.CommandLine.Flags.Version);
+        public bool RemoveLocalConfig => TestFlag(Constants.Runner.CommandLine.Flags.Local);
 
         // Keep this around since customers still relies on it
         public bool RunOnce => TestFlag(Constants.Runner.CommandLine.Flags.Once);

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -135,6 +135,12 @@ namespace GitHub.Runner.Listener
                 // remove config files, remove service, and exit
                 if (command.Remove)
                 {
+                    // only remove local config files and exit
+                    if(command.RemoveLocalConfig)
+                    {
+                        configManager.DeleteLocalRunnerConfig();
+                        return Constants.Runner.ReturnCode.Success;
+                    }
                     try
                     {
                         await configManager.UnconfigureAsync(command);
@@ -647,6 +653,7 @@ Config Options:
  --name string          Name of the runner to configure (default {Environment.MachineName ?? "myrunner"})
  --runnergroup string   Name of the runner group to add this runner to (defaults to the default runner group)
  --labels string        Extra labels in addition to the default: 'self-hosted,{Constants.Runner.Platform},{Constants.Runner.PlatformArchitecture}'
+ --local                Removes the runner config files from your local machine. Used as an option to the remove command
  --work string          Relative runner work directory (default {Constants.Path.WorkDirectory})
  --replace              Replace any existing runner with the same name (default false)
  --pat                  GitHub personal access token with repo scope. Used for checking network connectivity when executing `.{separator}run.{ext} --check`

--- a/src/Test/L0/Listener/CommandSettingsL0.cs
+++ b/src/Test/L0/Listener/CommandSettingsL0.cs
@@ -824,6 +824,7 @@ namespace GitHub.Runner.Common.Tests
         [InlineData("remove", "version")]
         [InlineData("remove", "commit")]
         [InlineData("remove", "check")]
+        [InlineData("remove", "local")]
         [InlineData("run", "help")]
         [InlineData("run", "version")]
         [InlineData("run", "commit")]

--- a/src/Test/L0/Listener/RunnerL0.cs
+++ b/src/Test/L0/Listener/RunnerL0.cs
@@ -502,5 +502,34 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _messageListener.Verify(x => x.DeleteMessageAsync(It.IsAny<TaskAgentMessage>()), Times.Once());
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async void TestRemoveLocalRunnerConfig()
+        {
+            using (var hc = new TestHostContext(this))
+            {
+                hc.SetSingleton<IConfigurationManager>(_configurationManager.Object);
+                hc.SetSingleton<IConfigurationStore>(_configStore.Object);
+                hc.SetSingleton<IPromptManager>(_promptManager.Object);
+
+                var command = new CommandSettings(hc, new[] { "remove", "--local" });
+
+                _configStore.Setup(x => x.IsConfigured())
+                    .Returns(true);
+
+                _configStore.Setup(x => x.HasCredentials())
+                    .Returns(true);
+
+
+                var runner = new Runner.Listener.Runner();
+                runner.Initialize(hc);
+                await runner.ExecuteCommand(command);
+
+                // verify that we delete the local runner config with the correct remove parameter
+                _configurationManager.Verify(x => x.DeleteLocalRunnerConfig(), Times.Once());
+            }
+        }
     }
 }


### PR DESCRIPTION
**Background**
Currently when force removing the runner from the ui, the runner config files need to be manually removed to ensure the runner is no longer configured locally. Or the runner can be removed by using a removal token with `./config remove`

**Changes**
Added a new option, `--local`, when using `./config.sh remove`. This will remove the local runner files from the system without deregistering the runner from the server.

Closes #2061

Example: 
```bash
 /workspaces/runner/_layout $ ./config.sh remove --local
√ Removed .credentials
√ Removed .runner
```