### PR TITLE
Register Runners against V2 servers

### DIFF
--- a/src/Runner.Common/RunnerDotcomServer.cs
+++ b/src/Runner.Common/RunnerDotcomServer.cs
@@ -17,7 +17,7 @@ namespace GitHub.Runner.Common
     {
         Task<List<TaskAgent>> GetRunnersAsync(int runnerGroupId, string githubUrl, string githubToken, string agentName);
 
-        Task<TaskAgent> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken, string publicKey, string hostId);
+        Task<DistributedTask.WebApi.Runner> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken, string publicKey);
         Task<List<TaskAgentPool>> GetRunnerGroupsAsync(string githubUrl, string githubToken);
 
         string GetGitHubRequestId(HttpResponseHeaders headers);
@@ -136,7 +136,7 @@ namespace GitHub.Runner.Common
             return agentPools?.ToAgentPoolList();
         }
 
-        public async Task<TaskAgent> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken, string publicKey, string hostId)
+        public async Task<DistributedTask.WebApi.Runner> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken, string publicKey)
         {
             var gitHubUrlBuilder = new UriBuilder(githubUrl);
             var path = gitHubUrlBuilder.Path.Split('/', '\\', StringSplitOptions.RemoveEmptyEntries);
@@ -159,20 +159,12 @@ namespace GitHub.Runner.Common
                         {"updates_disabled", agent.DisableUpdate},
                         {"ephemeral", agent.Ephemeral},
                         {"labels", agent.Labels},
-                        {"public_key", publicKey},
-                        {"host_id", hostId},
+                        {"public_key", publicKey}
                     };
 
             var body = new StringContent(StringUtil.ConvertToJson(bodyObject), null, "application/json");
 
-            var runner = await RetryRequest<DistributedTask.WebApi.Runner>(githubApiUrl, githubToken, RequestType.Post, 3, "Failed to add agent", body);
-            agent.Id = runner.Id;
-            agent.Authorization = new TaskAgentAuthorization()
-            {
-                AuthorizationUrl = runner.RunnerAuthorization.AuthorizationUrl,
-                ClientId = new Guid(runner.RunnerAuthorization.ClientId),
-            };
-            return agent;
+            return await RetryRequest<DistributedTask.WebApi.Runner>(githubApiUrl, githubToken, RequestType.Post, 3, "Failed to add agent", body);
         }
 
         private async Task<T> RetryRequest<T>(string githubApiUrl, string githubToken, RequestType requestType, int maxRetryAttemptsCount = 5, string errorMessage = null, StringContent body = null)

--- a/src/Runner.Common/RunnerDotcomServer.cs
+++ b/src/Runner.Common/RunnerDotcomServer.cs
@@ -136,7 +136,6 @@ namespace GitHub.Runner.Common
             return agentPools?.ToAgentPoolList();
         }
 
-        // return runner and the new server URL
         public async Task<DistributedTask.WebApi.Runner> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken, string publicKey)
         {
             var gitHubUrlBuilder = new UriBuilder(githubUrl);

--- a/src/Runner.Common/RunnerDotcomServer.cs
+++ b/src/Runner.Common/RunnerDotcomServer.cs
@@ -234,19 +234,5 @@ namespace GitHub.Runner.Common
             }
             return string.Empty;
         }
-
-
-        // Copy the id and authorization from the runner to the agent.
-        public static TaskAgent Merge(TaskAgent agent, DistributedTask.WebApi.Runner runner)
-        {
-            agent.Id = runner.Id;
-            agent.Authorization = new TaskAgentAuthorization()
-            {
-                AuthorizationUrl = runner.RunnerAuthorization.AuthorizationUrl,
-                ClientId = new Guid(runner.RunnerAuthorization.ClientId)
-            };
-
-            return agent;
-        }
     }
 }

--- a/src/Runner.Common/RunnerDotcomServer.cs
+++ b/src/Runner.Common/RunnerDotcomServer.cs
@@ -17,7 +17,7 @@ namespace GitHub.Runner.Common
     {
         Task<List<TaskAgent>> GetRunnersAsync(int runnerGroupId, string githubUrl, string githubToken, string agentName);
 
-        Task<TaskAgent> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken);
+        Task<TaskAgent> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken, string publicKey);
         Task<List<TaskAgentPool>> GetRunnerGroupsAsync(string githubUrl, string githubToken);
 
         string GetGitHubRequestId(HttpResponseHeaders headers);
