### PR TITLE
Revert "split by regex"

### DIFF
--- a/src/Runner.Sdk/ProcessInvoker.cs
+++ b/src/Runner.Sdk/ProcessInvoker.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using GitHub.Runner.Sdk;
-using System.Text.RegularExpressions;
 
 namespace GitHub.Runner.Sdk
 {
@@ -266,8 +265,8 @@ namespace GitHub.Runner.Sdk
                 foreach (KeyValuePair<string, string> kvp in environment)
                 {
 #if OS_WINDOWS
-                    string tempKey = String.IsNullOrWhiteSpace(kvp.Key) ? kvp.Key : Regex.Split(kvp.Key, @"\p{C}")[0];
-                    string tempValue = String.IsNullOrWhiteSpace(kvp.Value) ? kvp.Value :  Regex.Split(kvp.Value, @"\p{C}")[0];
+                    string tempKey = String.IsNullOrWhiteSpace(kvp.Key) ? kvp.Key : kvp.Key.Split('\0')[0];
+                    string tempValue = String.IsNullOrWhiteSpace(kvp.Value) ? kvp.Value : kvp.Value.Split('\0')[0];
                     if(!String.IsNullOrWhiteSpace(tempKey))
                     {
                          _proc.StartInfo.Environment[tempKey] = tempValue;

--- a/src/Test/L0/ProcessInvokerL0.cs
+++ b/src/Test/L0/ProcessInvokerL0.cs
@@ -167,40 +167,6 @@ namespace GitHub.Runner.Common.Tests
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public async Task SetTestEnvWithTabInKey()
-        {
-            using (TestHostContext hc = new(this))
-            {
-                Tracing trace = hc.GetTrace();
-
-                Int32 exitCode = -1;
-                var processInvoker = new ProcessInvokerWrapper();
-                processInvoker.Initialize(hc);
-                var stdout = new List<string>();
-                var stderr = new List<string>();
-                processInvoker.OutputDataReceived += (object sender, ProcessDataReceivedEventArgs e) =>
-                {
-                    trace.Info(e.Data);
-                    stdout.Add(e.Data);
-                };
-                processInvoker.ErrorDataReceived += (object sender, ProcessDataReceivedEventArgs e) =>
-                {
-                    trace.Info(e.Data);
-                    stderr.Add(e.Data);
-                };
-
-                exitCode = await processInvoker.ExecuteAsync("", "cmd.exe", "/c \"echo %TEST%\"",  new Dictionary<string, string>() { { "TEST\u0009second", "first" } }, CancellationToken.None);
-
-                trace.Info("Exit Code: {0}", exitCode);
-                Assert.Equal(0, exitCode);
-                Assert.Equal("first", stdout.First(x => !string.IsNullOrWhiteSpace(x)));
-
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Common")]
         public async Task SetTestEnvWithNullInValue()
         {
             using (TestHostContext hc = new(this))
@@ -224,40 +190,6 @@ namespace GitHub.Runner.Common.Tests
                 };
 
                 exitCode = await processInvoker.ExecuteAsync("", "cmd.exe", "/c \"echo %TEST%\"",  new Dictionary<string, string>() { { "TEST", "first\0second" } }, CancellationToken.None);
-
-                trace.Info("Exit Code: {0}", exitCode);
-                Assert.Equal(0, exitCode);
-                Assert.Equal("first", stdout.First(x => !string.IsNullOrWhiteSpace(x)));
-
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Common")]
-        public async Task SetTestEnvWithTabInValue()
-        {
-            using (TestHostContext hc = new(this))
-            {
-                Tracing trace = hc.GetTrace();
-
-                Int32 exitCode = -1;
-                var processInvoker = new ProcessInvokerWrapper();
-                processInvoker.Initialize(hc);
-                var stdout = new List<string>();
-                var stderr = new List<string>();
-                processInvoker.OutputDataReceived += (object sender, ProcessDataReceivedEventArgs e) =>
-                {
-                    trace.Info(e.Data);
-                    stdout.Add(e.Data);
-                };
-                processInvoker.ErrorDataReceived += (object sender, ProcessDataReceivedEventArgs e) =>
-                {
-                    trace.Info(e.Data);
-                    stderr.Add(e.Data);
-                };
-
-                exitCode = await processInvoker.ExecuteAsync("", "cmd.exe", "/c \"echo %TEST%\"",  new Dictionary<string, string>() { { "TEST", "first\u0009second" } }, CancellationToken.None);
 
                 trace.Info("Exit Code: {0}", exitCode);
                 Assert.Equal(0, exitCode);


### PR DESCRIPTION
Reverts actions/runner#2333

```
uses: actions/github-script@v6
with:
  script: |
    if (context.workflow != "foo") {
      console.log("hello")
    }
```

failed with `Unhandled error: SyntaxError: Unexpected token ')'`