### PR TITLE
Don't require GUI to run as service

### DIFF
--- a/src/Misc/layoutbin/actions.runner.plist.template
+++ b/src/Misc/layoutbin/actions.runner.plist.template
@@ -13,13 +13,13 @@
     <key>WorkingDirectory</key>
     <string>{{RunnerRoot}}</string>
     <key>RunAtLoad</key>
-    <true/>    
+    <true/>
     <key>StandardOutPath</key>
     <string>{{UserHome}}/Library/Logs/{{SvcName}}/stdout.log</string>
     <key>StandardErrorPath</key>
     <string>{{UserHome}}/Library/Logs/{{SvcName}}/stderr.log</string>
     <key>EnvironmentVariables</key>
-    <dict> 
+    <dict>
       <key>ACTIONS_RUNNER_SVC</key>
       <string>1</string>
     </dict>
@@ -27,5 +27,12 @@
     <string>Interactive</string>
     <key>SessionCreate</key>
     <true/>
+    <key>LimitLoadToSessionType</key>
+    <array>
+      <string>Background</string>
+      <string>Aqua</string>
+      <string>LoginWindow</string>
+      <string>StandardIO</string>
+    </array>
   </dict>
 </plist>

--- a/src/Misc/layoutbin/darwin.svc.sh.template
+++ b/src/Misc/layoutbin/darwin.svc.sh.template
@@ -67,7 +67,7 @@ function install()
     mv "${TEMP_PATH}" "${PLIST_PATH}" || failed "failed to copy plist"
 
     # Since we started with sudo, runsvc.sh will be owned by root. Change this to current login user.
-    echo Creating runsvc.sh    
+    echo Creating runsvc.sh
     cp ./bin/runsvc.sh ./runsvc.sh || failed "failed to copy runsvc.sh"
     chmod u+x ./runsvc.sh || failed "failed to set permission for runsvc.sh"
 
@@ -80,14 +80,14 @@ function install()
 function start()
 {
     echo "starting ${SVC_NAME}"
-    launchctl load -w "${PLIST_PATH}" || failed "failed to load ${PLIST_PATH}"
+    launchctl bootstrap user/${user_id} "${PLIST_PATH}" || failed "failed to load ${PLIST_PATH}"
     status
 }
 
 function stop()
 {
     echo "stopping ${SVC_NAME}"
-    launchctl unload "${PLIST_PATH}" || failed "failed to unload ${PLIST_PATH}"
+    launchctl bootout user/${user_id} "${PLIST_PATH}" || true "failed to unload ${PLIST_PATH}"
     status
 }
 
@@ -115,7 +115,7 @@ function status()
     fi
 
     echo
-    status_out=`launchctl list | grep "${SVC_NAME}"`
+    status_out=`launchctl print user/${user_id} | grep "${SVC_NAME}"`
     if [ ! -z "$status_out" ]; then
         echo Started:
         echo $status_out


### PR DESCRIPTION
There are a couple of changes in this pull request:

1. Don't require GUI to run as service
2. Use updated launchctl syntax
3. Don't require running service to uninstall

1) This is achieved by setting the session to be `Background` instead of the default `Aqua`. Since Mac machines are supported on AWS and it's cumbersome to require the use of a GUI, running this as a background service makes sense.
2) Starting with macOS 10.10 there's a new syntax for `launchctl`. Specifically I make use of `launchctl bootstrap user/UID` and `launchctl bootout user/UID`. Specifying the `user` context rather than `gui` makes sure this service runs in the background as well.
3) Somewhat unrelated perhaps but in testing I noticed that it was impossible to uninstall the service after stopping it. `stop()` would trigger the `failed` state if the service was already stopped, halting execution of the rest of the cleanup code. This would mean that if you can't start the service and want to uninstall it, you can't. I think returning `true` with the same error message makes more sense.

I only later realized this pull request is similar to https://github.com/actions/runner/pull/2449, though it doesn't use the updated launchctl syntax. In my testing I wasn't able to get that pull request to work either. The updated syntax was required to run in the background for me. This fixes #947 and #1056.