### PR TITLE
Add --no-default-labels config option to self-hosted runners

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -132,6 +132,7 @@ namespace GitHub.Runner.Common
                     public static readonly string GenerateServiceConfig = "generateServiceConfig";
                     public static readonly string Help = "help";
                     public static readonly string Local = "local";
+                    public static readonly string NoDefaultLabels = "no-default-labels";
                     public static readonly string Replace = "replace";
                     public static readonly string DisableUpdate = "disableupdate";
                     public static readonly string Once = "once"; // Keep this around since customers still relies on it

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace GitHub.Runner.Common
 {

--- a/src/Runner.Listener/CommandSettings.cs
+++ b/src/Runner.Listener/CommandSettings.cs
@@ -29,8 +29,8 @@ namespace GitHub.Runner.Listener
         private readonly Dictionary<string, string[]> validOptions = new()
         {
             // Valid configure flags and args
-            [Constants.Runner.CommandLine.Commands.Configure] = 
-                new string[] 
+            [Constants.Runner.CommandLine.Commands.Configure] =
+                new string[]
                 {
                     Constants.Runner.CommandLine.Flags.DisableUpdate,
                     Constants.Runner.CommandLine.Flags.Ephemeral,
@@ -184,7 +184,7 @@ namespace GitHub.Runner.Listener
             {
                 command = Constants.Runner.CommandLine.Commands.Warmup;
             }
-            
+
             return command;
         }
 

--- a/src/Runner.Listener/CommandSettings.cs
+++ b/src/Runner.Listener/CommandSettings.cs
@@ -38,6 +38,7 @@ namespace GitHub.Runner.Listener
                     Constants.Runner.CommandLine.Flags.Replace,
                     Constants.Runner.CommandLine.Flags.RunAsService,
                     Constants.Runner.CommandLine.Flags.Unattended,
+                    Constants.Runner.CommandLine.Flags.NoDefaultLabels,
                     Constants.Runner.CommandLine.Args.Auth,
                     Constants.Runner.CommandLine.Args.Labels,
                     Constants.Runner.CommandLine.Args.MonitorSocketAddress,
@@ -85,6 +86,7 @@ namespace GitHub.Runner.Listener
         public bool Ephemeral => TestFlag(Constants.Runner.CommandLine.Flags.Ephemeral);
         public bool GenerateServiceConfig => TestFlag(Constants.Runner.CommandLine.Flags.GenerateServiceConfig);
         public bool Help => TestFlag(Constants.Runner.CommandLine.Flags.Help);
+        public bool NoDefaultLabels => TestFlag(Constants.Runner.CommandLine.Flags.NoDefaultLabels);
         public bool Unattended => TestFlag(Constants.Runner.CommandLine.Flags.Unattended);
         public bool Version => TestFlag(Constants.Runner.CommandLine.Flags.Version);
         public bool RemoveLocalConfig => TestFlag(Constants.Runner.CommandLine.Flags.Local);

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -528,14 +528,15 @@ namespace GitHub.Runner.Listener.Configuration
 
             agent.Labels.Clear();
 
-            if (noDefaultLabels == false) { 
+            if (!noDefaultLabels)
+            {
                 agent.Labels.Add(new AgentLabel("self-hosted", LabelType.System));
                 agent.Labels.Add(new AgentLabel(VarUtil.OS, LabelType.System));
                 agent.Labels.Add(new AgentLabel(VarUtil.OSArchitecture, LabelType.System));
-            } else {
-                if (userLabels.Count == 0) {
-                    throw new NotSupportedException("Disabling default labels via --no-default-labels without specifying --labels is not supported");
-                }
+            }
+            else if (userLabels.Count == 0)
+            {
+                throw new NotSupportedException("Disabling default labels via --no-default-labels without specifying --labels is not supported");
             }
 
             foreach (var userLabel in userLabels)
@@ -561,14 +562,15 @@ namespace GitHub.Runner.Listener.Configuration
                 DisableUpdate = disableUpdate
             };
 
-            if (noDefaultLabels == false) { 
+            if (!noDefaultLabels)
+            {
                 agent.Labels.Add(new AgentLabel("self-hosted", LabelType.System));
                 agent.Labels.Add(new AgentLabel(VarUtil.OS, LabelType.System));
                 agent.Labels.Add(new AgentLabel(VarUtil.OSArchitecture, LabelType.System));
-            } else {
-                if (userLabels.Count == 0) {
-                    throw new NotSupportedException("Disabling default labels via --no-default-labels without specifying --labels is not supported");
-                }
+            }
+            else if (userLabels.Count == 0)
+            {
+                throw new NotSupportedException("Disabling default labels via --no-default-labels without specifying --labels is not supported");
             }
 
             foreach (var userLabel in userLabels)

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -534,7 +534,7 @@ namespace GitHub.Runner.Listener.Configuration
                 agent.Labels.Add(new AgentLabel(VarUtil.OSArchitecture, LabelType.System));
             } else {
                 if (userLabels.Count == 0) {
-                    throw new NotSupportedException("Disabling default labels via --nodefault-labels without specifying --labels is not supported");
+                    throw new NotSupportedException("Disabling default labels via --no-default-labels without specifying --labels is not supported");
                 }
             }
 

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -136,7 +136,7 @@ namespace GitHub.Runner.Listener
                 if (command.Remove)
                 {
                     // only remove local config files and exit
-                    if(command.RemoveLocalConfig)
+                    if (command.RemoveLocalConfig)
                     {
                         configManager.DeleteLocalRunnerConfig();
                         return Constants.Runner.ReturnCode.Success;

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -652,7 +652,8 @@ Config Options:
  --token string         Registration token. Required if unattended
  --name string          Name of the runner to configure (default {Environment.MachineName ?? "myrunner"})
  --runnergroup string   Name of the runner group to add this runner to (defaults to the default runner group)
- --labels string        Extra labels in addition to the default: 'self-hosted,{Constants.Runner.Platform},{Constants.Runner.PlatformArchitecture}'
+ --labels string        Custom labels that will be added to the runner. This option is mandatory if --no-default-labels is used.
+ --no-default-labels    Disables adding the default labels: 'self-hosted,{Constants.Runner.Platform},{Constants.Runner.PlatformArchitecture}'
  --local                Removes the runner config files from your local machine. Used as an option to the remove command
  --work string          Relative runner work directory (default {Constants.Path.WorkDirectory})
  --replace              Replace any existing runner with the same name (default false)


### PR DESCRIPTION
My apologies for the large wall of text bellow :smile: .

This change allows us to remove the default labels (`self-hosted`, `linux`, `x64` for example) attached to runners. In a lot of cases, workflow authors only include the `self-hosted` label to target runners. In an environment where we manage pools of ephemeral self-hosted runners, this scenario negates the usefulness of custom labels, causing a random runner to pick up a job.

For example, if you have a set of runners with custom labels like:

  * gpu
  * high-memory

And another with:

  * fpga
  * medium-memory

And the workflow author defines just ```self-hosted``` (because it's easy and the documentation encourages authors to use it to target self hosted runners), you may get a runner with a `gpu` when in fact you required one with `fpga`.

Yes, teams could be encouraged to target runners using only custom labels, but when you have many teams, this doesn't always work out, and we end up consuming runner types we should not, potentially generating unnecessary cost (gpu instances may be more expensive than general purpose ones).

It's easier to deal with support tickets where a team asks why the `self-hosted` label is not working, than having the ops team responsible for maintaining the runners, ping each team asking them to change their workflows so as not to accidentally consume expensive runners when they actually should be using general purpose runners.

Runner groups are only available to enterprise users. Removing the default labels would be useful even for single repos with more collaborators and free tier orgs that a lot of open source projects use. It's also simpler to use labels to target runners if we don't have strict ACL requirements  (that groups enable) and we simply want a simple way to target specific runners.

Allowing us to remove the default labels will give us the ability to define unique label sets and thus schedule jobs more efficiently. It also allows us to better react to `queued` workflow webhook and pick the right runner type to spin up if we have automation tools that allow us to define multiple pools with different characteristics (like detailed above). This saves on cost as we can correctly target runner types we can choose to spin up only on-demand as opposed to having them linger around.

Hoping this makes sense smile :smile:.