### PR TITLE
Fix color code detection in OutputManager

### DIFF
--- a/src/Runner.Worker/Handlers/OutputManager.cs
+++ b/src/Runner.Worker/Handlers/OutputManager.cs
@@ -13,10 +13,10 @@ namespace GitHub.Runner.Worker.Handlers
 {
     public sealed class OutputManager : IDisposable
     {
-        private const string _colorCodePrefix = "\033[";
+        private const string _colorCodePrefix = "\x1b[";
         private const int _maxAttempts = 3;
         private const string _timeoutKey = "GITHUB_ACTIONS_RUNNER_ISSUE_MATCHER_TIMEOUT";
-        private static readonly Regex _colorCodeRegex = new(@"\x0033\[[0-9;]*m?", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _colorCodeRegex = new(@"\x1b\[[0-9;]*m?", RegexOptions.Compiled | RegexOptions.CultureInvariant);
         private readonly IActionCommandManager _commandManager;
         private readonly ContainerInfo _container;
         private readonly IExecutionContext _executionContext;

--- a/src/Test/L0/Worker/OutputManagerL0.cs
+++ b/src/Test/L0/Worker/OutputManagerL0.cs
@@ -403,7 +403,8 @@ namespace GitHub.Runner.Common.Tests.Worker
                         },
                     },
                 });
-                Process("the error: \033[31mred, \033[1;31mbright red, \033[mreset");
+                // Shells may support "\033", but in C# that translates to a null followed by "33"
+                Process("the error: \x1B[31mred, \x1B[1;31mbright red, \x1B[mreset");
                 Assert.Equal(1, _issues.Count);
                 Assert.Equal("red, bright red, reset", _issues[0].Item1.Message);
                 Assert.Equal("the error: red, bright red, reset", _issues[0].Item2);


### PR DESCRIPTION
Fixes #2341 

This was a simple case of a mistaken translation from shell escape codes (which support octal `\NNN`) to C# (which only supports hex `\xNN` and `\uNNNN` in string literals, but does support octal `\NNN` in `Regex`). The test was passing because it also used incorrect escape codes, which matched the incorrect prefix.

Edit: manual testing against the original repro repo: https://github.com/ian-h-chamberlain/actions-color-repro/actions/runs/4157866967