### PR TITLE
Extend github context with host-workspace

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1355,7 +1355,7 @@ namespace GitHub.Runner.Worker
         {
             foreach (var key in dict.Keys.ToList())
             {
-                if (key == PipelineTemplateConstants.HostWorkDirectory)
+                if (key == PipelineTemplateConstants.HostWorkspace)
                 {
                     // The HostWorkspace context var is excluded so that there is a var that always points to the host path. 
                     // This var can be used to translate back from container paths, e.g. in HashFilesFunction, which always runs on the host machine

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1355,7 +1355,7 @@ namespace GitHub.Runner.Worker
         {
             foreach (var key in dict.Keys.ToList())
             {
-                if (key == PipelineTemplateConstants.HostWorkspace)
+                if (key == PipelineTemplateConstants.HostWorkDirectory)
                 {
                     continue;
                 }

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1357,6 +1357,8 @@ namespace GitHub.Runner.Worker
             {
                 if (key == PipelineTemplateConstants.HostWorkDirectory)
                 {
+                    // The HostWorkspace context var is excluded so that there is a var that always points to the host path. 
+                    // This var can be used to translate back from container paths, e.g. in HashFilesFunction, which always runs on the host machine
                     continue;
                 }
                 if (dict[key] is StringContextData)

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1355,6 +1355,10 @@ namespace GitHub.Runner.Worker
         {
             foreach (var key in dict.Keys.ToList())
             {
+                if (key == PipelineTemplateConstants.HostWorkspace)
+                {
+                    continue;
+                }
                 if (dict[key] is StringContextData)
                 {
                     var value = dict[key].ToString();

--- a/src/Runner.Worker/Expressions/HashFilesFunction.cs
+++ b/src/Runner.Worker/Expressions/HashFilesFunction.cs
@@ -38,15 +38,16 @@ namespace GitHub.Runner.Worker.Expressions
             ArgUtil.NotNull(runnerContextData, nameof(runnerContextData));
             var runnerContext = runnerContextData as DictionaryContextData;
             ArgUtil.NotNull(runnerContext, nameof(runnerContext));
-            runnerContext.TryGetValue(PipelineTemplateConstants.HostWorkspace, out var hostWorkspace);
+            runnerContext.TryGetValue(PipelineTemplateConstants.HostWorkDirectory, out var hostWorkDirectory);
 
-            if (hostWorkspace != null)
+            if (hostWorkDirectory != null)
             {
-                var hostWorkspaceData = hostWorkspace as StringContextData;
+                // Depends on the 'DistributedTask.UseContainerPathForTemplate' feature flag
+                var hostWorkDirectoryData = hostWorkDirectory as StringContextData;
                 ArgUtil.NotNull(workspaceData, nameof(workspaceData));
 
                 var containerInfo = new ContainerInfo();
-                containerInfo.AddPathTranslateMapping(hostWorkspaceData.Value, "/__w");
+                containerInfo.AddPathTranslateMapping(hostWorkDirectoryData.Value, "/__w");
                 githubWorkspace = containerInfo.TranslateToHostPath(githubWorkspace);
             }
 

--- a/src/Runner.Worker/Expressions/HashFilesFunction.cs
+++ b/src/Runner.Worker/Expressions/HashFilesFunction.cs
@@ -28,28 +28,17 @@ namespace GitHub.Runner.Worker.Expressions
             ArgUtil.NotNull(githubContextData, nameof(githubContextData));
             var githubContext = githubContextData as DictionaryContextData;
             ArgUtil.NotNull(githubContext, nameof(githubContext));
-            githubContext.TryGetValue(PipelineTemplateConstants.Workspace, out var workspace);
+
+            if (!githubContext.TryGetValue(PipelineTemplateConstants.HostWorkspace, out var workspace))
+            {
+                githubContext.TryGetValue(PipelineTemplateConstants.Workspace, out workspace);
+            }
+            ArgUtil.NotNull(workspace, nameof(workspace));
+
             var workspaceData = workspace as StringContextData;
             ArgUtil.NotNull(workspaceData, nameof(workspaceData));
 
             string githubWorkspace = workspaceData.Value;
-
-            templateContext.ExpressionValues.TryGetValue(PipelineTemplateConstants.Runner, out var runnerContextData);
-            ArgUtil.NotNull(runnerContextData, nameof(runnerContextData));
-            var runnerContext = runnerContextData as DictionaryContextData;
-            ArgUtil.NotNull(runnerContext, nameof(runnerContext));
-            runnerContext.TryGetValue(PipelineTemplateConstants.HostWorkDirectory, out var hostWorkDirectory);
-
-            if (hostWorkDirectory != null)
-            {
-                // Depends on the 'DistributedTask.UseContainerPathForTemplate' feature flag
-                var hostWorkDirectoryData = hostWorkDirectory as StringContextData;
-                ArgUtil.NotNull(workspaceData, nameof(workspaceData));
-
-                var containerInfo = new ContainerInfo();
-                containerInfo.AddPathTranslateMapping(hostWorkDirectoryData.Value, "/__w");
-                githubWorkspace = containerInfo.TranslateToHostPath(githubWorkspace);
-            }
 
             bool followSymlink = false;
             List<string> patterns = new();

--- a/src/Runner.Worker/Expressions/HashFilesFunction.cs
+++ b/src/Runner.Worker/Expressions/HashFilesFunction.cs
@@ -8,8 +8,6 @@ using System.Reflection;
 using System.Threading;
 using System.Collections.Generic;
 using GitHub.Runner.Common.Util;
-using GitHub.Runner.Worker.Container;
-using GitHub.Runner.Common;
 
 namespace GitHub.Runner.Worker.Expressions
 {

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -175,11 +175,14 @@ namespace GitHub.Runner.Worker
                     context.Debug("Update context data");
                     string _workDirectory = HostContext.GetDirectory(WellKnownDirectory.Work);
                     context.SetRunnerContext("workspace", Path.Combine(_workDirectory, trackingConfig.PipelineDirectory));
+
+                    var githubWorkspace = Path.Combine(_workDirectory, trackingConfig.WorkspaceDirectory);
                     if (jobContext.Global.Variables.GetBoolean(Constants.Runner.Features.UseContainerPathForTemplate) ?? false)
                     {
-                        context.SetRunnerContext("host-work-directory", _workDirectory);
+                        // This value is used to translate paths from the container path back to the host path.
+                        context.SetGitHubContext("host-workspace", githubWorkspace);
                     }
-                    context.SetGitHubContext("workspace", Path.Combine(_workDirectory, trackingConfig.WorkspaceDirectory));
+                    context.SetGitHubContext("workspace", githubWorkspace);
 
                     // Temporary hack for GHES alpha
                     var configurationStore = HostContext.GetService<IConfigurationStore>();

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -175,7 +175,10 @@ namespace GitHub.Runner.Worker
                     context.Debug("Update context data");
                     string _workDirectory = HostContext.GetDirectory(WellKnownDirectory.Work);
                     context.SetRunnerContext("workspace", Path.Combine(_workDirectory, trackingConfig.PipelineDirectory));
-                    context.SetRunnerContext("host-workspace", _workDirectory);
+                    if (jobContext.Global.Variables.GetBoolean(Constants.Runner.Features.UseContainerPathForTemplate) ?? false)
+                    {
+                        context.SetRunnerContext("host-work-directory", _workDirectory);
+                    }
                     context.SetGitHubContext("workspace", Path.Combine(_workDirectory, trackingConfig.WorkspaceDirectory));
 
                     // Temporary hack for GHES alpha

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -175,6 +175,7 @@ namespace GitHub.Runner.Worker
                     context.Debug("Update context data");
                     string _workDirectory = HostContext.GetDirectory(WellKnownDirectory.Work);
                     context.SetRunnerContext("workspace", Path.Combine(_workDirectory, trackingConfig.PipelineDirectory));
+                    context.SetRunnerContext("host-workspace", _workDirectory);
                     context.SetGitHubContext("workspace", Path.Combine(_workDirectory, trackingConfig.WorkspaceDirectory));
 
                     // Temporary hack for GHES alpha

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
@@ -82,5 +82,6 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
         public const String WorkflowRoot = "workflow-root";
         public const String WorkingDirectory = "working-directory";
         public const String Workspace = "workspace";
+        public const String HostWorkspace = "host-workspace";
     }
 }

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
@@ -82,6 +82,6 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
         public const String WorkflowRoot = "workflow-root";
         public const String WorkingDirectory = "working-directory";
         public const String Workspace = "workspace";
-        public const String HostWorkspace = "host-workspace";
+        public const String HostWorkDirectory = "host-work-directory";
     }
 }

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 
 namespace GitHub.DistributedTask.Pipelines.ObjectTemplating

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 
 namespace GitHub.DistributedTask.Pipelines.ObjectTemplating

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConstants.cs
@@ -82,6 +82,6 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
         public const String WorkflowRoot = "workflow-root";
         public const String WorkingDirectory = "working-directory";
         public const String Workspace = "workspace";
-        public const String HostWorkDirectory = "host-work-directory";
+        public const String HostWorkspace = "host-workspace";
     }
 }


### PR DESCRIPTION
We encountered an issue where step host was not used when evaluating user inputs.
The PR #1762 fixed this problem, but it introduced another problem for hash files.

hashFiles operates on the host, regardless of whether you are running inside the container or not.

Since inputs are translated based on the step host, we lose the ability to know how to translate back from the container path to the host path.

This change aims to add another context variable to the runner context named `host-workspace` that will be set to the runner host workspace regardless of whether the action is executed inside the container or not.
Example of the composite action:
```yaml
name: "test"
runs:
  using: "composite"
  steps:
  - run: |
      echo "${{github.action_path}}"
      echo "${{github.workspace}}" 
      echo "${{github.event_path}}"
    shell: bash
    name: "Just echo"
  - run: echo ${{ hashFiles('**/*.lock')}}
    shell: bash
    name: "test"
```

Repro of this issue with StepHost evaluation and hash files:
![image](https://user-images.githubusercontent.com/97525037/229784988-980e34a5-e2a2-4303-a2e3-cbd61165e3a4.png)

After applying this change:
![image](https://user-images.githubusercontent.com/97525037/229784498-b13f2184-6966-430e-b71f-512358bd0855.png)


Related to #716