### PR TITLE
Pivot toward immutable `DistributedTask.WebApi::Issue` instances.

### DIFF
--- a/src/Runner.Common/JobServerQueue.cs
+++ b/src/Runner.Common/JobServerQueue.cs
@@ -299,7 +299,7 @@ namespace GitHub.Runner.Common
                         {
                             try
                             {
-                                // Give at most 60s for each request. 
+                                // Give at most 60s for each request.
                                 using (var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(60)))
                                 {
                                     await _jobServer.AppendTimelineRecordFeedAsync(_scopeIdentifier, _hubName, _planId, _jobTimelineId, _jobTimelineRecordId, stepRecordId, batch.Select(logLine => logLine.Line).ToList(), batch[0].LineNumber, timeoutTokenSource.Token);
@@ -600,8 +600,7 @@ namespace GitHub.Runner.Common
                 {
                     foreach (var issue in record.Issues)
                     {
-                        String source;
-                        issue.Data.TryGetValue("sourcepath", out source);
+                        string source = issue["sourcepath"];
                         Trace.Verbose($"        Issue: c={issue.Category}, t={issue.Type}, s={source ?? string.Empty}, m={issue.Message}");
                     }
                 }

--- a/src/Runner.Listener/JobDispatcher.cs
+++ b/src/Runner.Listener/JobDispatcher.cs
@@ -33,7 +33,7 @@ namespace GitHub.Runner.Listener
     // This implementation of IJobDispatcher is not thread safe.
     // It is based on the fact that the current design of the runner is a dequeue
     // and processes one message from the message queue at a time.
-    // In addition, it only executes one job every time, 
+    // In addition, it only executes one job every time,
     // and the server will not send another job while this one is still running.
     public sealed class JobDispatcher : RunnerService, IJobDispatcher
     {
@@ -426,7 +426,7 @@ namespace GitHub.Runner.Listener
                                                 {
                                                     workerOutput.Add(stdout.Data);
                                                 }
-                                                
+
                                                 if (printToStdout)
                                                 {
                                                     term.WriteLine(stdout.Data, skipTracing: true);
@@ -512,7 +512,7 @@ namespace GitHub.Runner.Listener
                         var accessToken = systemConnection?.Authorization?.Parameters["AccessToken"];
                         notification.JobStarted(message.JobId, accessToken, systemConnection.Url);
 
-                        HostContext.WritePerfCounter($"SentJobToWorker_{requestId.ToString()}");
+                        HostContext.WritePerfCounter($"SentJobToWorker_{requestId}");
 
                         try
                         {
@@ -620,7 +620,7 @@ namespace GitHub.Runner.Listener
                                 }
                             }
 
-                            // wait worker to exit 
+                            // wait worker to exit
                             // if worker doesn't exit within timeout, then kill worker.
                             completedTask = await Task.WhenAny(workerProcessTask, Task.Delay(-1, workerCancelTimeoutKillToken));
 
@@ -1014,7 +1014,7 @@ namespace GitHub.Runner.Listener
                 }
 
                 var unhandledExceptionIssue = new Issue() { Type = IssueType.Error, Message = errorMessage };
-                unhandledExceptionIssue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.WorkerCrash;
+                unhandledExceptionIssue[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.WorkerCrash;
                 jobRecord.ErrorCount++;
                 jobRecord.Issues.Add(unhandledExceptionIssue);
                 await jobServer.UpdateTimelineRecordsAsync(message.Plan.ScopeIdentifier, message.Plan.PlanType, message.Plan.PlanId, message.Timeline.Id, new TimelineRecord[] { jobRecord }, CancellationToken.None);

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -648,7 +648,7 @@ namespace GitHub.Runner.Worker
             var filteredDictionaryEntries = command.Properties
                                                    .Where(kvp => !string.Equals(kvp.Key, keyToExclude, StringComparison.OrdinalIgnoreCase));
 
-            var metadata = new IssueMetadata(issueCategory, false, filteredDictionaryEntries);
+            var metadata = new IssueMetadata(issueCategory, false, null, filteredDictionaryEntries);
             var issue = context.CreateIssue(this.Type, command.Data, metadata, true);
             context.AddIssue(issue);
         }

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -276,7 +276,7 @@ namespace GitHub.Runner.Worker
                         Message = $"Can't update {blocked} environment variable using ::set-env:: command."
                     };
                     issue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = $"{Constants.Runner.UnsupportedCommand}_{envName}";
-                    context.AddIssue(issue);
+                    context.AddIssue(issue, writeToLog: true);
 
                     return;
                 }
@@ -315,7 +315,7 @@ namespace GitHub.Runner.Worker
                     Message = String.Format(Constants.Runner.UnsupportedCommandMessage, this.Command)
                 };
                 issue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.UnsupportedCommand;
-                context.AddIssue(issue);
+                context.AddIssue(issue, writeToLog: true);
             }
 
             if (!command.Properties.TryGetValue(SetOutputCommandProperties.Name, out string outputName) || string.IsNullOrEmpty(outputName))
@@ -350,7 +350,7 @@ namespace GitHub.Runner.Worker
                     Message = String.Format(Constants.Runner.UnsupportedCommandMessage, this.Command)
                 };
                 issue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.UnsupportedCommand;
-                context.AddIssue(issue);
+                context.AddIssue(issue, writeToLog: true);
             }
 
             if (!command.Properties.TryGetValue(SaveStateCommandProperties.Name, out string stateName) || string.IsNullOrEmpty(stateName))
@@ -666,7 +666,7 @@ namespace GitHub.Runner.Worker
                 }
             }
 
-            context.AddIssue(issue);
+            context.AddIssue(issue, writeToLog: true);
         }
 
         public static void ValidateLinesAndColumns(ActionCommand command, IExecutionContext context)

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -646,7 +646,8 @@ namespace GitHub.Runner.Worker
 
             string keyToExclude = Constants.Runner.InternalTelemetryIssueDataKey;
             var filteredDictionaryEntries = command.Properties
-                                                   .Where(kvp => !string.Equals(kvp.Key, keyToExclude, StringComparison.OrdinalIgnoreCase));
+                                                   .Where(kvp => !string.Equals(kvp.Key, keyToExclude, StringComparison.OrdinalIgnoreCase))
+                                                   .ToList();
 
             var metadata = new IssueMetadata(issueCategory, false, null, filteredDictionaryEntries);
             var issue = context.CreateIssue(this.Type, command.Data, metadata, true);

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
+using System.IO.Compression;     // required for OS_WINDOWS
 using System.Linq;
 using System.Net;
 using System.Net.Http;

--- a/src/Runner.Worker/DiagnosticLogManager.cs
+++ b/src/Runner.Worker/DiagnosticLogManager.cs
@@ -5,7 +5,6 @@ using System.IO.Compression;
 using GitHub.DistributedTask.WebApi;
 using System.Linq;
 using System.Globalization;
-using System.Threading.Tasks;
 using Pipelines = GitHub.DistributedTask.Pipelines;
 using GitHub.Runner.Common;
 using GitHub.Runner.Sdk;
