### PR TITLE
Update Runner to send step updates to Results

### DIFF
--- a/src/Runner.Common/JobServer.cs
+++ b/src/Runner.Common/JobServer.cs
@@ -322,7 +322,6 @@ namespace GitHub.Runner.Common
 
         public Task<List<TimelineRecord>> UpdateTimelineRecordsAsync(Guid scopeIdentifier, string hubName, Guid planId, Guid timelineId, IEnumerable<TimelineRecord> records, CancellationToken cancellationToken)
         {
-            // Send step updates to Results
             CheckConnection();
             return _taskClient.UpdateTimelineRecordsAsync(scopeIdentifier, hubName, planId, timelineId, records, cancellationToken: cancellationToken);
         }

--- a/src/Runner.Common/JobServerQueue.cs
+++ b/src/Runner.Common/JobServerQueue.cs
@@ -931,8 +931,6 @@ namespace GitHub.Runner.Common
         public long TotalLines { get; set; }
     }
 
-
-
     internal class ConsoleLineInfo
     {
         public ConsoleLineInfo(Guid recordId, string line, long? lineNumber)

--- a/src/Runner.Common/JobServerQueue.cs
+++ b/src/Runner.Common/JobServerQueue.cs
@@ -113,11 +113,8 @@ namespace GitHub.Runner.Common
                 !string.IsNullOrEmpty(resultsReceiverEndpoint))
             {
                 Trace.Info("Initializing results client");
-                if (_resultsServer != null)
-                {
-                    _resultsServer.InitializeResultsClient(new Uri(resultsReceiverEndpoint), accessToken);
-                    _resultsClientInitiated = true;
-                }
+                _resultsServer.InitializeResultsClient(new Uri(resultsReceiverEndpoint), accessToken);
+                _resultsClientInitiated = true;
             }
 
             if (_queueInProcess)

