### PR TITLE
Omit Base64 padding characters from Base64 representations of secrets.

### DIFF
--- a/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionNode.cs
+++ b/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Linq;
 using GitHub.DistributedTask.Logging;

--- a/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionNode.cs
+++ b/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionNode.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using GitHub.DistributedTask.Logging;
 
 namespace GitHub.DistributedTask.Expressions2.Sdk
@@ -55,7 +55,7 @@ namespace GitHub.DistributedTask.Expressions2.Sdk
             try
             {
                 // Evaluate
-                secretMasker = secretMasker?.Clone() ?? new SecretMasker();
+                secretMasker = secretMasker?.Clone() ?? new SecretMasker(Enumerable.Empty<ValueEncoder>());
                 trace = new EvaluationTraceWriter(trace, secretMasker);
                 var context = new EvaluationContext(trace, secretMasker, state, options, this);
                 trace.Info($"Evaluating: {ConvertToExpression()}");

--- a/src/Sdk/DTLogging/Logging/ISecretMasker.cs
+++ b/src/Sdk/DTLogging/Logging/ISecretMasker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 
 namespace GitHub.DistributedTask.Logging

--- a/src/Sdk/DTLogging/Logging/ISecretMasker.cs
+++ b/src/Sdk/DTLogging/Logging/ISecretMasker.cs
@@ -8,7 +8,6 @@ namespace GitHub.DistributedTask.Logging
     {
         void AddRegex(String pattern);
         void AddValue(String value);
-        void AddValueEncoder(ValueEncoder encoder);
         ISecretMasker Clone();
         String MaskSecrets(String input);
     }

--- a/src/Sdk/DTLogging/Logging/SecretMasker.cs
+++ b/src/Sdk/DTLogging/Logging/SecretMasker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/src/Sdk/DTLogging/Logging/SecretMasker.cs
+++ b/src/Sdk/DTLogging/Logging/SecretMasker.cs
@@ -14,7 +14,7 @@ namespace GitHub.DistributedTask.Logging
         {
             m_originalValueSecrets = new HashSet<ValueSecret>();
             m_regexSecrets = new HashSet<RegexSecret>();
-            m_valueEncoders = new HashSet<ValueEncoder>(encoders);
+            m_valueEncoders = new HashSet<ValueEncoder>(encoders ?? Enumerable.Empty<ValueEncoder>());
             m_valueSecrets = new HashSet<ValueSecret>();
         }
 

--- a/src/Sdk/DTLogging/Logging/ValueEncoders.cs
+++ b/src/Sdk/DTLogging/Logging/ValueEncoders.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/src/Sdk/DTLogging/Logging/ValueEncoders.cs
+++ b/src/Sdk/DTLogging/Logging/ValueEncoders.cs
@@ -1,73 +1,97 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Security;
 using System.Text;
-using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 
 namespace GitHub.DistributedTask.Logging
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public delegate String ValueEncoder(String value);
+    public delegate IEnumerable<string> ValueEncoder(string value);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class ValueEncoders
     {
-        public static String Base64StringEscape(String value)
-        {
-            return Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
-        }
 
-        // Base64 is 6 bits -> char
-        // A byte is 8 bits
-        // When end user doing somthing like base64(user:password)
-        // The length of the leading content will cause different base64 encoding result on the password
-        // So we add base64(value shifted 1 and two bytes) as secret as well. 
-        //    B1         B2      B3                    B4      B5     B6     B7
-        // 000000|00 0000|0000 00|000000|            000000|00 0000|0000 00|000000| 
-        //  Char1  Char2    Char3   Char4  
-        // See the above, the first byte has a character beginning at index 0, the second byte has a character beginning at index 4, the third byte has a character beginning at index 2 and then the pattern repeats
-        // We register byte offsets for all these possible values
-        public static String Base64StringEscapeShift1(String value)
+        public static IEnumerable<string> EnumerateBase64Variations(string value)
         {
-            return Base64StringEscapeShift(value, 1);
-        }
+            if (!string.IsNullOrEmpty(value))
+            {
+                // A byte is 8 bits.  A Base64 "digit" can hold a maximum of 6 bits (2^64 - 1, or values 0 to 63).
+                // As a result, many Unicode characters (including single-byte letters) cannot be represented using a single Base64 digit.
+                // Furthermore, on average a Base64 string will be about 33% longer than the original text.
+                // This is because it generally requires 4 Base64 digits to represent 3 Unicode bytes.  (4 / 3 ~ 1.33)
+                //
+                // Because of this 4:3 ratio (or, more precisely, 8 bits : 6 bits ratio), there's a cyclical pattern
+                // to when a byte boundary aligns with a Base64 digit boundary.
+                // The pattern repeats every 24 bits (the lowest common multiple of 8 and 6).
+                //
+                //                    |-----------24 bits-------------|-----------24 bits------------|
+                // Base64 Digits:     |digit 0|digit 1|digit 2|digit 3|digit 4|digit 5|digit 6|digit7|
+                // Allocated Bits:    aaaaaa  aaBBBB  BBBBcc  cccccc  DDDDDD  DDeeee  eeeeFF  FFFFFF
+                // Unicode chars:     |0th char |1st char |2nd char   |3rd char |4th char |5th char  |
 
-        public static String Base64StringEscapeShift2(String value)
-        {
-            return Base64StringEscapeShift(value, 2);
+                // Depending on alignment, the Base64-encoded secret can take any of 3 basic forms.
+                // For example, the Base64 digits representing "abc" could appear as any of the following:
+                //    "YWJj"     when aligned
+                //    ".!FiYw==" when preceded by 3x + 1 bytes
+                //    "..!hYmM=" when preceded by 3x + 2 bytes
+                // (where . represents an unrelated Base64 digit, ! represents a Base64 digit that should be masked, and x represents any non-negative integer)
+
+                var rawBytes = Encoding.UTF8.GetBytes(value);
+
+                for (var offset = 0; offset <= 2; offset++)
+                {
+                    var prunedBytes = rawBytes.Skip(offset).ToArray();
+                    if (prunedBytes.Length > 0)
+                    {
+                        // Don't include Base64 padding characters (=) in Base64 representations of the secret.
+                        // They don't represent anything interesting, so they don't need to be masked.
+                        // (Some clients omit the padding, so we want to be sure we recognize the secret regardless of whether the padding is present or not.)
+                        var buffer = new StringBuilder(Convert.ToBase64String(prunedBytes).TrimEnd(BASE64_PADDING_SUFFIX));
+                        yield return buffer.ToString();
+
+                        // Also, yield the RFC4648-equivalent RegEx.
+                        buffer.Replace('+', '-');
+                        buffer.Replace('/', '_');
+                        yield return buffer.ToString();
+                    }
+                }
+            }
         }
 
         // Used when we pass environment variables to docker to escape " with \"
-        public static String CommandLineArgumentEscape(String value)
+        public static IEnumerable<string> CommandLineArgumentEscape(string value)
         {
-            return value.Replace("\"", "\\\"");
+            yield return value.Replace("\"", "\\\"");
         }
 
-        public static String ExpressionStringEscape(String value)
+        public static IEnumerable<string> ExpressionStringEscape(string value)
         {
-            return Expressions2.Sdk.ExpressionUtility.StringEscape(value);
+            yield return Expressions2.Sdk.ExpressionUtility.StringEscape(value);
         }
 
-        public static String JsonStringEscape(String value)
+        public static IEnumerable<string> JsonStringEscape(string value)
         {
             // Convert to a JSON string and then remove the leading/trailing double-quote.
             String jsonString = JsonConvert.ToString(value);
             String jsonEscapedValue = jsonString.Substring(startIndex: 1, length: jsonString.Length - 2);
-            return jsonEscapedValue;
+            yield return jsonEscapedValue;
         }
 
-        public static String UriDataEscape(String value)
+        public static IEnumerable<string> UriDataEscape(string value)
         {
-            return UriDataEscape(value, 65519);
+            yield return UriDataEscape(value, 65519);
         }
 
-        public static String XmlDataEscape(String value)
+        public static IEnumerable<string> XmlDataEscape(string value)
         {
-            return SecurityElement.Escape(value);
+            yield return SecurityElement.Escape(value);
         }
 
-        public static String TrimDoubleQuotes(String value)
+        public static IEnumerable<string> TrimDoubleQuotes(string value)
         {
             var trimmed = string.Empty;
             if (!string.IsNullOrEmpty(value) &&
@@ -78,17 +102,17 @@ namespace GitHub.DistributedTask.Logging
                 trimmed = value.Substring(1, value.Length - 2);
             }
 
-            return trimmed;
+            yield return trimmed;
         }
 
-        public static String PowerShellPreAmpersandEscape(String value)
+        public static IEnumerable<string> PowerShellPreAmpersandEscape(string value)
         {
             // if the secret is passed to PS as a command and it causes an error, sections of it can be surrounded by color codes
-            // or printed individually. 
-            
+            // or printed individually.
+
             // The secret secretpart1&secretpart2&secretpart3 would be split into 2 sections:
             // 'secretpart1&secretpart2&' and 'secretpart3'. This method masks for the first section.
-            
+
             // The secret secretpart1&+secretpart2&secretpart3 would be split into 2 sections:
             // 'secretpart1&+' and (no 's') 'ecretpart2&secretpart3'. This method masks for the first section.
 
@@ -112,10 +136,10 @@ namespace GitHub.DistributedTask.Logging
                 }
             }
 
-            return trimmed;
+            yield return trimmed;
         }
 
