### PR TITLE
Set runner environment in context and env

### DIFF
--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -126,6 +126,11 @@ namespace GitHub.Runner.Worker
                 _runnerSettings = HostContext.GetService<IConfigurationStore>().GetSettings();
                 jobContext.SetRunnerContext("name", _runnerSettings.AgentName);
 
+                if (jobContext.Global.Variables.TryGetValue(WellKnownDistributedTaskVariables.RunnerEnvironment, out var runnerEnvironment))
+                {
+                    jobContext.SetRunnerContext("environment", runnerEnvironment);
+                }
+
                 string toolsDirectory = HostContext.GetDirectory(WellKnownDirectory.Tools);
                 Directory.CreateDirectory(toolsDirectory);
                 jobContext.SetRunnerContext("tool_cache", toolsDirectory);

--- a/src/Sdk/DTWebApi/WebApi/WellKnownDistributedTaskVariables.cs
+++ b/src/Sdk/DTWebApi/WebApi/WellKnownDistributedTaskVariables.cs
@@ -6,5 +6,6 @@ namespace GitHub.DistributedTask.WebApi
     {
         public static readonly String JobId = "system.jobId";
         public static readonly String RunnerLowDiskspaceThreshold = "system.runner.lowdiskspacethreshold";
+        public static readonly String RunnerEnvironment = "system.runnerEnvironment";
     }
 }

--- a/src/Sdk/DTWebApi/WebApi/WellKnownDistributedTaskVariables.cs
+++ b/src/Sdk/DTWebApi/WebApi/WellKnownDistributedTaskVariables.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace GitHub.DistributedTask.WebApi
 {


### PR DESCRIPTION
## Problem

`runner_environment` was added to the [OIDC id token claims](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token) but it's currently not exposed in the runner context or ENV.

We would like to access the runner env value from the system ENV on the runner in order to include it in the provenance statement generated in the npm CLI when constructing the `builder.id`: https://github.com/npm/cli/blob/latest/workspaces/libnpmpublish/lib/provenance.js#L7 