@@ -32,7 +31,7 @@ namespace GitHub.Runner.Worker
     {
         private static string DateTimeFormat = "yyyyMMdd-HHmmss";
         public void UploadDiagnosticLogs(IExecutionContext executionContext,
-                                         IExecutionContext parentContext, 
+                                         IExecutionContext parentContext,
                                          Pipelines.AgentJobRequestMessage message,
                                          DateTime jobStartTimeUtc)
         {

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -586,14 +586,13 @@ namespace GitHub.Runner.Worker
 
             var result = new Issue() {
                 Type = issueType,
-                Category = metadata?.Category,
-                IsInfrastructureIssue = metadata?.IsInfrastructureIssue ?? false,
                 Message = refinedMessage,
             };
 
-
             if (metadata != null)
             {
+                result.Category = metadata.Category;
+                result.IsInfrastructureIssue = metadata.IsInfrastructureIssue;
                 foreach (var kvp in metadata.Data)
                 {
                     result[kvp.Key] = kvp.Value;

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -620,10 +620,15 @@ namespace GitHub.Runner.Worker
 
             if (!string.IsNullOrEmpty(wellKnownTag))
             {
-                if (writeToLog && !string.IsNullOrEmpty(refinedMessage))
+                if (writeToLog)
                 {
-                    long logLineNumber = Write(wellKnownTag, refinedMessage);
-                    result.Data["logFileLineNumber"] = logLineNumber.ToString();
+                    //Note that ::Write() has it's own secret masking logic
+                    string logText = metadata?.LogMessageOverride ?? result.Message;
+                    if (!string.IsNullOrEmpty(logText))
+                    {
+                        long logLineNumber = Write(wellKnownTag, logText);
+                        result.Data["logFileLineNumber"] = logLineNumber.ToString();
+                    }
                 }
                 if (previousCountForIssueType.GetValueOrDefault(0) < _maxIssueCount)
                 {
@@ -1192,7 +1197,7 @@ namespace GitHub.Runner.Worker
         // Do not add a format string overload. See comment on ExecutionContext.Write().
         public static void InfrastructureError(this IExecutionContext context, string message)
         {
-            var metadata = new IssueMetadata(null, true, Enumerable.Empty<KeyValuePair<string, string>>());
+            var metadata = new IssueMetadata(null, true, null, Enumerable.Empty<KeyValuePair<string, string>>());
             var issue = context.CreateIssue(IssueType.Error, message, metadata, true);
             context.AddIssue(issue);
         }

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -591,13 +591,20 @@ namespace GitHub.Runner.Worker
                 Message = refinedMessage,
             };
 
-            result.Data.AddRangeIfRangeNotNull(metadata?.Data);
+
+            if (metadata != null)
+            {
+                foreach (var kvp in metadata.Data)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
 
             // It's important to keep track of the step number (key:stepNumber) and the line number (key:logFileLineNumber) of every issue that gets logged.
             // Actions UI from the run summary page use both values to easily link to an exact locations in logs where annotations originate from.
             if (_record.Order != null)
             {
-                result.Data["stepNumber"] = _record.Order.ToString();
+                result["stepNumber"] = _record.Order.ToString();
             }
 
             string wellKnownTag = null;
@@ -627,7 +634,7 @@ namespace GitHub.Runner.Worker
                     if (!string.IsNullOrEmpty(logText))
                     {
                         long logLineNumber = Write(wellKnownTag, logText);
-                        result.Data["logFileLineNumber"] = logLineNumber.ToString();
+                        result["logFileLineNumber"] = logLineNumber.ToString();
                     }
                 }
                 if (previousCountForIssueType.GetValueOrDefault(0) < _maxIssueCount)

--- a/src/Runner.Worker/Handlers/OutputManager.cs
+++ b/src/Runner.Worker/Handlers/OutputManager.cs
@@ -98,7 +98,7 @@ namespace GitHub.Runner.Worker.Handlers
                 var matchers = _matchers;
 
                 // Strip color codes
-                var stripped = line.Contains(_colorCodePrefix) ? _colorCodeRegex.Replace(line, string.Empty) : line;
+                var refinedLine = line.Contains(_colorCodePrefix) ? _colorCodeRegex.Replace(line, string.Empty) : line;
 
                 foreach (var matcher in matchers)
                 {
@@ -108,7 +108,7 @@ namespace GitHub.Runner.Worker.Handlers
                         // Match
                         try
                         {
-                            match = matcher.Match(stripped);
+                            match = matcher.Match(refinedLine);
                             break;
                         }
                         catch (RegexMatchTimeoutException ex)
@@ -116,7 +116,7 @@ namespace GitHub.Runner.Worker.Handlers
                             if (attempt < _maxAttempts)
                             {
                                 // Debug
-                                _executionContext.Debug($"Timeout processing issue matcher '{matcher.Owner}' against line '{stripped}'. Exception: {ex}");
+                                _executionContext.Debug($"Timeout processing issue matcher '{matcher.Owner}' against line '{refinedLine}'. Exception: {ex}");
                             }
                             else
                             {
@@ -324,7 +324,7 @@ namespace GitHub.Runner.Worker.Handlers
                 _executionContext.Debug($"Dropping file value '{match.File}' and fromPath value '{match.FromPath}'. Exception during validation: {ex}");
             }
 
-            var metadata = new IssueMetadata(null, false, issueData);
+            var metadata = new IssueMetadata(null, false, match.SourceText, issueData);
             var issue = _executionContext.CreateIssue(issueType, match.Message, metadata, true);
             return issue;
         }

--- a/src/Runner.Worker/Handlers/OutputManager.cs
+++ b/src/Runner.Worker/Handlers/OutputManager.cs
@@ -108,7 +108,6 @@ namespace GitHub.Runner.Worker.Handlers
                         try
                         {
                             match = matcher.Match(stripped);
-
                             break;
                         }
                         catch (RegexMatchTimeoutException ex)
@@ -116,7 +115,7 @@ namespace GitHub.Runner.Worker.Handlers
                             if (attempt < _maxAttempts)
                             {
                                 // Debug
-                                _executionContext.Debug($"Timeout processing issue matcher '{matcher.Owner}' against line '{stripped}'. Exception: {ex.ToString()}");
+                                _executionContext.Debug($"Timeout processing issue matcher '{matcher.Owner}' against line '{stripped}'. Exception: {ex}");
                             }
                             else
                             {
@@ -139,12 +138,10 @@ namespace GitHub.Runner.Worker.Handlers
 
                         // Convert to issue
                         var issue = ConvertToIssue(match);
-
                         if (issue != null)
                         {
                             // Log issue
-                            _executionContext.AddIssue(issue, stripped);
-
+                            _executionContext.AddIssue(issue, writeToLog: true);
                             return;
                         }
                     }

--- a/src/Runner.Worker/IssueMatcher.cs
+++ b/src/Runner.Worker/IssueMatcher.cs
@@ -24,7 +24,7 @@ namespace GitHub.Runner.Worker
 
             // Close-over the incoming IEnumerable to force immediate evaluation.
             var empty = Enumerable.Empty<KeyValuePair<string, string>>();
-            this.Data = new Dictionary<string, string>(data ?? empty);
+            this.Data = new Dictionary<string, string>(data ?? empty, StringComparer.OrdinalIgnoreCase);
         }
 
         public readonly string Category;

--- a/src/Runner.Worker/IssueMatcher.cs
+++ b/src/Runner.Worker/IssueMatcher.cs
@@ -21,7 +21,10 @@ namespace GitHub.Runner.Worker
             this.Category = category;
             this.IsInfrastructureIssue = infrastructureIssue;
             this.LogMessageOverride = logMessageOverride;
-            this.Data = data;
+
+            // Close-over the incoming IEnumerable to force immediate evaluation.
+            var empty = Enumerable.Empty<KeyValuePair<string, string>>();
+            this.Data = new Dictionary<string, string>(data ?? empty);
         }
 
         public readonly string Category;

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -325,10 +325,10 @@ namespace GitHub.Runner.Worker
                         if (message.ContextData.TryGetValue("inputs", out var pipelineContextData))
                         {
                             var inputs = pipelineContextData.AssertDictionary("inputs");
-                            if (inputs.Any()) 
+                            if (inputs.Any())
                             {
                                 context.Output($"##[group] Inputs");
-                                foreach (var input in inputs) 
+                                foreach (var input in inputs)
                                 {
                                     context.Output($"  {input.Key}: {input.Value}");
                                 }
@@ -336,7 +336,7 @@ namespace GitHub.Runner.Worker
                             }
                         }
 
-                        if (!string.IsNullOrWhiteSpace(message.JobDisplayName)) 
+                        if (!string.IsNullOrWhiteSpace(message.JobDisplayName))
                         {
                             context.Output($"Complete job name: {message.JobDisplayName}");
                         }
@@ -662,7 +662,7 @@ namespace GitHub.Runner.Worker
                 {
                     var issue = new Issue() { Type = IssueType.Warning, Message = $"You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: {freeSpaceInMB} MB" };
                     issue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.LowDiskSpace;
-                    context.AddIssue(issue);
+                    context.AddIssue(issue, writeToLog: true);
                     return;
                 }
 

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -660,9 +660,10 @@ namespace GitHub.Runner.Worker
                 var freeSpaceInMB = driveInfo.AvailableFreeSpace / 1024 / 1024;
                 if (freeSpaceInMB < lowDiskSpaceThreshold)
                 {
-                    var issue = new Issue() { Type = IssueType.Warning, Message = $"You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: {freeSpaceInMB} MB" };
-                    issue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.LowDiskSpace;
-                    context.AddIssue(issue, writeToLog: true);
+                    var message = $"You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: {freeSpaceInMB} MB";
+                    var metadata = new IssueMetadata(Constants.Runner.InternalTelemetryIssueDataKey, Constants.Runner.LowDiskSpace);
+                    var issue = context.CreateIssue(IssueType.Warning, message, metadata, true);
+                    context.AddIssue(issue);
                     return;
                 }
 

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -84,8 +84,8 @@ namespace GitHub.Runner.Worker
                         default:
                             throw new ArgumentException(HostContext.RunnerShutdownReason.ToString(), nameof(HostContext.RunnerShutdownReason));
                     }
-                    var issue = new Issue() { Type = IssueType.Error, Message = errorMessage };
-                    jobContext.AddIssue(issue, writeToLog: true);
+                    var issue = jobContext.CreateIssue(IssueType.Error, errorMessage, null, true);
+                    jobContext.AddIssue(issue);
                 });
 
                 // Validate directory permissions.

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -84,7 +84,8 @@ namespace GitHub.Runner.Worker
                         default:
                             throw new ArgumentException(HostContext.RunnerShutdownReason.ToString(), nameof(HostContext.RunnerShutdownReason));
                     }