@@ -136,7 +136,7 @@ namespace GitHub.Runner.Common
             return agentPools?.ToAgentPoolList();
         }
 
-        public async Task<TaskAgent> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken)
+        public async Task<TaskAgent> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken, string publicKey)
         {
             var gitHubUrlBuilder = new UriBuilder(githubUrl);
             var path = gitHubUrlBuilder.Path.Split('/', '\\', StringSplitOptions.RemoveEmptyEntries);
@@ -159,6 +159,7 @@ namespace GitHub.Runner.Common
                         {"updates_disabled", agent.DisableUpdate},
                         {"ephemeral", agent.Ephemeral},
                         {"labels", agent.Labels},
+                        {"public_key", publicKey},
                     };
 
             var body = new StringContent(StringUtil.ConvertToJson(bodyObject), null, "application/json");

--- a/src/Runner.Common/RunnerDotcomServer.cs
+++ b/src/Runner.Common/RunnerDotcomServer.cs
@@ -17,7 +17,7 @@ namespace GitHub.Runner.Common
     {
         Task<List<TaskAgent>> GetRunnersAsync(int runnerGroupId, string githubUrl, string githubToken, string agentName);
 
-        Task<(DistributedTask.WebApi.TaskAgent, string)> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken, string publicKey);
+        Task<DistributedTask.WebApi.Runner> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken, string publicKey);
         Task<List<TaskAgentPool>> GetRunnerGroupsAsync(string githubUrl, string githubToken);
 
         string GetGitHubRequestId(HttpResponseHeaders headers);
@@ -137,7 +137,7 @@ namespace GitHub.Runner.Common
         }
 
         // return runner and the new server URL
-        public async Task<(DistributedTask.WebApi.TaskAgent, string)> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken, string publicKey)
+        public async Task<DistributedTask.WebApi.Runner> AddRunnerAsync(int runnerGroupId, TaskAgent agent, string githubUrl, string githubToken, string publicKey)
         {
             var gitHubUrlBuilder = new UriBuilder(githubUrl);
             var path = gitHubUrlBuilder.Path.Split('/', '\\', StringSplitOptions.RemoveEmptyEntries);
@@ -165,9 +165,7 @@ namespace GitHub.Runner.Common
 
             var body = new StringContent(StringUtil.ConvertToJson(bodyObject), null, "application/json");
 
-            var runner = await RetryRequest<DistributedTask.WebApi.Runner>(githubApiUrl, githubToken, RequestType.Post, 3, "Failed to add agent", body);
-
-            return (RunnerDotcomServer.Merge(agent, runner), runner.RunnerAuthorization.ServerUrl);
+            return await RetryRequest<DistributedTask.WebApi.Runner>(githubApiUrl, githubToken, RequestType.Post, 3, "Failed to add agent", body);
         }
 
         private async Task<T> RetryRequest<T>(string githubApiUrl, string githubToken, RequestType requestType, int maxRetryAttemptsCount = 5, string errorMessage = null, StringContent body = null)

--- a/src/Runner.Common/RunnerDotcomServer.cs
+++ b/src/Runner.Common/RunnerDotcomServer.cs
@@ -165,8 +165,7 @@ namespace GitHub.Runner.Common
 
             var body = new StringContent(StringUtil.ConvertToJson(bodyObject), null, "application/json");
 
