### PR TITLE
Replace deprecated `set-output` command with environment file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
         file=$(ls)
         sha=$(sha256sum $file | awk '{ print $1 }')
         echo "Computed sha256: $sha for $file"
-        echo "::set-output name=${{matrix.runtime}}-sha256::$sha"
+        echo "${{matrix.runtime}}-sha256=$sha" >> $GITHUB_OUTPUT
       shell: bash
       id: sha
       name: Compute SHA256
@@ -140,8 +140,8 @@ jobs:
         file=$(ls)
         sha=$(sha256sum $file | awk '{ print $1 }')
         echo "Computed sha256: $sha for $file"
-        echo "::set-output name=${{matrix.runtime}}-sha256::$sha"
-        echo "::set-output name=sha256::$sha"
+        echo "${{matrix.runtime}}-sha256=$sha" >> $GITHUB_OUTPUT
+        echo "sha256=$sha" >> $GITHUB_OUTPUT
       shell: bash
       id: sha_noexternals
       name: Compute SHA256
@@ -150,8 +150,8 @@ jobs:
         file=$(ls)
         sha=$(sha256sum $file | awk '{ print $1 }')
         echo "Computed sha256: $sha for $file"
-        echo "::set-output name=${{matrix.runtime}}-sha256::$sha"
-        echo "::set-output name=sha256::$sha"
+        echo "${{matrix.runtime}}-sha256=$sha" >> $GITHUB_OUTPUT
+        echo "sha256=$sha" >> $GITHUB_OUTPUT
       shell: bash
       id: sha_noruntime
       name: Compute SHA256
@@ -160,8 +160,8 @@ jobs:
         file=$(ls)
         sha=$(sha256sum $file | awk '{ print $1 }')
         echo "Computed sha256: $sha for $file"
-        echo "::set-output name=${{matrix.runtime}}-sha256::$sha"
-        echo "::set-output name=sha256::$sha"
+        echo "${{matrix.runtime}}-sha256=$sha" >> $GITHUB_OUTPUT
+        echo "sha256=$sha" >> $GITHUB_OUTPUT
       shell: bash
       id: sha_noruntime_noexternals
       name: Compute SHA256

--- a/src/Test/TestData/conditional_composite_action.yml
+++ b/src/Test/TestData/conditional_composite_action.yml
@@ -25,21 +25,21 @@ runs:
       - run: exit ${{ inputs.exit-code }}
         shell: bash
 
-      - run: echo "::set-output name=default::true"
+      - run: echo "default=true" >> $GITHUB_OUTPUT
         id: default-conditional
         shell: bash
 
-      - run: echo "::set-output name=success::true"
+      - run: echo "success=true" >> $GITHUB_OUTPUT
         id: success-conditional
         shell: bash
         if: success()
 
-      - run: echo "::set-output name=failure::true"
+      - run: echo "failure=true" >> $GITHUB_OUTPUT
         id: failure-conditional
         shell: bash
         if: failure()
 
-      - run: echo "::set-output name=always::true"
+      - run: echo "always=true" >> $GITHUB_OUTPUT
         id: always-conditional
         shell: bash
         if: always()


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

> **Warning** The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Update files to use environment file instead of deprecated `set-output` command. 
I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```