-                    jobContext.AddIssue(new Issue() { Type = IssueType.Error, Message = errorMessage });
+                    var issue = new Issue() { Type = IssueType.Error, Message = errorMessage };
+                    jobContext.AddIssue(issue, writeToLog: true);
                 });
 
                 // Validate directory permissions.

--- a/src/Sdk/Common/Common/Utility/PrimitiveExtensions.cs
+++ b/src/Sdk/Common/Common/Utility/PrimitiveExtensions.cs
@@ -27,6 +27,18 @@ namespace GitHub.Services.Common
             }
         }
 
+        public static string TrimExcess(string text, int maxLength)
+        {
+            string result = text;
+
+            if (!string.IsNullOrEmpty(text) && text.Length > maxLength)
+            {
+                result = text.Substring(0, maxLength);
+            }
+
+            return result;
+        }
+
         public static string ToBase64StringNoPaddingFromString(string utf8String)
         {
             return ToBase64StringNoPadding(Encoding.UTF8.GetBytes(utf8String));
@@ -46,7 +58,7 @@ namespace GitHub.Services.Common
 
         //These methods convert To and From base64 strings without padding
         //for JWT scenarios
-        //code taken from the JWS spec here: 
+        //code taken from the JWS spec here:
         //http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-08#appendix-C
         public static String ToBase64StringNoPadding(this byte[] bytes)
         {

--- a/src/Sdk/Common/Common/Utility/PrimitiveExtensions.cs
+++ b/src/Sdk/Common/Common/Utility/PrimitiveExtensions.cs
@@ -31,9 +31,9 @@ namespace GitHub.Services.Common
         {
             string result = text;
 
-            if (!string.IsNullOrEmpty(text) && text.Length > maxLength)
+            if (!string.IsNullOrEmpty(result) && result.Length > maxLength)
             {
-                result = text.Substring(0, maxLength);
+                result = result.Substring(0, maxLength);
             }
 
             return result;

--- a/src/Sdk/DTWebApi/WebApi/Issue.cs
+++ b/src/Sdk/DTWebApi/WebApi/Issue.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using GitHub.Services.Common;
 
 namespace GitHub.DistributedTask.WebApi
 {
@@ -14,48 +15,25 @@ namespace GitHub.DistributedTask.WebApi
         string this[string key] { get; }
     }
 
-    public class IssueMetadata
-    {
-
-        public IssueMetadata(string key, string value)
-            : this(null, false, new []{ KeyValuePair.Create(key, value) })
-        {
-        }
-
-        public IssueMetadata(string category, bool infrastructureIssue, IEnumerable<KeyValuePair<string, string>> data)
-        {
-            this.Category = category;
-            this.IsInfrastructureIssue = infrastructureIssue;
-            this.Data = data;
-        }
-
-
-        public readonly string Category;
-        public readonly bool IsInfrastructureIssue;
-        public readonly IEnumerable<KeyValuePair<string, string>> Data;
-    }
-
     [DataContract]
     public class Issue : IReadOnlyIssue
     {
 
         public Issue()
+            : this(null)
         {
         }
 
         private Issue(Issue original)
         {
-            this.Type = original.Type;
-            this.Category = original.Category;
-            this.Message = original.Message;
-            this.IsInfrastructureIssue = original.IsInfrastructureIssue;
-
-            if (original.m_data != null)
+            m_data = new Dictionary<String, String>(StringComparer.OrdinalIgnoreCase);
+            if (original != null)
             {
-                foreach (var item in original.m_data)
-                {
-                    this.Data.Add(item);
-                }
+                this.Type = original.Type;
+                this.Category = original.Category;
+                this.Message = original.Message;
+                this.IsInfrastructureIssue = original.IsInfrastructureIssue;
+                this.Data.AddRange(original.Data);
             }
         }
 
@@ -91,10 +69,6 @@ namespace GitHub.DistributedTask.WebApi
         {
             get
             {
-                if (m_data == null)
-                {
-                    m_data = new Dictionary<String, String>(StringComparer.OrdinalIgnoreCase);
-                }
                 return m_data;
             }
         }

--- a/src/Sdk/DTWebApi/WebApi/Issue.cs
+++ b/src/Sdk/DTWebApi/WebApi/Issue.cs
@@ -25,7 +25,8 @@ namespace GitHub.DistributedTask.WebApi
 
         private Issue(Issue original)
         {
-            m_data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            // DataContractSerializer bypasses all constructor logic and inline initialization!
+            this.EnsureInitialized();
             if (original != null)
             {
                 this.Type = original.Type;
@@ -86,6 +87,7 @@ namespace GitHub.DistributedTask.WebApi
         private void OnDeserialized(StreamingContext context)
         {
             SerializationHelper.Copy(ref m_serializedData, ref m_data, StringComparer.OrdinalIgnoreCase, true);
+            this.EnsureInitialized();
         }
 
         [OnSerializing]
@@ -104,5 +106,10 @@ namespace GitHub.DistributedTask.WebApi
         private IDictionary<string, string> m_serializedData;
 
         private IDictionary<string, string> m_data;
+
+        private void EnsureInitialized()
+        {
+            m_data = m_data ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
     }
 }

--- a/src/Sdk/DTWebApi/WebApi/Issue.cs
+++ b/src/Sdk/DTWebApi/WebApi/Issue.cs
@@ -5,7 +5,6 @@ using GitHub.Services.Common;
 
 namespace GitHub.DistributedTask.WebApi
 {
-
     public interface IReadOnlyIssue
     {
         IssueType Type { get; }
@@ -26,14 +25,14 @@ namespace GitHub.DistributedTask.WebApi
 
         private Issue(Issue original)
         {
-            m_data = new Dictionary<String, String>(StringComparer.OrdinalIgnoreCase);
+            m_data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             if (original != null)
             {
                 this.Type = original.Type;
                 this.Category = original.Category;
                 this.Message = original.Message;
                 this.IsInfrastructureIssue = original.IsInfrastructureIssue;
-                this.Data.AddRange(original.Data);
+                m_data.AddRange(original.m_data);
             }
         }
 
@@ -45,14 +44,14 @@ namespace GitHub.DistributedTask.WebApi
         }
 
         [DataMember(Order = 2)]
-        public String Category
+        public string Category
         {
             get;
             set;
         }
 
         [DataMember(Order = 3)]
-        public String Message
+        public string Message
         {
             get;
             set;
@@ -65,14 +64,6 @@ namespace GitHub.DistributedTask.WebApi
             set;
         }
 
-        public IDictionary<String, String> Data
-        {
-            get
-            {
-                return m_data;
-            }
-        }
-
         public string this[string key]
         {
             get
@@ -80,8 +71,11 @@ namespace GitHub.DistributedTask.WebApi
                 m_data.TryGetValue(key, out string result);
                 return result;
             }
+            set
+            {
+                m_data[key] = value;
+            }
         }
-
 
         public Issue Clone()
         {
@@ -107,8 +101,8 @@ namespace GitHub.DistributedTask.WebApi
         }
 
         [DataMember(Name = "Data", EmitDefaultValue = false, Order = 4)]
-        private IDictionary<String, String> m_serializedData;
+        private IDictionary<string, string> m_serializedData;
 
-        private IDictionary<String, String> m_data;
+        private IDictionary<string, string> m_data;
     }
 }

--- a/src/Sdk/DTWebApi/WebApi/Issue.cs
+++ b/src/Sdk/DTWebApi/WebApi/Issue.cs
@@ -4,24 +4,55 @@ using System.Runtime.Serialization;
 
 namespace GitHub.DistributedTask.WebApi
 {
+
+    public interface IReadOnlyIssue
+    {
+        IssueType Type { get; }
+        string Category { get; }
+        string Message { get; }
+        bool? IsInfrastructureIssue { get; }
+        string this[string key] { get; }
+    }
+
+    public class IssueMetadata
+    {
+
+        public IssueMetadata(string key, string value)
+            : this(null, false, new []{ KeyValuePair.Create(key, value) })
+        {
+        }
+
+        public IssueMetadata(string category, bool infrastructureIssue, IEnumerable<KeyValuePair<string, string>> data)
+        {
+            this.Category = category;
+            this.IsInfrastructureIssue = infrastructureIssue;
+            this.Data = data;
+        }
+
+
+        public readonly string Category;
+        public readonly bool IsInfrastructureIssue;
+        public readonly IEnumerable<KeyValuePair<string, string>> Data;
+    }
+
     [DataContract]
-    public class Issue
+    public class Issue : IReadOnlyIssue
     {
 
         public Issue()
         {
         }
 
-        private Issue(Issue issueToBeCloned)
+        private Issue(Issue original)
         {
-            this.Type = issueToBeCloned.Type;
-            this.Category = issueToBeCloned.Category;
-            this.Message = issueToBeCloned.Message;
-            this.IsInfrastructureIssue = issueToBeCloned.IsInfrastructureIssue;
+            this.Type = original.Type;
+            this.Category = original.Category;
+            this.Message = original.Message;
+            this.IsInfrastructureIssue = original.IsInfrastructureIssue;
 
-            if (issueToBeCloned.m_data != null)
+            if (original.m_data != null)
             {
-                foreach (var item in issueToBeCloned.m_data)
+                foreach (var item in original.m_data)
                 {
                     this.Data.Add(item);
                 }
@@ -67,6 +98,16 @@ namespace GitHub.DistributedTask.WebApi
                 return m_data;
             }
         }
+
+        public string this[string key]
+        {
+            get
+            {
+                m_data.TryGetValue(key, out string result);
+                return result;
+            }
+        }
+
 
         public Issue Clone()
         {

--- a/src/Sdk/DTWebApi/WebApi/Issue.cs
+++ b/src/Sdk/DTWebApi/WebApi/Issue.cs
@@ -101,11 +101,6 @@ namespace GitHub.DistributedTask.WebApi
             m_serializedData = null;
         }
 
-        [DataMember(Name = "Data", EmitDefaultValue = false, Order = 4)]
-        private IDictionary<string, string> m_serializedData;
-
-        private IDictionary<string, string> m_data;
-
         /// <summary>
         /// DataContractSerializer bypasses all constructor logic and inline initialization!
         /// This method takes the place of a workhorse constructor for baseline initialization.
@@ -113,7 +108,14 @@ namespace GitHub.DistributedTask.WebApi
         /// </summary>
         private void EnsureInitialized()
         {
+            //Note that ?? is a short-circuiting operator.
             m_data = m_data ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
+
+        [DataMember(Name = "Data", EmitDefaultValue = false, Order = 4)]
+        private IDictionary<string, string> m_serializedData;
+
+        private IDictionary<string, string> m_data;
+
     }
 }

--- a/src/Sdk/DTWebApi/WebApi/Issue.cs
+++ b/src/Sdk/DTWebApi/WebApi/Issue.cs
@@ -25,7 +25,6 @@ namespace GitHub.DistributedTask.WebApi
 
         private Issue(Issue original)
         {
-            // DataContractSerializer bypasses all constructor logic and inline initialization!
             this.EnsureInitialized();
             if (original != null)
             {
@@ -107,6 +106,11 @@ namespace GitHub.DistributedTask.WebApi
 
         private IDictionary<string, string> m_data;
 
+        /// <summary>
+        /// DataContractSerializer bypasses all constructor logic and inline initialization!
+        /// This method takes the place of a workhorse constructor for baseline initialization.
+        /// The expectation is for this logic to be accessible to constructors and also to the OnDeserialized helper.
+        /// </summary>
         private void EnsureInitialized()
         {
             m_data = m_data ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Test/L0/TestUtil.cs
+++ b/src/Test/L0/TestUtil.cs
@@ -2,6 +2,8 @@
 using Xunit;
 using GitHub.Runner.Sdk;
 using System.Runtime.CompilerServices;
+using GitHub.DistributedTask.WebApi;
+using GitHub.Runner.Worker;
 
 namespace GitHub.Runner.Common.Tests
 {
@@ -40,6 +42,27 @@ namespace GitHub.Runner.Common.Tests
             string testDataDir = Path.Combine(GetProjectPath(), TestData);
             Assert.True(Directory.Exists(testDataDir));
             return testDataDir;
+        }
+
+        public static IReadOnlyIssue CreateTestIssue(IssueType type, string message, IssueMetadata metadata, bool writeToLog)
+        {
+            var result = new Issue()
+            {
+                Type = type,
+                Message = message,
+            };
+
+            if (metadata != null)
+            {
+                result.Category = metadata.Category;
+                result.IsInfrastructureIssue = metadata.IsInfrastructureIssue;
+                foreach (var kvp in metadata.Data)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -6,7 +6,6 @@ using GitHub.DistributedTask.Pipelines.ContextData;
 using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Worker;
 using GitHub.Runner.Worker.Container;
-using GitHub.Services.Common;
 using Moq;
 using Xunit;
 using Pipelines = GitHub.DistributedTask.Pipelines;
@@ -94,19 +93,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                             });
 
                 _ec.Setup(x => x.CreateIssue(It.IsAny<IssueType>(), It.IsAny<string>(), It.IsAny<IssueMetadata>(), It.IsAny<bool>()))
-                    .Returns((IssueType type, string message, IssueMetadata metadata, bool writeToLog) =>
-                    {
-                        var result = new Issue()
-                        {
-                            Type = type,
-                            Message = message,
-                            Category = metadata?.Category,
-                            IsInfrastructureIssue = metadata?.IsInfrastructureIssue ?? false
-                        };
-                        result.Data.AddRangeIfRangeNotNull(metadata?.Data);
-                        return result;
-                    });
-
+                   .Returns(TestUtil.CreateTestIssue);
                 _ec.Setup(x => x.AddIssue(It.IsAny<IReadOnlyIssue>()))
                    .Callback((IReadOnlyIssue issue) =>
                    {

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -2148,18 +2148,7 @@ runs:
             _ec.Object.Global.Plan = new TaskOrchestrationPlanReference();
             _ec.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>())).Callback((string tag, string message) => { _hc.GetTrace().Info($"[{tag}]{message}"); });
             _ec.Setup(x => x.CreateIssue(It.IsAny<IssueType>(), It.IsAny<string>(), It.IsAny<IssueMetadata>(), It.IsAny<bool>()))
-                .Returns((IssueType type, string message, IssueMetadata metadata, bool writeToLog) =>
-                {
-                    var result = new Issue()
-                    {
-                        Type = type,
-                        Message = message,
-                        Category = metadata?.Category,
-                        IsInfrastructureIssue = metadata?.IsInfrastructureIssue ?? false
-                    };
-                    result.Data.AddRangeIfRangeNotNull(metadata?.Data);
-                    return result;
-                });
+               .Returns(TestUtil.CreateTestIssue);
             _ec.Setup(x => x.AddIssue(It.IsAny<IReadOnlyIssue>())).Callback((IReadOnlyIssue issue) => { _hc.GetTrace().Info($"[{issue.Type}]{issue.Message}"); });
             _ec.Setup(x => x.GetGitHubContext("workspace")).Returns(Path.Combine(_workFolder, "actions", "actions"));
 

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -13,7 +13,11 @@ using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker;
 using GitHub.Runner.Worker.Container;
-using GitHub.Services.Common;
+
+#if OS_WINDOWS
+using System.IO.Compression;
+#endif
+
 using Moq;
 using Moq.Protected;
 using Xunit;

--- a/src/Test/L0/Worker/ActionManifestManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManifestManagerL0.cs
@@ -862,19 +862,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             _ec.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>())).Callback((string tag, string message) => { _hc.GetTrace().Info($"{tag}{message}"); });
 
             _ec.Setup(x => x.CreateIssue(It.IsAny<IssueType>(), It.IsAny<string>(), It.IsAny<IssueMetadata>(), It.IsAny<bool>()))
-                .Returns((IssueType type, string message, IssueMetadata metadata, bool writeToLog) =>
-                {
-                    var result = new Issue()
-                    {
-                        Type = type,
-                        Message = message,
-                        Category = metadata?.Category,
-                        IsInfrastructureIssue = metadata?.IsInfrastructureIssue ?? false
-                    };
-                    result.Data.AddRangeIfRangeNotNull(metadata?.Data);
-                    return result;
-                });
-
+               .Returns(TestUtil.CreateTestIssue);
             _ec.Setup(x => x.AddIssue(It.IsAny<IReadOnlyIssue>())).Callback((IReadOnlyIssue issue) => { _hc.GetTrace().Info($"[{issue.Type}]{issue.Message}"); });
         }
 

--- a/src/Test/L0/Worker/ActionRunnerL0.cs
+++ b/src/Test/L0/Worker/ActionRunnerL0.cs
@@ -445,19 +445,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             _ec.Object.Global.Variables = new Variables(_hc, new Dictionary<string, VariableValue>());
             _ec.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>())).Callback((string tag, string message) => { _hc.GetTrace().Info($"[{tag}]{message}"); });
             _ec.Setup(x => x.CreateIssue(It.IsAny<IssueType>(), It.IsAny<string>(), It.IsAny<IssueMetadata>(), It.IsAny<bool>()))
-                .Returns((IssueType type, string message, IssueMetadata metadata, bool writeToLog) =>
-                {
-                    var result = new Issue()
-                    {
-                        Type = type,
-                        Message = message,
-                        Category = metadata?.Category,
-                        IsInfrastructureIssue = metadata?.IsInfrastructureIssue ?? false
-                    };
-                    result.Data.AddRangeIfRangeNotNull(metadata?.Data);
-                    return result;
-                });
-
+               .Returns(TestUtil.CreateTestIssue);
             _ec.Setup(x => x.AddIssue(It.IsAny<IReadOnlyIssue>())).Callback((IReadOnlyIssue issue) => { _hc.GetTrace().Info($"[{issue.Type}]{issue.Message}"); });
 
             _hc.SetSingleton<IActionManager>(_actionManager.Object);

--- a/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
+++ b/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
@@ -255,19 +255,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     _trace.Info($"Issue '{issue.Type}': {issue.Message}");
                 });
             _executionContext.Setup(x => x.CreateIssue(It.IsAny<IssueType>(), It.IsAny<string>(), It.IsAny<IssueMetadata>(), It.IsAny<bool>()))
