### PR TITLE
fix #349 #403 #947 - fix headless setup on Mac OSX using ssh

### DIFF
--- a/src/Misc/layoutbin/actions.runner.plist.template
+++ b/src/Misc/layoutbin/actions.runner.plist.template
@@ -27,5 +27,12 @@
     <string>Interactive</string>
     <key>SessionCreate</key>
     <true/>
+    <key>LimitLoadToSessionType</key>
+    <array>
+      <string>Aqua</string>
+      <string>LoginWindow</string>
+      <string>Background</string>
+      <string>StandardIO</string>
+    </array>
   </dict>
 </plist>

--- a/src/Misc/layoutbin/actions.runner.plist.template
+++ b/src/Misc/layoutbin/actions.runner.plist.template
@@ -33,6 +33,7 @@
       <string>LoginWindow</string>
       <string>Background</string>
       <string>StandardIO</string>
+      <string>System</string>
     </array>
   </dict>
 </plist>

--- a/src/Misc/layoutbin/darwin.svc.sh.template
+++ b/src/Misc/layoutbin/darwin.svc.sh.template
@@ -80,14 +80,14 @@ function install()
 function start()
 {
     echo "starting ${SVC_NAME}"
-    launchctl load -w "${PLIST_PATH}" || failed "failed to load ${PLIST_PATH}"
+    launchctl load -w -S Background "${PLIST_PATH}" || failed "failed to load ${PLIST_PATH}"
     status
 }
 
 function stop()
 {
     echo "stopping ${SVC_NAME}"
-    launchctl unload "${PLIST_PATH}" || failed "failed to unload ${PLIST_PATH}"
+    launchctl unload -S Background  "${PLIST_PATH}" || failed "failed to unload ${PLIST_PATH}"
     status
 }
 


### PR DESCRIPTION
This should fix #349 #403 #947 because it fixes the `Could not find domain for port (Aqua)` error, by moving the agent to the Background context where it belongs. 

**Why it works**  

By default (without the LimitLoadToSessionType key in the plist file) launchd tries to load the agent into the Aqua context but this context doesnt exist when you are only logged in using ssh. The same applies to launchctl as it also by default tries to load the agent into the Aqua context unless you specify a different context (using the `-S` option in this case `-S Background` ). The Background context on the other hand exists when you are logged in using ssh and when you are logged in using the GUI, or to be more precises almost always when you are logged in somehow.

**Potential Problems**  
 If the runner (or more specificly the sh file I changed) is updated to my changed version while the service is loaded, you won't be able to unload the currently loaded agent as it is not loaded in the Background context but instead int the Aqua context. 
I dont know how you want to deal with this problem, but I have created seperate pull request #2450  that fixes this potential problem as well, because I don't know If my solution is acceptable. If someone wants to implement their own solution see the further explanation below.
<details>
  <summary>further explanation of the potential problem</summary>

In the beginning the agent was loaded using this line ` launchctl load -w "${PLIST_PATH}" || failed "failed to load ${PLIST_PATH}"` since no context is specified the agent is now loaded into the Aqua context on the system because it is the default one.   
Now the runner is updated in a way that my code changes are applied without unloading the service before updating, or restarting the system (because a restart will also unload all services), meaning the runner is updated while the agent is loaded, threfore the following line will be used to unload the service after the update `launchctl unload -S Background  "${PLIST_PATH}" || failed "failed to unload ${PLIST_PATH}"` which will fail because the agent is (as mentioned above) still loaded into the Aqua context and because of that cant be unloaded from the Background context but instead must be unloaded from the Aqua context using this line `launchctl unload "${PLIST_PATH}" || failed "failed to unload ${PLIST_PATH}"` (yes `launchctl unload -S Aqua  "${PLIST_PATH}" || failed "failed to unload ${PLIST_PATH}"` would also work.) when unloading for the first time after the update.   
After this first initial unload after the update the sevice can be unloaded from the Background context without any problems using this line `launchctl unload -S Background  "${PLIST_PATH}" || failed "failed to unload ${PLIST_PATH}"` because it was (breforehand) loaded in the Background context using `launchctl load -w -S Background "${PLIST_PATH}" || failed "failed to load ${PLIST_PATH}"`
No you cant load the same service twice into different contexts. 

 **TLDR**. 
The problem occurs with liveupdates only.
To mitigate the problem, the agent when unloaded for the first time after the update must be unloaded using`launchctl unload "${PLIST_PATH}" || failed "failed to unload ${PLIST_PATH}"`

</details> 

**Background**  
  I am currently working on a small complete admins guide to launchd and therefore doing extensive research.
  I came across this [Issue](https://github.com/buildkite/docs/issues/353) and saw it mentioned here multiple times.
