### PR TITLE
Bypass all proxies for all hosts if `no_proxy='*'` is set

### DIFF
--- a/src/Runner.Sdk/RunnerWebProxy.cs
+++ b/src/Runner.Sdk/RunnerWebProxy.cs
@@ -164,13 +164,6 @@ namespace GitHub.Runner.Sdk
                         {
                             continue;
                         }
-
-                        // Strip leading '.' fron noproxy host
-                        if (noProxyInfo.Host.StartsWith("."))
-                        {
-                            noProxyInfo.Host = noProxyInfo.Host[1..];
-                        }
-
                         _noProxyList.Add(noProxyInfo);
                     }
                 }
@@ -231,7 +224,14 @@ namespace GitHub.Runner.Sdk
                     matchPort = string.Equals(noProxy.Port, input.Port.ToString());
                 }
 
-                matchHost = string.Equals(input.Host, noProxy.Host, StringComparison.OrdinalIgnoreCase) || input.Host.EndsWith($".{noProxy.Host}", StringComparison.OrdinalIgnoreCase);
+                if (noProxy.Host.StartsWith('.'))
+                {
+                    matchHost = input.Host.EndsWith(noProxy.Host, StringComparison.OrdinalIgnoreCase);
+                }
+                else
+                {
+                    matchHost = string.Equals(input.Host, noProxy.Host, StringComparison.OrdinalIgnoreCase) || input.Host.EndsWith($".{noProxy.Host}", StringComparison.OrdinalIgnoreCase);
+                }
 
                 if (matchHost && matchPort)
                 {

--- a/src/Runner.Sdk/RunnerWebProxy.cs
+++ b/src/Runner.Sdk/RunnerWebProxy.cs
@@ -199,12 +199,6 @@ namespace GitHub.Runner.Sdk
                 return true;
             }
 
-            // bypass on wildcard no_proxy
-            if (string.Equals(_noProxyString, "*", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
             return uri.IsLoopback || IsUriInBypassList(uri);
         }
 
@@ -212,6 +206,11 @@ namespace GitHub.Runner.Sdk
         {
             foreach (var noProxy in _noProxyList)
             {
+                // bypass on wildcard no_proxy
+                if (string.Equals(noProxy.Host, "*", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
                 var matchHost = false;
                 var matchPort = false;
 

--- a/src/Runner.Sdk/RunnerWebProxy.cs
+++ b/src/Runner.Sdk/RunnerWebProxy.cs
@@ -206,6 +206,12 @@ namespace GitHub.Runner.Sdk
                 return true;
             }
 
+            // bypass on wildcard no_proxy
+            if (string.Equals(_noProxyString, "*", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
             return uri.IsLoopback || IsUriInBypassList(uri);
         }
 

--- a/src/Runner.Sdk/RunnerWebProxy.cs
+++ b/src/Runner.Sdk/RunnerWebProxy.cs
@@ -165,6 +165,12 @@ namespace GitHub.Runner.Sdk
                             continue;
                         }
 
+                        // Strip leading '.' fron noproxy host
+                        if (noProxyInfo.Host.StartsWith("."))
+                        {
+                            noProxyInfo.Host = noProxyInfo.Host[1..];
+                        }
+
                         _noProxyList.Add(noProxyInfo);
                     }
                 }
@@ -219,14 +225,7 @@ namespace GitHub.Runner.Sdk
                     matchPort = string.Equals(noProxy.Port, input.Port.ToString());
                 }
 
-                if (noProxy.Host.StartsWith('.'))
-                {
-                    matchHost = input.Host.EndsWith(noProxy.Host, StringComparison.OrdinalIgnoreCase);
-                }
-                else
-                {
-                    matchHost = string.Equals(input.Host, noProxy.Host, StringComparison.OrdinalIgnoreCase) || input.Host.EndsWith($".{noProxy.Host}", StringComparison.OrdinalIgnoreCase);
-                }
+                matchHost = string.Equals(input.Host, noProxy.Host, StringComparison.OrdinalIgnoreCase) || input.Host.EndsWith($".{noProxy.Host}", StringComparison.OrdinalIgnoreCase);
 
                 if (matchHost && matchPort)
                 {

--- a/src/Test/L0/RunnerWebProxyL0.cs
+++ b/src/Test/L0/RunnerWebProxyL0.cs
@@ -375,6 +375,44 @@ namespace GitHub.Runner.Common.Tests
                 CleanProxyEnv();
             }
         }
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void BypassAllOnWildcardNoProxy()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("http_proxy", "http://user1:pass1%40@127.0.0.1:8888");
+                Environment.SetEnvironmentVariable("https_proxy", "http://user2:pass2%40@127.0.0.1:9999");
+                Environment.SetEnvironmentVariable("no_proxy", "*");
+                var proxy = new RunnerWebProxy();
+
+                Assert.True(proxy.IsBypassed(new Uri("https://actions.com")));
+                Assert.True(proxy.IsBypassed(new Uri("https://ggithub.com")));
+                Assert.True(proxy.IsBypassed(new Uri("https://github.comm")));
+                Assert.True(proxy.IsBypassed(new Uri("https://example.com")));
+                Assert.True(proxy.IsBypassed(new Uri("http://example.com:333")));
+                Assert.True(proxy.IsBypassed(new Uri("http://192.168.0.123:123")));
+                Assert.True(proxy.IsBypassed(new Uri("http://192.168.1.123/home")));
+                Assert.True(proxy.IsBypassed(new Uri("https://google.com")));
+                Assert.True(proxy.IsBypassed(new Uri("https://google.com:8080/inbox")));
+                Assert.True(proxy.IsBypassed(new Uri("https://github.com")));
+                Assert.True(proxy.IsBypassed(new Uri("https://GITHUB.COM")));
+                Assert.True(proxy.IsBypassed(new Uri("https://github.com/owner/repo")));
+                Assert.True(proxy.IsBypassed(new Uri("https://actions.github.com")));
+                Assert.True(proxy.IsBypassed(new Uri("https://mails.google.com")));
+                Assert.True(proxy.IsBypassed(new Uri("https://MAILS.GOOGLE.com")));
+                Assert.True(proxy.IsBypassed(new Uri("https://mails.v2.google.com")));
+                Assert.True(proxy.IsBypassed(new Uri("http://mails.v2.v3.google.com/inbox")));
+                Assert.True(proxy.IsBypassed(new Uri("https://example.com:444")));
+                Assert.True(proxy.IsBypassed(new Uri("http://example.com:444")));
+                Assert.True(proxy.IsBypassed(new Uri("http://example.COM:444")));
+            }
+            finally
+            {
+                CleanProxyEnv();
+            }
+        }
 
         [Fact]
         [Trait("Level", "L0")]