-                .Returns((IssueType type, string message, IssueMetadata metadata, bool writeToLog) =>
-                {
-                    var result = new Issue()
-                    {
-                        Type = type,
-                        Message = message,
-                        Category = metadata?.Category,
-                        IsInfrastructureIssue = metadata?.IsInfrastructureIssue ?? false
-                    };
-                    result.Data.AddRangeIfRangeNotNull(metadata?.Data);
-                    return result;
-                });
-
+                             .Returns(TestUtil.CreateTestIssue);
             _executionContext.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>()))
                 .Callback((string tag, string message) =>
                 {

--- a/src/Test/L0/Worker/ExecutionContextL0.cs
+++ b/src/Test/L0/Worker/ExecutionContextL0.cs
@@ -52,36 +52,36 @@ namespace GitHub.Runner.Common.Tests.Worker
                 // Act.
                 ec.InitializeJob(jobRequest, CancellationToken.None);
 
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
 
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
 
                 ec.Complete();
 
@@ -190,9 +190,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                     bigMessage += "a";
                 }
 
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = bigMessage });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = bigMessage });
-                ec.AddIssue(new Issue() { Type = IssueType.Notice, Message = bigMessage });
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, bigMessage, null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, bigMessage, null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Notice, bigMessage, null, true));
 
                 ec.Complete();
 