-        public static String PowerShellPostAmpersandEscape(String value)
+        public static IEnumerable<string> PowerShellPostAmpersandEscape(string value)
         {
             var trimmed = string.Empty;
             if (!string.IsNullOrEmpty(value) && value.Contains("&"))
@@ -137,27 +161,10 @@ namespace GitHub.DistributedTask.Logging
                 }
             }
 
-            return trimmed;
+            yield return trimmed;
         }
 
-        private static string Base64StringEscapeShift(String value, int shift)
-        {
-            var bytes = Encoding.UTF8.GetBytes(value);
-            if (bytes.Length > shift)
-            {
-                var shiftArray = new byte[bytes.Length - shift];
-                Array.Copy(bytes, shift, shiftArray, 0, bytes.Length - shift);
-                return Convert.ToBase64String(shiftArray);
-            }
-            else
-            {
-                return Convert.ToBase64String(bytes);
-            }
-        }
-
-        private static String UriDataEscape(
-            String value,
-            Int32 maxSegmentSize)
+        private static string UriDataEscape(string value, Int32 maxSegmentSize)
         {
             if (value.Length <= maxSegmentSize)
             {
@@ -183,5 +190,7 @@ namespace GitHub.DistributedTask.Logging
 
             return result.ToString();
         }
+
+        private const char BASE64_PADDING_SUFFIX = '=';
     }
 }

