### PR TITLE
Run service: fix small bug

### DIFF
--- a/src/Runner.Common/RunServer.cs
+++ b/src/Runner.Common/RunServer.cs
@@ -29,7 +29,7 @@ namespace GitHub.Runner.Common
         {
             requestUri = serverUri;
 
-            _connection = VssUtil.CreateRawConnection(new Uri(serverUri.Authority), credentials);
+            _connection = VssUtil.CreateRawConnection(serverUri, credentials);
             _runServiceHttpClient = await _connection.GetClientAsync<RunServiceHttpClient>();
             _hasConnection = true;
         }


### PR DESCRIPTION
URL schema is missing and honestly not sure why we have it `new Uri(serverUri.Authority)`

Ideally, we need to have tests around this, but things are still in flux w.r.t run service so skipping that for now, I hope it's okay