@@ -242,9 +242,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var embeddedStep = ec.CreateChild(Guid.NewGuid(), "action_1_pre", "action_1_pre", null, null, ActionRunStage.Main, isEmbedded: true);
                 embeddedStep.Start();
 
-                embeddedStep.AddIssue(new Issue() { Type = IssueType.Error, Message = "error annotation that should have step and line number information" });
-                embeddedStep.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning annotation that should have step and line number information" });
-                embeddedStep.AddIssue(new Issue() { Type = IssueType.Notice, Message = "notice annotation that should have step and line number information" });
+                embeddedStep.AddIssue(embeddedStep.CreateIssue(IssueType.Error, "error annotation that should have step and line number information", null, true));
+                embeddedStep.AddIssue(embeddedStep.CreateIssue(IssueType.Warning, "warning annotation that should have step and line number information", null, true));
+                embeddedStep.AddIssue(embeddedStep.CreateIssue(IssueType.Notice, "notice annotation that should have step and line number information", null, true));
 
                 jobServerQueue.Verify(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.Is<TimelineRecord>(t => t.Issues.Where(i => i.Data.ContainsKey("stepNumber") && i.Data.ContainsKey("logFileLineNumber") && i.Type == IssueType.Error).Count() == 1)), Times.AtLeastOnce);
                 jobServerQueue.Verify(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.Is<TimelineRecord>(t => t.Issues.Where(i => i.Data.ContainsKey("stepNumber") && i.Data.ContainsKey("logFileLineNumber") && i.Type == IssueType.Warning).Count() == 1)), Times.AtLeastOnce);
@@ -626,12 +626,12 @@ namespace GitHub.Runner.Common.Tests.Worker
                 ec.StepTelemetry.StepId = Guid.NewGuid();
                 ec.StepTelemetry.Stage = "main";
 
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Notice, Message = "notice" });
-                ec.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                ec.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                ec.AddIssue(new Issue() { Type = IssueType.Notice, Message = "notice" });
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Notice, "notice", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                ec.AddIssue(ec.CreateIssue(IssueType.Notice, "notice", null, true));
 
                 ec.Complete();
 
@@ -692,9 +692,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 embeddedStep.StepTelemetry.Action = "actions/checkout";
                 embeddedStep.StepTelemetry.Ref = "v2";
 
-                embeddedStep.AddIssue(new Issue() { Type = IssueType.Error, Message = "error" });
-                embeddedStep.AddIssue(new Issue() { Type = IssueType.Warning, Message = "warning" });
-                embeddedStep.AddIssue(new Issue() { Type = IssueType.Notice, Message = "notice" });
+                embeddedStep.AddIssue(ec.CreateIssue(IssueType.Error, "error", null, true));
+                embeddedStep.AddIssue(ec.CreateIssue(IssueType.Warning, "warning", null, true));
+                embeddedStep.AddIssue(ec.CreateIssue(IssueType.Notice, "notice", null, true));
 
                 embeddedStep.PublishStepTelemetry();
 
@@ -870,7 +870,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 inputVarsContext["VARIABLE_2"] = new StringContextData("value2");
                 jobRequest.ContextData["vars"] = inputVarsContext;
 
-                // Arrange: Setup the paging logger. 
+                // Arrange: Setup the paging logger.
                 var pagingLogger1 = new Mock<IPagingLogger>();
                 var jobServerQueue = new Mock<IJobServerQueue>();
                 hc.EnqueueInstance(pagingLogger1.Object);
@@ -884,7 +884,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 var expected = new DictionaryContextData();
                 expected["VARIABLE_1"] = new StringContextData("value1");
                 expected["VARIABLE_2"] = new StringContextData("value1");
-                
+
                 Assert.True(ExpressionValuesAssertEqual(expected, jobContext.ExpressionValues["vars"] as DictionaryContextData));
             }
         }
@@ -915,7 +915,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 inputVarsContext[Constants.Variables.Actions.RunnerDebug] = new StringContextData("true");
                 jobRequest.ContextData["vars"] = inputVarsContext;
 
-                // Arrange: Setup the paging logger. 
+                // Arrange: Setup the paging logger.
                 var pagingLogger1 = new Mock<IPagingLogger>();
                 var jobServerQueue = new Mock<IJobServerQueue>();
                 hc.EnqueueInstance(pagingLogger1.Object);
@@ -926,7 +926,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 jobContext.InitializeJob(jobRequest, CancellationToken.None);
 
-                
+
                 Assert.Equal("true", jobContext.Global.Variables.Get(Constants.Variables.Actions.StepDebug));
                 Assert.Equal("true", jobContext.Global.Variables.Get(Constants.Variables.Actions.RunnerDebug));
             }
@@ -961,7 +961,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 jobRequest.Variables[Constants.Variables.Actions.StepDebug] = "false";
                 jobRequest.Variables[Constants.Variables.Actions.RunnerDebug] = "false";
 
-                // Arrange: Setup the paging logger. 
+                // Arrange: Setup the paging logger.
                 var pagingLogger1 = new Mock<IPagingLogger>();
                 var jobServerQueue = new Mock<IJobServerQueue>();
                 hc.EnqueueInstance(pagingLogger1.Object);
@@ -972,7 +972,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 jobContext.InitializeJob(jobRequest, CancellationToken.None);
 
-                
+
                 Assert.Equal("false", jobContext.Global.Variables.Get(Constants.Variables.Actions.StepDebug));
                 Assert.Equal("false", jobContext.Global.Variables.Get(Constants.Variables.Actions.RunnerDebug));
             }

--- a/src/Test/L0/Worker/ExecutionContextL0.cs
+++ b/src/Test/L0/Worker/ExecutionContextL0.cs
@@ -246,9 +246,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 embeddedStep.AddIssue(embeddedStep.CreateIssue(IssueType.Warning, "warning annotation that should have step and line number information", null, true));
                 embeddedStep.AddIssue(embeddedStep.CreateIssue(IssueType.Notice, "notice annotation that should have step and line number information", null, true));
 
