### PR TITLE
Add support for ghe.com domain

### DIFF
--- a/src/Runner.Sdk/Util/UrlUtil.cs
+++ b/src/Runner.Sdk/Util/UrlUtil.cs
@@ -6,9 +6,16 @@ namespace GitHub.Runner.Sdk
     {
         public static bool IsHostedServer(UriBuilder gitHubUrl)
         {
-            return string.Equals(gitHubUrl.Host, "github.com", StringComparison.OrdinalIgnoreCase) ||
+            if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_FORCE_GHES")))
+            {
+                return false;
+            }
+
+            return 
+                string.Equals(gitHubUrl.Host, "github.com", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(gitHubUrl.Host, "www.github.com", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(gitHubUrl.Host, "github.localhost", StringComparison.OrdinalIgnoreCase);
+                string.Equals(gitHubUrl.Host, "github.localhost", StringComparison.OrdinalIgnoreCase) ||
+                gitHubUrl.Host.EndsWith(".ghe.com", StringComparison.OrdinalIgnoreCase);
         }
 
         public static Uri GetCredentialEmbeddedUrl(Uri baseUrl, string username, string password)


### PR DESCRIPTION
This PR adds support for treating domains ending in `ghe.com` as hosted.