-            var response = await RetryRequest(githubApiUrl, githubToken, RequestType.Post, 3, "Failed to add agent", body);
-            var runner = StringUtil.ConvertFromJson<GitHub.DistributedTask.WebApi.Runner>(response);
+            var runner = await RetryRequest<DistributedTask.WebApi.Runner>(githubApiUrl, githubToken, RequestType.Post, 3, "Failed to add agent", body);
             agent.Id = runner.Id;
             agent.Authorization = new TaskAgentAuthorization()
             {

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -196,6 +196,11 @@ namespace GitHub.Runner.Listener
             var configManager = HostContext.GetService<IConfigurationManager>();
             _settings = configManager.LoadSettings();
 
+            if (_settings.ServerUrlV2 == null)
+            {
+                throw new InvalidOperationException("ServerUrlV2 is not set");
+            }
+
             var credMgr = HostContext.GetService<ICredentialManager>();
             VssCredentials creds = credMgr.LoadCredentials();
             await _brokerServer.ConnectAsync(new Uri(_settings.ServerUrlV2), creds);

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -299,9 +299,15 @@ namespace GitHub.Runner.Listener.Configuration
                     {
                         if (runnerSettings.UseV2Flow)
                         {
-                            var (newAgent, serverUrl) = await _dotcomServer.AddRunnerAsync(runnerSettings.PoolId, agent, runnerSettings.GitHubUrl, registerToken, publicKeyXML);
-                            runnerSettings.ServerUrlV2 = serverUrl;
-                            agent = newAgent;
+                            var runner = await _dotcomServer.AddRunnerAsync(runnerSettings.PoolId, agent, runnerSettings.GitHubUrl, registerToken, publicKeyXML);
+                            runnerSettings.ServerUrlV2 = runner.RunnerAuthorization.ServerUrl;
+
+                            agent.Id = runner.Id;
+                            agent.Authorization = new TaskAgentAuthorization()
+                            {
+                                AuthorizationUrl = runner.RunnerAuthorization.AuthorizationUrl,
+                                ClientId = new Guid(runner.RunnerAuthorization.ClientId)
+                            };
                         }
                         else
                         {

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -14,7 +14,6 @@ using GitHub.Runner.Sdk;
 using GitHub.Services.Common;
 using GitHub.Services.Common.Internal;
 using GitHub.Services.OAuth;
-using GitHub.Services.WebApi.Jwt;
 
 namespace GitHub.Runner.Listener.Configuration
 {

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -181,9 +181,11 @@ namespace GitHub.Runner.Listener.Configuration
             // We want to use the native CSP of the platform for storage, so we use the RSACSP directly
             RSAParameters publicKey;
             var keyManager = HostContext.GetService<IRSAKeyManager>();
+            string publicKeyXML;
             using (var rsa = keyManager.CreateKey())
             {
                 publicKey = rsa.ExportParameters(false);
+                publicKeyXML = rsa.ToXmlString(includePrivateParameters: false);
             }
 
             _term.WriteSection("Runner Registration");
@@ -297,7 +299,7 @@ namespace GitHub.Runner.Listener.Configuration
                     {
                         if (runnerSettings.UseV2Flow)
                         {
-                            agent = await _dotcomServer.AddRunnerAsync(runnerSettings.PoolId, agent, runnerSettings.GitHubUrl, registerToken);
+                            agent = await _dotcomServer.AddRunnerAsync(runnerSettings.PoolId, agent, runnerSettings.GitHubUrl, registerToken, publicKeyXML);
                         }
                         else
                         {

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -299,9 +299,9 @@ namespace GitHub.Runner.Listener.Configuration
                     {
                         if (runnerSettings.UseV2Flow)
                         {
-                            var runner = await _dotcomServer.AddRunnerAsync(runnerSettings.PoolId, agent, runnerSettings.GitHubUrl, registerToken, publicKeyXML);
-                            runner.ApplyToTaskAgent(agent);
-                            runnerSettings.ServerUrlV2 = runner.RunnerAuthorization.ServerUrl;
+                            var (newAgent, serverUrl) = await _dotcomServer.AddRunnerAsync(runnerSettings.PoolId, agent, runnerSettings.GitHubUrl, registerToken, publicKeyXML);
+                            runnerSettings.ServerUrlV2 = serverUrl;
+                            agent = newAgent;
                         }
                         else
                         {

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -343,6 +343,7 @@ namespace GitHub.Runner.Listener
         {
             if (settings.UseV2Flow)
             {
+                Trace.Info($"Using BrokerMessageListener");
                 var brokerListener = new BrokerMessageListener();
                 brokerListener.Initialize(HostContext);
                 return brokerListener;

--- a/src/Sdk/DTWebApi/WebApi/ListRunnersResponse.cs
+++ b/src/Sdk/DTWebApi/WebApi/ListRunnersResponse.cs
@@ -34,13 +34,6 @@ namespace GitHub.DistributedTask.WebApi
             set;
         }
 
-        public List<TaskAgent> ToTaskAgents()
-        {
-            List<TaskAgent> taskAgents = new List<TaskAgent>();
-
-            return Runners.Select(runner => new TaskAgent() { Name = runner.Name }).ToList();
-        }
-
         public ListRunnersResponse Clone()
         {
             return new ListRunnersResponse(this);
@@ -48,8 +41,6 @@ namespace GitHub.DistributedTask.WebApi
 
         public List<TaskAgent> ToTaskAgents()
         {
-            List<TaskAgent> taskAgents = new List<TaskAgent>();
-
             return Runners.Select(runner => new TaskAgent() { Name = runner.Name }).ToList();
         }
     }

--- a/src/Sdk/DTWebApi/WebApi/ListRunnersResponse.cs
+++ b/src/Sdk/DTWebApi/WebApi/ListRunnersResponse.cs
@@ -34,6 +34,13 @@ namespace GitHub.DistributedTask.WebApi
             set;
         }
 
+        public List<TaskAgent> ToTaskAgents()
+        {
+            List<TaskAgent> taskAgents = new List<TaskAgent>();
+
+            return Runners.Select(runner => new TaskAgent() { Name = runner.Name }).ToList();
+        }
+
         public ListRunnersResponse Clone()
         {
             return new ListRunnersResponse(this);

--- a/src/Sdk/DTWebApi/WebApi/Runner.cs
+++ b/src/Sdk/DTWebApi/WebApi/Runner.cs
@@ -8,6 +8,9 @@ namespace GitHub.DistributedTask.WebApi
 
         public class Authorization
         {
+            /// <summary>
+            /// The url to refresh tokens
+            /// </summary> 
             [JsonProperty("authorization_url")]
             public Uri AuthorizationUrl
             {
@@ -15,6 +18,19 @@ namespace GitHub.DistributedTask.WebApi
                 internal set;
             }
 
+            /// <summary>
+            /// The url to connect to to poll for messages
+            /// </summary> 
+            [JsonProperty("server_url")]
+            public string ServerUrl
+            {
+                get;
+                internal set;
+            }
+
+            /// <summary>
+            /// The client id to use when connecting to the authorization_url
+            /// </summary>
             [JsonProperty("client_id")]
             public string ClientId
             {
@@ -42,6 +58,17 @@ namespace GitHub.DistributedTask.WebApi
         {
             get;
             internal set;
+        }
+
+        public TaskAgent ApplyToTaskAgent(TaskAgent agent)
+        {
+            agent.Id = this.Id;
+            agent.Authorization = new TaskAgentAuthorization()
+            {
+                AuthorizationUrl = this.RunnerAuthorization.AuthorizationUrl,
+                ClientId = new Guid(this.RunnerAuthorization.ClientId)
+            };
+            return agent;
         }
     }
 }

--- a/src/Sdk/DTWebApi/WebApi/Runner.cs
+++ b/src/Sdk/DTWebApi/WebApi/Runner.cs
@@ -1,5 +1,5 @@
+using System;
 using Newtonsoft.Json;
-using System.Security.AccessControl;
 
 namespace GitHub.DistributedTask.WebApi
 {

--- a/src/Sdk/DTWebApi/WebApi/Runner.cs
+++ b/src/Sdk/DTWebApi/WebApi/Runner.cs
@@ -1,12 +1,28 @@
 using Newtonsoft.Json;
+using System.Security.AccessControl;
 
 namespace GitHub.DistributedTask.WebApi
 {
     public class Runner
     {
-        /// <summary>
-        /// Name of the agent
-        /// </summary>
+
+        public class Authorization
+        {
+            [JsonProperty("authorization_url")]
+            public Uri AuthorizationUrl
+            {
+                get;
+                internal set;
+            }
+
+            [JsonProperty("client_id")]
+            public string ClientId
+            {
+                get;
+                internal set;
+            }
+        }
+
         [JsonProperty("name")]
         public string Name
         {
@@ -14,5 +30,18 @@ namespace GitHub.DistributedTask.WebApi
             internal set;
         }
 
+        [JsonProperty("id")]
+        public Int32 Id
+        {
+            get;
+            internal set;
+        }
+
+        [JsonProperty("authorization")]
+        public Authorization RunnerAuthorization
+        {
+            get;
+            internal set;
+        }
     }
 }

--- a/src/Sdk/DTWebApi/WebApi/Runner.cs
+++ b/src/Sdk/DTWebApi/WebApi/Runner.cs
@@ -60,7 +60,7 @@ namespace GitHub.DistributedTask.WebApi
             internal set;
         }
 
-        public TaskAgent ApplyToTaskAgent(TaskAgent agent)
+        public void ApplyToTaskAgent(TaskAgent agent)
         {
             agent.Id = this.Id;
             agent.Authorization = new TaskAgentAuthorization()
@@ -68,7 +68,6 @@ namespace GitHub.DistributedTask.WebApi
                 AuthorizationUrl = this.RunnerAuthorization.AuthorizationUrl,
                 ClientId = new Guid(this.RunnerAuthorization.ClientId)
             };
-            return agent;
         }
     }
 }

--- a/src/Sdk/DTWebApi/WebApi/Runner.cs
+++ b/src/Sdk/DTWebApi/WebApi/Runner.cs
@@ -59,15 +59,5 @@ namespace GitHub.DistributedTask.WebApi
             get;
             internal set;
         }
-
-        public void ApplyToTaskAgent(TaskAgent agent)
-        {
-            agent.Id = this.Id;
-            agent.Authorization = new TaskAgentAuthorization()
-            {
-                AuthorizationUrl = this.RunnerAuthorization.AuthorizationUrl,
-                ClientId = new Guid(this.RunnerAuthorization.ClientId)
-            };
-        }
     }
 }

--- a/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
+++ b/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
@@ -110,7 +110,7 @@ namespace GitHub.Runner.Common.Tests.Listener.Configuration
 
             _dotcomServer.Setup(x => x.GetRunnersAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(expectedAgents));
             _dotcomServer.Setup(x => x.GetRunnerGroupsAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(expectedPools));
-            _dotcomServer.Setup(x => x.AddRunnerAsync(It.IsAny<int>(), It.IsAny<TaskAgent>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(expectedAgent));
+            _dotcomServer.Setup(x => x.AddRunnerAsync(It.IsAny<int>(), It.IsAny<TaskAgent>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(expectedAgent));
 
             rsa = new RSACryptoServiceProvider(2048);
 

--- a/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
+++ b/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
@@ -73,6 +73,13 @@ namespace GitHub.Runner.Common.Tests.Listener.Configuration
                 AuthorizationUrl = new Uri("http://localhost:8080/pipelines"),
             };
 
+            var expectedRunner = new GitHub.DistributedTask.WebApi.Runner() { Name = expectedAgent.Name, Id = 1 };
+            expectedRunner.RunnerAuthorization = new GitHub.DistributedTask.WebApi.Runner.Authorization
+            {
+                ClientId = expectedAgent.Authorization.ClientId.ToString(),
+                AuthorizationUrl = new Uri("http://localhost:8080/pipelines"),
+            };
+
             var connectionData = new ConnectionData()
             {
                 InstanceId = Guid.NewGuid(),
@@ -110,7 +117,7 @@ namespace GitHub.Runner.Common.Tests.Listener.Configuration
 
             _dotcomServer.Setup(x => x.GetRunnersAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(expectedAgents));
             _dotcomServer.Setup(x => x.GetRunnerGroupsAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(expectedPools));
-            _dotcomServer.Setup(x => x.AddRunnerAsync(It.IsAny<int>(), It.IsAny<TaskAgent>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(expectedAgent));
+            _dotcomServer.Setup(x => x.AddRunnerAsync(It.IsAny<int>(), It.IsAny<TaskAgent>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(expectedRunner));
 
             rsa = new RSACryptoServiceProvider(2048);
 


### PR DESCRIPTION
This PR registers runners against the new endpoint. The biggest changes are:

- Sending the runner's public key, encoded as an XML string up to the registration call

- Parsing the authorization object from the runner registration response and saves it for refreshing tokens

- Saves the `ServerUrlV2` in the RunnerSettings to connect to the new server for messages