--- a/src/Runner.Common/ResultsServer.cs
+++ b/src/Runner.Common/ResultsServer.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GitHub.DistributedTask.WebApi;
+using GitHub.Services.Results.Client;
+
+namespace GitHub.Runner.Common
+{
+    [ServiceLocator(Default = typeof(ResultServer))]
+    public interface IResultsServer : IRunnerService, IAsyncDisposable
+    {
+        void InitializeResultsClient(Uri uri, string token);
+
+        // logging and console
+        Task CreateResultsStepSummaryAsync(string planId, string jobId, Guid stepId, string file,
+            CancellationToken cancellationToken);
+
+        Task CreateResultsStepLogAsync(string planId, string jobId, Guid stepId, string file, bool finalize,
+            bool firstBlock, long lineCount, CancellationToken cancellationToken);
+
+        Task CreateResultsJobLogAsync(string planId, string jobId, string file, bool finalize, bool firstBlock,
+            long lineCount, CancellationToken cancellationToken);
+
+        Task UpdateResultsWorkflowStepsAsync(Guid scopeIdentifier, string hubName, Guid planId, Guid timelineId,
+            IEnumerable<TimelineRecord> records, CancellationToken cancellationToken);
+    }
+
+    public sealed class ResultServer : RunnerService, IResultsServer
+    {
+        private ResultsHttpClient _resultsClient;
+
+        public void InitializeResultsClient(Uri uri, string token)
+        {
+            var httpMessageHandler = HostContext.CreateHttpClientHandler();
+            this._resultsClient = new ResultsHttpClient(uri, httpMessageHandler, token, disposeHandler: true);
+        }
+
+        public Task CreateResultsStepSummaryAsync(string planId, string jobId, Guid stepId, string file,
+            CancellationToken cancellationToken)
+        {
+            if (_resultsClient != null)
+            {
+                return _resultsClient.UploadStepSummaryAsync(planId, jobId, stepId, file,
+                    cancellationToken: cancellationToken);
+            }
+
+            throw new InvalidOperationException("Results client is not initialized.");
+        }
+
+        public Task CreateResultsStepLogAsync(string planId, string jobId, Guid stepId, string file, bool finalize,
+            bool firstBlock, long lineCount, CancellationToken cancellationToken)
+        {
+            if (_resultsClient != null)
+            {
+                return _resultsClient.UploadResultsStepLogAsync(planId, jobId, stepId, file, finalize, firstBlock,
+                    lineCount, cancellationToken: cancellationToken);
+            }
+
+            throw new InvalidOperationException("Results client is not initialized.");
+        }
+
+        public Task CreateResultsJobLogAsync(string planId, string jobId, string file, bool finalize, bool firstBlock,
+            long lineCount, CancellationToken cancellationToken)
+        {
+            if (_resultsClient != null)
+            {
+                return _resultsClient.UploadResultsJobLogAsync(planId, jobId, file, finalize, firstBlock, lineCount,
+                    cancellationToken: cancellationToken);
+            }
+
+            throw new InvalidOperationException("Results client is not initialized.");
+        }
+
+        public Task UpdateResultsWorkflowStepsAsync(Guid scopeIdentifier, string hubName, Guid planId, Guid timelineId,
+            IEnumerable<TimelineRecord> records, CancellationToken cancellationToken)
+        {
+            if (_resultsClient != null)
+            {
+                try
+                {
+                    var timelineRecords = records.ToList();
+                    return _resultsClient.UpdateWorkflowStepsAsync(planId, new List<TimelineRecord>(timelineRecords),
+                        cancellationToken: cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    // Log error, but continue as this call is best-effort
+                    Trace.Info($"Failed to update steps status due to {ex.GetType().Name}");
+                    Trace.Error(ex);
+                }
+            }
+
+            throw new InvalidOperationException("Results client is not initialized.");
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Runner.Common/ResultsServer.cs
+++ b/src/Runner.Common/ResultsServer.cs
@@ -9,7 +9,7 @@ using GitHub.Services.Results.Client;
 namespace GitHub.Runner.Common
 {
     [ServiceLocator(Default = typeof(ResultServer))]
-    public interface IResultsServer : IRunnerService, IAsyncDisposable
+    public interface IResultsServer : IRunnerService
     {
         void InitializeResultsClient(Uri uri, string token);
 
@@ -93,11 +93,6 @@ namespace GitHub.Runner.Common
             }
 
             throw new InvalidOperationException("Results client is not initialized.");
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            return ValueTask.CompletedTask;
         }
     }
 }

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -49,6 +49,8 @@ namespace GitHub.Runner.Worker
                 VssCredentials jobServerCredential = VssUtil.GetVssCredential(systemConnection);
                 await runServer.ConnectAsync(systemConnection.Url, jobServerCredential);
                 server = runServer;
+
+                _jobServerQueue.Start(message);
             }
             else
             {

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -49,8 +49,6 @@ namespace GitHub.Runner.Worker
                 VssCredentials jobServerCredential = VssUtil.GetVssCredential(systemConnection);
                 await runServer.ConnectAsync(systemConnection.Url, jobServerCredential);
                 server = runServer;
-
-                _jobServerQueue.Start(message);
             }
             else
             {

--- a/src/Sdk/Common/Common/RawClientHttpRequestSettings.cs
+++ b/src/Sdk/Common/Common/RawClientHttpRequestSettings.cs
@@ -184,8 +184,32 @@ namespace GitHub.Services.Common
             return settings;
         }
 
+        /// <summary>
+        /// Gets or sets the maximum size allowed for response content buffering.
+        /// </summary>
+        [DefaultValue(c_defaultContentBufferSize)]
+        public Int32 MaxContentBufferSize
+        {
+            get
+            {
+                return m_maxContentBufferSize;
+            }
+            set
+            {
+                ArgumentUtility.CheckForOutOfRange(value, nameof(value), 0, c_maxAllowedContentBufferSize);
+                m_maxContentBufferSize = value;
+            }
+        }
+
         private static Lazy<RawClientHttpRequestSettings> s_defaultSettings
             = new Lazy<RawClientHttpRequestSettings>(ConstructDefaultSettings);
+
+        private Int32 m_maxContentBufferSize;
+        // We will buffer a maximum of 1024MB in the message handler
+        private const Int32 c_maxAllowedContentBufferSize = 1024 * 1024 * 1024;
+
+        // We will buffer, by default, up to 512MB in the message handler
+        private const Int32 c_defaultContentBufferSize = 1024 * 1024 * 512;
 
         private const Int32 c_defaultMaxRetry = 3;
         private static readonly TimeSpan s_defaultTimeout = TimeSpan.FromSeconds(100); //default WebAPI timeout

--- a/src/Sdk/Common/Common/RawHttpMessageHandler.cs
+++ b/src/Sdk/Common/Common/RawHttpMessageHandler.cs
@@ -9,7 +9,7 @@ using GitHub.Services.OAuth;
 
 namespace GitHub.Services.Common
 {
-    public class RawHttpMessageHandler: HttpMessageHandler
+    public class RawHttpMessageHandler : HttpMessageHandler
     {
         public RawHttpMessageHandler(
             FederatedCredential credentials)

--- a/src/Sdk/Common/Common/RawHttpMessageHandler.cs
+++ b/src/Sdk/Common/Common/RawHttpMessageHandler.cs
@@ -120,6 +120,7 @@ namespace GitHub.Services.Common
             Boolean succeeded = false;
             HttpResponseMessageWrapper responseWrapper;
 
+            Boolean lastResponseDemandedProxyAuth = false;
             Int32 retries = m_maxAuthRetries;
             try
             {
@@ -138,7 +139,13 @@ namespace GitHub.Services.Common
 
                     // Let's start with sending a token
                     IssuedToken token = await m_tokenProvider.GetTokenAsync(null, tokenSource.Token).ConfigureAwait(false);
-                    ApplyToken(request, token);
+                    ApplyToken(request, token, applyICredentialsToWebProxy: lastResponseDemandedProxyAuth);
+
+                    // The WinHttpHandler will chunk any content that does not have a computed length which is
+                    // not what we want. By loading into a buffer up-front we bypass this behavior and there is
+                    // no difference in the normal HttpClientHandler behavior here since this is what they were
+                    // already doing.
+                    await BufferRequestContentAsync(request, tokenSource.Token).ConfigureAwait(false);
 
                     // ConfigureAwait(false) enables the continuation to be run outside any captured
                     // SyncronizationContext (such as ASP.NET's) which keeps things from deadlocking...
@@ -147,7 +154,8 @@ namespace GitHub.Services.Common
                     responseWrapper = new HttpResponseMessageWrapper(response);
 
                     var isUnAuthorized = responseWrapper.StatusCode == HttpStatusCode.Unauthorized;
-                    if (!isUnAuthorized)
+                    lastResponseDemandedProxyAuth = responseWrapper.StatusCode == HttpStatusCode.ProxyAuthenticationRequired;
+                    if (!isUnAuthorized && !lastResponseDemandedProxyAuth)
                     {
                         // Validate the token after it has been successfully authenticated with the server.
                         m_tokenProvider?.ValidateToken(token, responseWrapper);
@@ -211,15 +219,42 @@ namespace GitHub.Services.Common
             }
         }
 
+        private static async Task BufferRequestContentAsync(
+             HttpRequestMessage request,
+             CancellationToken cancellationToken)
+        {
+            if (request.Content != null &&
+                request.Headers.TransferEncodingChunked != true)
+            {
+                Int64? contentLength = request.Content.Headers.ContentLength;
+                if (contentLength == null)
+                {
+                    await request.Content.LoadIntoBufferAsync().EnforceCancellation(cancellationToken).ConfigureAwait(false);
+                }
+
+                // Explicitly turn off chunked encoding since we have computed the request content size
+                request.Headers.TransferEncodingChunked = false;
+            }
+        }
+
         private void ApplyToken(
             HttpRequestMessage request,
-            IssuedToken token)
+            IssuedToken token,
+            bool applyICredentialsToWebProxy = false)
         {
             switch (token)
             {
                 case null:
                     return;
                 case ICredentials credentialsToken:
+                    if (applyICredentialsToWebProxy)
+                    {
+                        HttpClientHandler httpClientHandler = m_transportHandler as HttpClientHandler;
+                        if (httpClientHandler != null && httpClientHandler.Proxy != null)
+                        {
+                            httpClientHandler.Proxy.Credentials = credentialsToken;
+                        }
+                    }
                     m_credentialWrapper.InnerCredentials = credentialsToken;
                     break;
                 default:

--- a/src/Sdk/Common/Common/VssHttpMessageHandler.cs
+++ b/src/Sdk/Common/Common/VssHttpMessageHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/Sdk/Common/Common/VssHttpRequestSettings.cs
+++ b/src/Sdk/Common/Common/VssHttpRequestSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;

--- a/src/Sdk/WebApi/WebApi/Contracts.cs
+++ b/src/Sdk/WebApi/WebApi/Contracts.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -124,6 +125,46 @@ namespace GitHub.Services.Results.Contracts
     {
         [DataMember]
         public bool Ok;
+    }
+
+    [DataContract]
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
+    public class StepsUpdateRequest
+    {
+        [DataMember]
+        public IEnumerable<Step> Steps;
+        [DataMember]
+        public long ChangeOrder;
+        [DataMember]
+        public string WorkflowJobRunBackendId;
+        [DataMember]
+        public string WorkflowRunBackendId;
+    }
+
+    [DataContract]
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
+    public class Step
+    {
+        [DataMember]
+        public string ExternalId;
+        [DataMember]
+        public int Number;
+        [DataMember]
+        public string Name;
+        [DataMember]
+        public Status Status;
+        [DataMember]
+        public string StartedAt;
+        [DataMember]
+        public string CompletedAt;
+    }
+
+    public enum Status
+    {
+        StatusUnknown = 0,
+        StatusInProgress = 3,
+        StatusPending = 5,
+        StatusCompleted = 6
     }
 
     public static class BlobStorageTypes

--- a/src/Sdk/WebApi/WebApi/ResultsHttpClient.cs
+++ b/src/Sdk/WebApi/WebApi/ResultsHttpClient.cs
@@ -354,10 +354,10 @@ namespace GitHub.Services.Results.Client
             var stepRecords = records.Where(r => String.Equals(r.RecordType, "Task", StringComparison.Ordinal));
             var stepUpdateRequests = stepRecords.GroupBy(r => r.ParentId).Select(sg => new StepsUpdateRequest()
             {
-                    WorkflowRunBackendId = planId.ToString(),
-                    WorkflowJobRunBackendId = sg.Key.ToString(),
-                    ChangeOrder = m_changeIdCounter++,
-                    Steps = sg.Select(ConvertTimelineRecordToStep)
+                WorkflowRunBackendId = planId.ToString(),
+                WorkflowJobRunBackendId = sg.Key.ToString(),
+                ChangeOrder = m_changeIdCounter++,
+                Steps = sg.Select(ConvertTimelineRecordToStep)
             });
 
             var stepUpdateEndpoint = new Uri(m_resultsServiceUrl, Constants.WorkflowStepsUpdate);

--- a/src/Sdk/WebApi/WebApi/ResultsHttpClient.cs
+++ b/src/Sdk/WebApi/WebApi/ResultsHttpClient.cs
@@ -348,7 +348,7 @@ namespace GitHub.Services.Results.Client
             }
         }
 
-        public async Task UpdateTimelineRecordsAsync(Guid planId, IEnumerable<TimelineRecord> records, CancellationToken cancellationToken)
+        public async Task UpdateWorkflowStepsAsync(Guid planId, IEnumerable<TimelineRecord> records, CancellationToken cancellationToken)
         {
             var timestamp = DateTime.UtcNow.ToString(Constants.TimestampFormat);
             var stepRecords = records.Where(r => String.Equals(r.RecordType, "Task", StringComparison.Ordinal));


### PR DESCRIPTION
* Refactored `jobServer` so `Results` code are in `ResultsServer` now.
* Updated `ResultsServer` to send steps update to Results
* Results upload is best effort and any exception should skip subsequent uploads
* Add authenticated proxy support
* Buffer request for `WinHttpHandler` 