-                jobServerQueue.Verify(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.Is<TimelineRecord>(t => t.Issues.Where(i => i.Data.ContainsKey("stepNumber") && i.Data.ContainsKey("logFileLineNumber") && i.Type == IssueType.Error).Count() == 1)), Times.AtLeastOnce);
-                jobServerQueue.Verify(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.Is<TimelineRecord>(t => t.Issues.Where(i => i.Data.ContainsKey("stepNumber") && i.Data.ContainsKey("logFileLineNumber") && i.Type == IssueType.Warning).Count() == 1)), Times.AtLeastOnce);
-                jobServerQueue.Verify(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.Is<TimelineRecord>(t => t.Issues.Where(i => i.Data.ContainsKey("stepNumber") && i.Data.ContainsKey("logFileLineNumber") && i.Type == IssueType.Notice).Count() == 1)), Times.AtLeastOnce);
+                jobServerQueue.Verify(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.Is<TimelineRecord>(t => t.Issues.Where(i => i["stepNumber"] != null && i["logFileLineNumber"] != null && i.Type == IssueType.Error).Count() == 1)), Times.AtLeastOnce);
+                jobServerQueue.Verify(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.Is<TimelineRecord>(t => t.Issues.Where(i => i["stepNumber"] != null && i["logFileLineNumber"] != null && i.Type == IssueType.Warning).Count() == 1)), Times.AtLeastOnce);
+                jobServerQueue.Verify(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.Is<TimelineRecord>(t => t.Issues.Where(i => i["stepNumber"] != null && i["logFileLineNumber"] != null && i.Type == IssueType.Notice).Count() == 1)), Times.AtLeastOnce);
             }
         }
 

--- a/src/Test/L0/Worker/OutputManagerL0.cs
+++ b/src/Test/L0/Worker/OutputManagerL0.cs
@@ -984,19 +984,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     _onMatcherChanged = handler;
                 });
             _executionContext.Setup(x => x.CreateIssue(It.IsAny<DTWebApi.IssueType>(), It.IsAny<string>(), It.IsAny<IssueMetadata>(), It.IsAny<bool>()))
-                .Returns((DTWebApi.IssueType type, string message, IssueMetadata metadata, bool writeToLog) =>
-                {
-                    var result = new DTWebApi.Issue()
-                    {
-                        Type = type,
-                        Message = message,
-                        Category = metadata?.Category,
-                        IsInfrastructureIssue = metadata?.IsInfrastructureIssue ?? false
-                    };
-                    result.Data.AddRangeIfRangeNotNull(metadata?.Data);
-                    return result;
-                });
-
+                             .Returns(TestUtil.CreateTestIssue);
             _executionContext.Setup(x => x.AddIssue(It.IsAny<DTWebApi.IReadOnlyIssue>()))
                 .Callback((DTWebApi.IReadOnlyIssue issue) =>
                 {

--- a/src/Test/L0/Worker/OutputManagerL0.cs
+++ b/src/Test/L0/Worker/OutputManagerL0.cs
@@ -9,6 +9,7 @@ using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker;
 using GitHub.Runner.Worker.Container;
 using GitHub.Runner.Worker.Handlers;
+using GitHub.Services.Common;
 using Moq;
 using Xunit;
 using DTWebApi = GitHub.DistributedTask.WebApi;
@@ -21,7 +22,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         private Mock<IActionCommandManager> _commandManager;
         private Variables _variables;
         private OnMatcherChanged _onMatcherChanged;
-        private List<Tuple<DTWebApi.Issue, string>> _issues;
+        private List<DTWebApi.IReadOnlyIssue> _issues;
         private List<string> _messages;
         private List<string> _commands;
         private OutputManager _outputManager;
@@ -82,10 +83,10 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Process("ERROR: message 4");
                 Process("NOT GOOD: message 5");
                 Assert.Equal(4, _issues.Count);
-                Assert.Equal("message 1", _issues[0].Item1.Message);
-                Assert.Equal("message 2", _issues[1].Item1.Message);
-                Assert.Equal("message 3", _issues[2].Item1.Message);
-                Assert.Equal("message 5", _issues[3].Item1.Message);
+                Assert.Equal("message 1", _issues[0].Message);
+                Assert.Equal("message 2", _issues[1].Message);
+                Assert.Equal("message 3", _issues[2].Message);
+                Assert.Equal("message 5", _issues[3].Message);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(1, _messages.Count);
                 Assert.Equal("ERROR: message 4", _messages[0]);
@@ -148,11 +149,11 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Process("ERROR: message 4");
                 Process("NOT GOOD: message 5");
                 Assert.Equal(5, _issues.Count);
-                Assert.Equal("message 1", _issues[0].Item1.Message);
-                Assert.Equal("message 2", _issues[1].Item1.Message);
-                Assert.Equal("message 3", _issues[2].Item1.Message);
-                Assert.Equal("message 4", _issues[3].Item1.Message);
-                Assert.Equal("message 5", _issues[4].Item1.Message);
+                Assert.Equal("message 1", _issues[0].Message);
+                Assert.Equal("message 2", _issues[1].Message);
+                Assert.Equal("message 3", _issues[2].Message);
+                Assert.Equal("message 4", _issues[3].Message);
+                Assert.Equal("message 5", _issues[4].Message);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(0, _messages.Count);
             }
@@ -188,10 +189,10 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Process("BAD: real bad");
                 Process(": not working");
                 Assert.Equal(2, _issues.Count);
-                Assert.Equal("real bad", _issues[0].Item1.Message);
-                Assert.Equal("BAD", _issues[0].Item1.Data["code"]);
-                Assert.Equal("not working", _issues[1].Item1.Message);
-                Assert.False(_issues[1].Item1.Data.ContainsKey("code"));
+                Assert.Equal("real bad", _issues[0].Message);
+                Assert.Equal("BAD", _issues[0]["code"]);
+                Assert.Equal("not working", _issues[1].Message);
+                Assert.Null(_issues[1]["code"]);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(0, _messages.Count);
             }
@@ -238,11 +239,11 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Process("Error: real bad");
                 Process("regular message 2");
                 Assert.Equal(5, _issues.Count);
-                Assert.Equal("it broke", _issues[0].Item1.Message);
-                Assert.Equal("oh no", _issues[1].Item1.Message);
-                Assert.Equal("not good", _issues[2].Item1.Message);
-                Assert.Equal("it broke again", _issues[3].Item1.Message);
-                Assert.Equal("real bad", _issues[4].Item1.Message);
+                Assert.Equal("it broke", _issues[0].Message);
+                Assert.Equal("oh no", _issues[1].Message);
+                Assert.Equal("not good", _issues[2].Message);
+                Assert.Equal("it broke again", _issues[3].Message);
+                Assert.Equal("real bad", _issues[4].Message);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(4, _messages.Count);
                 Assert.Equal("Start: hello", _messages[0]);
@@ -293,8 +294,8 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Process("ERROR: it is broken");
                 Process("NOT GOOD: that did not work");
                 Assert.Equal(2, _issues.Count);
-                Assert.Equal("it is broken", _issues[0].Item1.Message);
-                Assert.Equal("that did not work", _issues[1].Item1.Message);
+                Assert.Equal("it is broken", _issues[0].Message);
+                Assert.Equal("that did not work", _issues[1].Message);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(0, _messages.Count);
             }
@@ -332,15 +333,15 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Process("(12,thirty-four): it is broken");
                 Process("(twelve,34): not working");
                 Assert.Equal(3, _issues.Count);
-                Assert.Equal("real bad", _issues[0].Item1.Message);
-                Assert.Equal("12", _issues[0].Item1.Data["line"]);
-                Assert.Equal("34", _issues[0].Item1.Data["col"]);
-                Assert.Equal("it is broken", _issues[1].Item1.Message);
-                Assert.Equal("12", _issues[1].Item1.Data["line"]);
-                Assert.False(_issues[1].Item1.Data.ContainsKey("col"));
-                Assert.Equal("not working", _issues[2].Item1.Message);
-                Assert.False(_issues[2].Item1.Data.ContainsKey("line"));
-                Assert.Equal("34", _issues[2].Item1.Data["col"]);
+                Assert.Equal("real bad", _issues[0].Message);
+                Assert.Equal("12", _issues[0]["line"]);
+                Assert.Equal("34", _issues[0]["col"]);
+                Assert.Equal("it is broken", _issues[1].Message);
+                Assert.Equal("12", _issues[1]["line"]);
+                Assert.Null(_issues[1]["col"]);
+                Assert.Equal("not working", _issues[2].Message);
+                Assert.Null(_issues[2]["line"]);
+                Assert.Equal("34", _issues[2]["col"]);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(2, _messages.Count);
                 Assert.Equal("##[debug]Unable to parse column number 'thirty-four'", _messages[0]);
@@ -373,8 +374,8 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Process("this line is a command too ##[some-command]even though it contains ERROR: not working again");
                 Process("##[not-command]this line is an ERROR: it is broken again");
                 Assert.Equal(2, _issues.Count);
