### PR TITLE
If conclusion is not set, we cannot get default value

### DIFF
--- a/src/Sdk/WebApi/WebApi/ResultsHttpClient.cs
+++ b/src/Sdk/WebApi/WebApi/ResultsHttpClient.cs
@@ -330,7 +330,7 @@ namespace GitHub.Services.Results.Client
                 Status = ConvertStateToStatus(r.State.GetValueOrDefault()),
                 StartedAt = r.StartTime?.ToString(Constants.TimestampFormat),
                 CompletedAt = r.FinishTime?.ToString(Constants.TimestampFormat),
-                Conclusion = ConvertResultToConclusion(r.Result.GetValueOrDefault())
+                Conclusion = ConvertResultToConclusion(r.Result)
             };
         }
 
@@ -349,8 +349,13 @@ namespace GitHub.Services.Results.Client
             }
         }
 
-        private Conclusion ConvertResultToConclusion(TaskResult r)
+        private Conclusion ConvertResultToConclusion(TaskResult? r)
         {
+            if (!r.HasValue)
+            {
+                return Conclusion.ConclusionUnknown;
+            }
+
             switch (r)
             {
                 case TaskResult.Succeeded:


### PR DESCRIPTION
Fix a bug, otherwise we are always getting `succeeded` for steps that haven't run yet.