--- a/src/Test/L0/RunnerWebProxyL0.cs
+++ b/src/Test/L0/RunnerWebProxyL0.cs
@@ -386,26 +386,12 @@ namespace GitHub.Runner.Common.Tests
                 Environment.SetEnvironmentVariable("no_proxy", "*");
                 var proxy = new RunnerWebProxy();
 
+                Assert.True(proxy.IsBypassed(new Uri("http://actions.com")));
+                Assert.True(proxy.IsBypassed(new Uri("http://localhost")));
+                Assert.True(proxy.IsBypassed(new Uri("http://127.0.0.1:8080")));
                 Assert.True(proxy.IsBypassed(new Uri("https://actions.com")));
-                Assert.True(proxy.IsBypassed(new Uri("https://ggithub.com")));
-                Assert.True(proxy.IsBypassed(new Uri("https://github.comm")));
-                Assert.True(proxy.IsBypassed(new Uri("https://example.com")));
-                Assert.True(proxy.IsBypassed(new Uri("http://example.com:333")));
-                Assert.True(proxy.IsBypassed(new Uri("http://192.168.0.123:123")));
-                Assert.True(proxy.IsBypassed(new Uri("http://192.168.1.123/home")));
-                Assert.True(proxy.IsBypassed(new Uri("https://google.com")));
-                Assert.True(proxy.IsBypassed(new Uri("https://google.com:8080/inbox")));
-                Assert.True(proxy.IsBypassed(new Uri("https://github.com")));
-                Assert.True(proxy.IsBypassed(new Uri("https://GITHUB.COM")));
-                Assert.True(proxy.IsBypassed(new Uri("https://github.com/owner/repo")));
-                Assert.True(proxy.IsBypassed(new Uri("https://actions.github.com")));
-                Assert.True(proxy.IsBypassed(new Uri("https://mails.google.com")));
-                Assert.True(proxy.IsBypassed(new Uri("https://MAILS.GOOGLE.com")));
-                Assert.True(proxy.IsBypassed(new Uri("https://mails.v2.google.com")));
-                Assert.True(proxy.IsBypassed(new Uri("http://mails.v2.v3.google.com/inbox")));
-                Assert.True(proxy.IsBypassed(new Uri("https://example.com:444")));
-                Assert.True(proxy.IsBypassed(new Uri("http://example.com:444")));
-                Assert.True(proxy.IsBypassed(new Uri("http://example.COM:444")));
+                Assert.True(proxy.IsBypassed(new Uri("https://localhost")));
+                Assert.True(proxy.IsBypassed(new Uri("https://127.0.0.1:8080")));
             }
             finally
             {

--- a/src/Test/L0/RunnerWebProxyL0.cs
+++ b/src/Test/L0/RunnerWebProxyL0.cs
@@ -383,7 +383,53 @@ namespace GitHub.Runner.Common.Tests
             {
                 Environment.SetEnvironmentVariable("http_proxy", "http://user1:pass1%40@127.0.0.1:8888");
                 Environment.SetEnvironmentVariable("https_proxy", "http://user2:pass2%40@127.0.0.1:9999");
-                Environment.SetEnvironmentVariable("no_proxy", "*");
+                Environment.SetEnvironmentVariable("no_proxy", "example.com, * , example2.com");
+                var proxy = new RunnerWebProxy();
+
+                Assert.True(proxy.IsBypassed(new Uri("http://actions.com")));
+                Assert.True(proxy.IsBypassed(new Uri("http://localhost")));
+                Assert.True(proxy.IsBypassed(new Uri("http://127.0.0.1:8080")));
+                Assert.True(proxy.IsBypassed(new Uri("https://actions.com")));
+                Assert.True(proxy.IsBypassed(new Uri("https://localhost")));
+                Assert.True(proxy.IsBypassed(new Uri("https://127.0.0.1:8080")));
+            }
+            finally
+            {
+                CleanProxyEnv();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void IgnoreWildcardInNoProxySubdomain()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("http_proxy", "http://user1:pass1%40@127.0.0.1:8888");
+                Environment.SetEnvironmentVariable("https_proxy", "http://user2:pass2%40@127.0.0.1:9999");
+                Environment.SetEnvironmentVariable("no_proxy", "*.example.com");
+                var proxy = new RunnerWebProxy();
+
+                Assert.False(proxy.IsBypassed(new Uri("http://sub.example.com")));
+                Assert.False(proxy.IsBypassed(new Uri("http://example.com")));
+            }
+            finally
+            {
+                CleanProxyEnv();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void WildcardNoProxyWorksWhenOtherNoProxyAreAround()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("http_proxy", "http://user1:pass1%40@127.0.0.1:8888");
+                Environment.SetEnvironmentVariable("https_proxy", "http://user2:pass2%40@127.0.0.1:9999");
+                Environment.SetEnvironmentVariable("no_proxy", "example.com,*,example2.com");
                 var proxy = new RunnerWebProxy();
 
                 Assert.True(proxy.IsBypassed(new Uri("http://actions.com")));

--- a/src/Test/L0/RunnerWebProxyL0.cs
+++ b/src/Test/L0/RunnerWebProxyL0.cs
@@ -351,12 +351,13 @@ namespace GitHub.Runner.Common.Tests
                 Assert.False(proxy.IsBypassed(new Uri("https://actions.com")));
                 Assert.False(proxy.IsBypassed(new Uri("https://ggithub.com")));
                 Assert.False(proxy.IsBypassed(new Uri("https://github.comm")));
-                Assert.False(proxy.IsBypassed(new Uri("https://google.com")));
                 Assert.False(proxy.IsBypassed(new Uri("https://example.com")));
                 Assert.False(proxy.IsBypassed(new Uri("http://example.com:333")));
                 Assert.False(proxy.IsBypassed(new Uri("http://192.168.0.123:123")));
                 Assert.False(proxy.IsBypassed(new Uri("http://192.168.1.123/home")));
 
+                Assert.True(proxy.IsBypassed(new Uri("https://google.com")));
+                Assert.True(proxy.IsBypassed(new Uri("https://google.com:8080/inbox")));
                 Assert.True(proxy.IsBypassed(new Uri("https://github.com")));
                 Assert.True(proxy.IsBypassed(new Uri("https://GITHUB.COM")));
                 Assert.True(proxy.IsBypassed(new Uri("https://github.com/owner/repo")));

--- a/src/Test/L0/RunnerWebProxyL0.cs
+++ b/src/Test/L0/RunnerWebProxyL0.cs
@@ -351,13 +351,12 @@ namespace GitHub.Runner.Common.Tests
                 Assert.False(proxy.IsBypassed(new Uri("https://actions.com")));
                 Assert.False(proxy.IsBypassed(new Uri("https://ggithub.com")));
                 Assert.False(proxy.IsBypassed(new Uri("https://github.comm")));
+                Assert.False(proxy.IsBypassed(new Uri("https://google.com"))); // no_proxy has '.google.com', specifying only subdomains bypass
                 Assert.False(proxy.IsBypassed(new Uri("https://example.com")));
                 Assert.False(proxy.IsBypassed(new Uri("http://example.com:333")));
                 Assert.False(proxy.IsBypassed(new Uri("http://192.168.0.123:123")));
                 Assert.False(proxy.IsBypassed(new Uri("http://192.168.1.123/home")));
 
-                Assert.True(proxy.IsBypassed(new Uri("https://google.com")));
-                Assert.True(proxy.IsBypassed(new Uri("https://google.com:8080/inbox")));
                 Assert.True(proxy.IsBypassed(new Uri("https://github.com")));
                 Assert.True(proxy.IsBypassed(new Uri("https://GITHUB.COM")));
                 Assert.True(proxy.IsBypassed(new Uri("https://github.com/owner/repo")));


### PR DESCRIPTION
The behaviour of `no_proxy` is in no way standardised, and it is handled differently by the runner app vs in github actions (see actions/toolkit PR below). The behaviour in this PR is consistent with 

`no_proxy='*'` will now bypass any proxy for any host.