### PR TITLE
Update runner container hooks version to 0.3.0

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:6.0 as build
 
 ARG RUNNER_VERSION
 ARG RUNNER_ARCH="x64"
-ARG RUNNER_CONTAINER_HOOKS_VERSION=0.2.0
+ARG RUNNER_CONTAINER_HOOKS_VERSION=0.3.0
 ARG DOCKER_VERSION=20.10.23
 
 RUN apt update -y && apt install curl unzip -y


### PR DESCRIPTION
### Context

A new version of the container hooks has been released https://github.com/actions/runner-container-hooks/pull/68