### PR TITLE
Show more information in the runner log

### DIFF
--- a/docs/contribute/vscode.md
+++ b/docs/contribute/vscode.md
@@ -35,7 +35,7 @@ All the configs below can be found in `.vscode/launch.json`.
 If you launch `Run` or `Run [build]`, it starts a process called `Runner.Listener`.
 This process will receive any job queued on this repository if the job runs on matching labels (e.g `runs-on: self-hosted`).
 Once a job is received, a `Runner.Listener` starts a new process of `Runner.Worker`.
-Since this is a diferent process, you can't use the same debugger session debug it.
+Since this is a different process, you can't use the same debugger session debug it.
 Instead, a parallel debugging session has to be started, using a different launch config.
 Luckily, VS Code supports multiple parallel debugging sessions.
 

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -321,7 +321,13 @@ namespace GitHub.Runner.Worker
 
                     if (message.Variables.TryGetValue("system.workflowFileFullPath", out VariableValue workflowFileFullPath))
                     {
-                        context.Output($"Uses: {workflowFileFullPath.Value}");
+                        var usesOutput = $"Uses: {workflowFileFullPath.Value}";
+                        if (message.Variables.TryGetValue("system.workflowFileRef", out VariableValue workflowFileRef))
+                        {
+                            usesOutput += $"@{workflowFileRef.Value}";
+                        }
+                        context.Output(usesOutput);
+
                         if (message.ContextData.TryGetValue("inputs", out var pipelineContextData))
                         {
                             var inputs = pipelineContextData.AssertDictionary("inputs");

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -341,11 +341,11 @@ namespace GitHub.Runner.Worker
                                 context.Output("##[endgroup]");
                             }
                         }
+                    }
 
-                        if (!string.IsNullOrWhiteSpace(message.JobDisplayName)) 
-                        {
-                            context.Output($"Complete job name: {message.JobDisplayName}");
-                        }
+                    if (!string.IsNullOrWhiteSpace(message.JobDisplayName))
+                    {
+                        context.Output($"Complete job name: {message.JobDisplayName}");
                     }
 
                     var intraActionStates = new Dictionary<Guid, Dictionary<string, string>>();


### PR DESCRIPTION
To provide more information in the run log, add
 - the reference used when calling reusable workflows
 - the job name for both non-reusable/reusable workflow jobs

Actions service side PR: https://github.com/github/actions-dotnet/pull/14151

Related to https://github.com/github/actions-enablers-policy/issues/704