### PR TITLE
Support matrix context in output keys

### DIFF
--- a/src/Sdk/DTPipelines/workflow-v1.0.json
+++ b/src/Sdk/DTPipelines/workflow-v1.0.json
@@ -215,6 +215,9 @@
     },
 
     "job-outputs": {
+      "context": [
+        "matrix"
+      ],
       "mapping": {
         "loose-key-type": "non-empty-string",
         "loose-value-type": "string-runner-context"


### PR DESCRIPTION
Currently outputs for matrix jobs are represented by a single output and only the last successful matrix job is used to populate the output. This prevents users from being able to target output from a specific job and can lead to unpredictable results since the matrix jobs don't run in a guaranteed order.

So as part of the improvements, we want to support
Allow the `matrix context` to be used to define the output variable name. This allows users to make the output completely deterministic if they choose to include all dimensions of the matrix in their key.

```yml
outputs:
  ${{ matrix.os }}_${{ matrix.arch }}_result: ${{ steps.step1.outputs.test }}
```

Example using all dimensions in output key:
```yml
jobs:
  job1:
    runs-on: ubuntu-latest
    strategy:
      matrix:
        os: ['linux', 'windows','macos']
        arch: ['x86','x64']
    outputs:
      ${{ matrix.os }}_${{ matrix.arch }}_result: ${{ steps.step1.outputs.test }}
    steps:
      - id: step1
        run: "test=${{ matrix.os }} - ${{ matrix.arch }}" >> $GITHUB_OUTPUT
  job2:
    runs-on: ubuntu-latest
    needs: job1
    steps:
      - run: echo ${{ needs.job1.outputs["linux_x86_result"] }}
```

Please note that: Server side changes are still in-progess