### PR TITLE
Remove latest tag from runner image publishing workflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -55,7 +55,6 @@ jobs:
           context: ./images
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image.outputs.version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           build-args: |
             RUNNER_VERSION=${{ steps.image.outputs.version }}
           push: true


### PR DESCRIPTION
### Context

The `latest` tag creates a big maintenance and security burden. Staying aligned with https://github.com/actions/actions-runner-controller/issues/2056 I think it's best to remove the latest tag from this runner image as well.

Users will need to pin a specific runner version and create more controlled mechanisms to switch to the latest version.