--- a/src/Test/L0/HostContextL0.cs
+++ b/src/Test/L0/HostContextL0.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/Test/L0/HostContextL0.cs
+++ b/src/Test/L0/HostContextL0.cs
@@ -95,11 +95,11 @@ namespace GitHub.Runner.Common.Tests
                 Assert.Equal("123***123", _hc.SecretMasker.MaskSecrets("123Pass%20word%20123%21123"));
                 Assert.Equal("123***123", _hc.SecretMasker.MaskSecrets("123Pass&lt;word&gt;123!123"));
                 Assert.Equal("123***123", _hc.SecretMasker.MaskSecrets("123Pass''word''123!123"));
-                Assert.Equal("OlBh***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($":Password123!"))));
-                Assert.Equal("YTpQ***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"a:Password123!"))));
+                Assert.Equal("OlBh***==", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($":Password123!"))));
+                Assert.Equal("YTpQ***=", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"a:Password123!"))));
                 Assert.Equal("YWI6***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"ab:Password123!"))));
-                Assert.Equal("YWJjOlBh***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"abc:Password123!"))));
-                Assert.Equal("YWJjZDpQ***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"abcd:Password123!"))));
+                Assert.Equal("YWJjOlBh***==", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"abc:Password123!"))));
+                Assert.Equal("YWJjZDpQ***=", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"abcd:Password123!"))));
                 Assert.Equal("YWJjZGU6***", _hc.SecretMasker.MaskSecrets(Convert.ToBase64String(Encoding.UTF8.GetBytes($"abcde:Password123!"))));
                 Assert.Equal("123***123", _hc.SecretMasker.MaskSecrets("123Password123!!123"));
                 Assert.Equal("123short123", _hc.SecretMasker.MaskSecrets("123short123"));

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -56,9 +56,12 @@ namespace GitHub.Runner.Common.Tests
             }
 
             var traceListener = new HostTraceListener(TraceFileName);
-            _secretMasker = new SecretMasker();
-            _secretMasker.AddValueEncoder(ValueEncoders.JsonStringEscape);
-            _secretMasker.AddValueEncoder(ValueEncoders.UriDataEscape);
+            var encoders = new List<ValueEncoder>()
+            {
+                ValueEncoders.JsonStringEscape,
+                ValueEncoders.UriDataEscape
+            };
+            _secretMasker = new SecretMasker(encoders);
             _traceManager = new TraceManager(traceListener, null, _secretMasker);
             _trace = GetTrace(nameof(TestHostContext));
 

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.Runner.Common.Util;
+using GitHub.Runner.Common.Util;
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;


### PR DESCRIPTION
### Also

Added a unit test for thorough Base64 secret masking.