-                Assert.Equal("it is broken", _issues[0].Item1.Message);
-                Assert.Equal("it is broken again", _issues[1].Item1.Message);
+                Assert.Equal("it is broken", _issues[0].Message);
+                Assert.Equal("it is broken again", _issues[1].Message);
                 Assert.Equal(2, _commands.Count);
                 Assert.Equal("##[some-command]this line is a command even though it contains ERROR: not working", _commands[0]);
                 Assert.Equal("this line is a command too ##[some-command]even though it contains ERROR: not working again", _commands[1]);
@@ -404,8 +405,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 });
                 Process("the error: \033[31mred, \033[1;31mbright red, \033[mreset");
                 Assert.Equal(1, _issues.Count);
-                Assert.Equal("red, bright red, reset", _issues[0].Item1.Message);
-                Assert.Equal("the error: red, bright red, reset", _issues[0].Item2);
+                Assert.Equal("red, bright red, reset", _issues[0].Message);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(0, _messages.Count);
             }
@@ -455,9 +455,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Process("ERROR: message 3");
                 Process("NOT GOOD: message 4");
                 Assert.Equal(3, _issues.Count);
-                Assert.Equal("message 1", _issues[0].Item1.Message);
-                Assert.Equal("message 2", _issues[1].Item1.Message);
-                Assert.Equal("message 4", _issues[2].Item1.Message);
+                Assert.Equal("message 1", _issues[0].Message);
+                Assert.Equal("message 2", _issues[1].Message);
+                Assert.Equal("message 4", _issues[2].Message);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(1, _messages.Count);
                 Assert.Equal("ERROR: message 3", _messages[0]);
@@ -517,8 +517,8 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Process("Matches both line 1: hello again");
                 Process("oh no, another error");
                 Assert.Equal(2, _issues.Count);
-                Assert.Equal("it broke", _issues[0].Item1.Message);
-                Assert.Equal("oh no, another error", _issues[1].Item1.Message);
+                Assert.Equal("it broke", _issues[0].Message);
+                Assert.Equal("oh no, another error", _issues[1].Message);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(4, _messages.Count);
                 Assert.Equal("Matches both line 1: hello", _messages[0]);
@@ -573,14 +573,14 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Process(": not working");
                 Process("ERROR! uh oh");
                 Assert.Equal(4, _issues.Count);
-                Assert.Equal("real bad", _issues[0].Item1.Message);
-                Assert.Equal(DTWebApi.IssueType.Error, _issues[0].Item1.Type);
-                Assert.Equal("not great", _issues[1].Item1.Message);
-                Assert.Equal(DTWebApi.IssueType.Warning, _issues[1].Item1.Type);
-                Assert.Equal("not working", _issues[2].Item1.Message);
-                Assert.Equal(DTWebApi.IssueType.Error, _issues[2].Item1.Type);
-                Assert.Equal("uh oh", _issues[3].Item1.Message);
-                Assert.Equal(DTWebApi.IssueType.Error, _issues[3].Item1.Type);
+                Assert.Equal("real bad", _issues[0].Message);
+                Assert.Equal(DTWebApi.IssueType.Error, _issues[0].Type);
+                Assert.Equal("not great", _issues[1].Message);
+                Assert.Equal(DTWebApi.IssueType.Warning, _issues[1].Type);
+                Assert.Equal("not working", _issues[2].Message);
+                Assert.Equal(DTWebApi.IssueType.Error, _issues[2].Type);
+                Assert.Equal("uh oh", _issues[3].Message);
+                Assert.Equal(DTWebApi.IssueType.Error, _issues[3].Type);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(2, _messages.Count);
                 Assert.StartsWith("##[debug]Skipped", _messages[0]);
@@ -633,9 +633,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Process("jane.doe@contoso.com");
                 Process("ERR: this error");
                 Assert.Equal(3, _issues.Count);
-                Assert.Equal("john.doe@contoso.com", _issues[0].Item1.Message);
-                Assert.Contains("Removing issue matcher 'email'", _issues[1].Item1.Message);
-                Assert.Equal("this error", _issues[2].Item1.Message);
+                Assert.Equal("john.doe@contoso.com", _issues[0].Message);
+                Assert.Contains("Removing issue matcher 'email'", _issues[1].Message);
+                Assert.Equal("this error", _issues[2].Message);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(2, _messages.Where(x => x.StartsWith("##[debug]Timeout processing issue matcher")).Count());
                 Assert.Equal(1, _messages.Where(x => x.Equals("t@t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.t.c%20")).Count());
@@ -725,32 +725,32 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 Assert.Equal(9, _issues.Count);
 
-                Assert.Equal("some error 1", _issues[0].Item1.Message);
-                Assert.False(_issues[0].Item1.Data.ContainsKey("file"));
+                Assert.Equal("some error 1", _issues[0].Message);
+                Assert.Null(_issues[0]["file"]);
 
-                Assert.Equal("some error 2", _issues[1].Item1.Message);
-                Assert.Equal(file_workflowRepository.Substring(workflowRepository.Length + 1).Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), _issues[1].Item1.Data["file"]);
+                Assert.Equal("some error 2", _issues[1].Message);
+                Assert.Equal(file_workflowRepository.Substring(workflowRepository.Length + 1).Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), _issues[1]["file"]);
 
-                Assert.Equal("some error 3", _issues[2].Item1.Message);
-                Assert.Equal(file_workflowRepository.Substring(workflowRepository.Length + 1).Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), _issues[2].Item1.Data["file"]);
+                Assert.Equal("some error 3", _issues[2].Message);
+                Assert.Equal(file_workflowRepository.Substring(workflowRepository.Length + 1).Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), _issues[2]["file"]);
 
-                Assert.Equal("some error 4", _issues[3].Item1.Message);
-                Assert.Equal(file_workflowRepository_nestedDirectory.Substring(workflowRepository.Length + 1).Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), _issues[3].Item1.Data["file"]);
+                Assert.Equal("some error 4", _issues[3].Message);
+                Assert.Equal(file_workflowRepository_nestedDirectory.Substring(workflowRepository.Length + 1).Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), _issues[3]["file"]);
 
-                Assert.Equal("some error 5", _issues[4].Item1.Message);
-                Assert.False(_issues[4].Item1.Data.ContainsKey("file"));
+                Assert.Equal("some error 5", _issues[4].Message);
+                Assert.Null(_issues[4]["file"]);
 
-                Assert.Equal("some error 6", _issues[5].Item1.Message);
-                Assert.False(_issues[5].Item1.Data.ContainsKey("file"));
+                Assert.Equal("some error 6", _issues[5].Message);
+                Assert.Null(_issues[5]["file"]);
 
-                Assert.Equal("some error 7", _issues[6].Item1.Message);
-                Assert.False(_issues[6].Item1.Data.ContainsKey("file"));
+                Assert.Equal("some error 7", _issues[6].Message);
+                Assert.Null(_issues[6]["file"]);
 
-                Assert.Equal("some error 8", _issues[7].Item1.Message);
-                Assert.Equal(file_nestedWorkflowRepository.Substring(nestedWorkflowRepository.Length + 1).Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), _issues[7].Item1.Data["file"]);
+                Assert.Equal("some error 8", _issues[7].Message);
+                Assert.Equal(file_nestedWorkflowRepository.Substring(nestedWorkflowRepository.Length + 1).Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), _issues[7]["file"]);
 
-                Assert.Equal("some error 9", _issues[8].Item1.Message);
-                Assert.Equal(file_workflowRepositoryUsingSsh.Substring(workflowRepositoryUsingSsh.Length + 1).Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), _issues[8].Item1.Data["file"]);
+                Assert.Equal("some error 9", _issues[8].Message);
+                Assert.Equal(file_workflowRepositoryUsingSsh.Substring(workflowRepositoryUsingSsh.Length + 1).Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), _issues[8]["file"]);
             }
 
             Environment.SetEnvironmentVariable("RUNNER_TEST_GET_REPOSITORY_PATH_FAILSAFE", "");
@@ -810,11 +810,11 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 Assert.Equal(2, _issues.Count);
 
-                Assert.Equal("some error 1", _issues[0].Item1.Message);
-                Assert.Equal("some-file.txt", _issues[0].Item1.Data["file"]);
+                Assert.Equal("some error 1", _issues[0].Message);
+                Assert.Equal("some-file.txt", _issues[0]["file"]);
 
-                Assert.Equal("some error 2", _issues[1].Item1.Message);
-                Assert.Equal("some-file.txt", _issues[1].Item1.Data["file"]);
+                Assert.Equal("some error 2", _issues[1].Message);
+                Assert.Equal("some-file.txt", _issues[1]["file"]);
             }
         }
 
@@ -871,11 +871,11 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 Assert.Equal(2, _issues.Count);
 
