### PR TITLE
Fix JIT configurations on Windows

### DIFF
--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -220,7 +220,7 @@ namespace GitHub.Runner.Listener
 #endif
                             File.WriteAllBytes(configFile, configContent);
                             File.SetAttributes(configFile, File.GetAttributes(configFile) | FileAttributes.Hidden);
-                            Trace.Info($"Save {configContent.Length} chars to '{configFile}'.");
+                            Trace.Info($"Saved {configContent.Length} bytes to '{configFile}'.");
                         }
                     }
                     catch (Exception ex)


### PR DESCRIPTION
JIT configurations don't work on Windows because all configuration files get written as plain text. On Windows, the runner then tries to decrypt the `.credentials_rsaparams` file using `ProtectedData.Unprotect`, which fails if the file contents were never encrypted.

I've tested this patch on Windows and Linux and everything seems to work as expected.