-                Assert.Equal("some error 1", _issues[0].Item1.Message);
-                Assert.Equal("some-file.txt", _issues[0].Item1.Data["file"]);
+                Assert.Equal("some error 1", _issues[0].Message);
+                Assert.Equal("some-file.txt", _issues[0]["file"]);
 
-                Assert.Equal("some error 2", _issues[1].Item1.Message);
-                Assert.Equal("some-file.txt", _issues[1].Item1.Data["file"]);
+                Assert.Equal("some error 2", _issues[1].Message);
+                Assert.Equal("some-file.txt", _issues[1]["file"]);
             }
         }
 #endif
@@ -929,8 +929,8 @@ namespace GitHub.Runner.Common.Tests.Worker
                 // Process
                 Process("some-directory/some-file.txt: some error [workflow-repo/some-project/some-project.proj]");
                 Assert.Equal(1, _issues.Count);
-                Assert.Equal("some error", _issues[0].Item1.Message);
-                Assert.Equal("some-project/some-directory/some-file.txt", _issues[0].Item1.Data["file"]);
+                Assert.Equal("some error", _issues[0].Message);
+                Assert.Equal("some-project/some-directory/some-file.txt", _issues[0]["file"]);
                 Assert.Equal(0, _commands.Count);
                 Assert.Equal(0, _messages.Count);
             }
@@ -958,7 +958,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             matchers?.Validate();
 
             _onMatcherChanged = null;
-            _issues = new List<Tuple<DTWebApi.Issue, string>>();
+            _issues = new List<DTWebApi.IReadOnlyIssue>();
             _messages = new List<string>();
             _commands = new List<string>();
 
@@ -983,10 +983,24 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _onMatcherChanged = handler;
                 });
-            _executionContext.Setup(x => x.AddIssue(It.IsAny<DTWebApi.Issue>(), It.IsAny<string>()))
-                .Callback((DTWebApi.Issue issue, string logMessage) =>
+            _executionContext.Setup(x => x.CreateIssue(It.IsAny<DTWebApi.IssueType>(), It.IsAny<string>(), It.IsAny<DTWebApi.IssueMetadata>(), It.IsAny<bool>()))
+                .Returns((DTWebApi.IssueType type, string message, DTWebApi.IssueMetadata metadata, bool writeToLog) =>
                 {
-                    _issues.Add(new Tuple<DTWebApi.Issue, string>(issue, logMessage));
+                    var result = new DTWebApi.Issue()
+                    {
+                        Type = type,
+                        Message = message,
+                        Category = metadata?.Category,
+                        IsInfrastructureIssue = metadata?.IsInfrastructureIssue ?? false
+                    };
+                    result.Data.AddRangeIfRangeNotNull(metadata?.Data);
+                    return result;
+                });
+
+            _executionContext.Setup(x => x.AddIssue(It.IsAny<DTWebApi.IReadOnlyIssue>()))
+                .Callback((DTWebApi.IReadOnlyIssue issue) =>
+                {
+                    _issues.Add(issue);
                 });
             _executionContext.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>()))
                 .Callback((string tag, string message) =>

--- a/src/Test/L0/Worker/OutputManagerL0.cs
+++ b/src/Test/L0/Worker/OutputManagerL0.cs
@@ -983,8 +983,8 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     _onMatcherChanged = handler;
                 });
-            _executionContext.Setup(x => x.CreateIssue(It.IsAny<DTWebApi.IssueType>(), It.IsAny<string>(), It.IsAny<DTWebApi.IssueMetadata>(), It.IsAny<bool>()))
-                .Returns((DTWebApi.IssueType type, string message, DTWebApi.IssueMetadata metadata, bool writeToLog) =>
+            _executionContext.Setup(x => x.CreateIssue(It.IsAny<DTWebApi.IssueType>(), It.IsAny<string>(), It.IsAny<IssueMetadata>(), It.IsAny<bool>()))
+                .Returns((DTWebApi.IssueType type, string message, IssueMetadata metadata, bool writeToLog) =>
                 {
                     var result = new DTWebApi.Issue()
                     {

--- a/src/Test/L0/Worker/SaveStateFileCommandL0.cs
+++ b/src/Test/L0/Worker/SaveStateFileCommandL0.cs
@@ -21,7 +21,7 @@ namespace GitHub.Runner.Common.Tests.Worker
     public sealed class SaveStateFileCommandL0
     {
         private Mock<IExecutionContext> _executionContext;
-        private List<Tuple<DTWebApi.Issue, string>> _issues;
+        private List<DTWebApi.IReadOnlyIssue> _issues;
         private string _rootDirectory;
         private SaveStateFileCommand _saveStateFileCommand;
         private Dictionary<string, string> _intraActionState;
@@ -390,7 +390,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
         private TestHostContext Setup([CallerMemberName] string name = "")
         {
-            _issues = new List<Tuple<DTWebApi.Issue, string>>();
+            _issues = new List<DTWebApi.IReadOnlyIssue>();
             _intraActionState = new Dictionary<string, string>();
 
             var hostContext = new TestHostContext(this, name);
@@ -413,12 +413,11 @@ namespace GitHub.Runner.Common.Tests.Worker
                     EnvironmentVariables = new Dictionary<string, string>(VarUtil.EnvironmentVariableKeyComparer),
                     WriteDebug = true,
                 });
-            _executionContext.Setup(x => x.AddIssue(It.IsAny<DTWebApi.Issue>(), It.IsAny<string>()))
-                .Callback((DTWebApi.Issue issue, string logMessage) =>
+            _executionContext.Setup(x => x.AddIssue(It.IsAny<DTWebApi.IReadOnlyIssue>()))
+                .Callback((DTWebApi.IReadOnlyIssue issue) =>
                 {
-                    _issues.Add(new Tuple<DTWebApi.Issue, string>(issue, logMessage));
-                    var message = !string.IsNullOrEmpty(logMessage) ? logMessage : issue.Message;
-                    _trace.Info($"Issue '{issue.Type}': {message}");
+                    _issues.Add(issue);
+                    _trace.Info($"Issue '{issue.Type}': {issue.Message}");
                 });
             _executionContext.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>()))
                 .Callback((string tag, string message) =>

--- a/src/Test/L0/Worker/SetOutputFileCommandL0.cs
+++ b/src/Test/L0/Worker/SetOutputFileCommandL0.cs
@@ -1,17 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker;
-using GitHub.Runner.Worker.Container;
-using GitHub.Runner.Worker.Handlers;
 using Moq;
 using Xunit;
 using DTWebApi = GitHub.DistributedTask.WebApi;
@@ -21,7 +15,7 @@ namespace GitHub.Runner.Common.Tests.Worker
     public sealed class SetOutputFileCommandL0
     {
         private Mock<IExecutionContext> _executionContext;
-        private List<Tuple<DTWebApi.Issue, string>> _issues;
+        private List<DTWebApi.IReadOnlyIssue> _issues;
         private Dictionary<string, string> _outputs;
         private string _rootDirectory;
         private SetOutputFileCommand _setOutputFileCommand;
@@ -390,7 +384,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
         private TestHostContext Setup([CallerMemberName] string name = "")
         {
-            _issues = new List<Tuple<DTWebApi.Issue, string>>();
+            _issues = new List<DTWebApi.IReadOnlyIssue>();
             _outputs = new Dictionary<string, string>();
 
             var hostContext = new TestHostContext(this, name);
@@ -413,12 +407,11 @@ namespace GitHub.Runner.Common.Tests.Worker
                     EnvironmentVariables = new Dictionary<string, string>(VarUtil.EnvironmentVariableKeyComparer),
                     WriteDebug = true,
                 });
-            _executionContext.Setup(x => x.AddIssue(It.IsAny<DTWebApi.Issue>(), It.IsAny<string>()))
-                .Callback((DTWebApi.Issue issue, string logMessage) =>
+            _executionContext.Setup(x => x.AddIssue(It.IsAny<DTWebApi.IReadOnlyIssue>()))
+                .Callback((DTWebApi.IReadOnlyIssue issue) =>
                 {
-                    _issues.Add(new Tuple<DTWebApi.Issue, string>(issue, logMessage));
-                    var message = !string.IsNullOrEmpty(logMessage) ? logMessage : issue.Message;
-                    _trace.Info($"Issue '{issue.Type}': {message}");
+                    _issues.Add(issue);
+                    _trace.Info($"Issue '{issue.Type}': {issue.Message}");
                 });
             _executionContext.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>()))
                 .Callback((string tag, string message) =>


### PR DESCRIPTION
The proper way to instantiate a `DistributedTask.WebApi::Issue` is now via the factory method on an `ExecutionContext` (`IExecutionContext::CreateIssue`)

This variation addresses feedback in https://github.com/actions/runner/pull/2311
