### PR TITLE
Link feature request to Discussions > Actions after split

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,13 +1,13 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🛑 Request a feature in the runner application
-    url: https://github.com/orgs/community/discussions/categories/actions-and-packages
-    about: If you have feature requests for GitHub Actions, please use the Actions and Packages section on the Github Product Feedback page.
+    url: https://github.com/orgs/community/discussions/categories/actions
+    about: If you have feature requests for GitHub Actions, please use the Actions section on the GitHub Product Feedback page.
   - name: ✅ Support for GitHub Actions
     url: https://github.community/c/code-to-cloud/52
     about: If you have questions about GitHub Actions or need support writing workflows, please ask in the GitHub Community Support forum.
   - name: ✅ Feedback and suggestions for GitHub Actions
-    url: https://github.com/github/feedback/discussions/categories/actions-and-packages-feedback
+    url: https://github.com/orgs/community/discussions/categories/actions
     about: If you have feedback or suggestions about GitHub Actions, please open a discussion (or add to an existing one) in the GitHub Actions Feedback.  GitHub Actions Product Managers and Engineers monitor the feedback forum.
   - name: ‼️ GitHub Security Bug Bounty
     url: https://bounty.github.com/

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ For more information about installing and using self-hosted runners, see [Adding
 
 Runner releases:
 
-![win](docs/res/win_sm.png) [Pre-reqs](docs/start/envwin.md) | [Download](https://github.com/actions/runner/releases)  
+![win](docs/res/win_sm.png) [Pre-reqs](docs/start/envwin.md) | [Download](https://github.com/actions/runner/releases)
 
-![macOS](docs/res/apple_sm.png)  [Pre-reqs](docs/start/envosx.md) | [Download](https://github.com/actions/runner/releases)  
+![macOS](docs/res/apple_sm.png)  [Pre-reqs](docs/start/envosx.md) | [Download](https://github.com/actions/runner/releases)
 
 ![linux](docs/res/linux_sm.png)  [Pre-reqs](docs/start/envlinux.md) | [Download](https://github.com/actions/runner/releases)
 
 ## Contribute
 
-We accept contributions in the form of issues and pull requests. The runner typically requires changes across the entire system and we aim for issues in the runner to be entirely self contained and fixable here. Therefore, we will primarily handle bug issues opened in this repo and we kindly request you to create all feature and enhancement requests on the [GitHub Feedback](https://github.com/community/community/discussions/categories/actions-and-packages) page. [Read more about our guidelines here](docs/contribute.md) before contributing.
+We accept contributions in the form of issues and pull requests. The runner typically requires changes across the entire system and we aim for issues in the runner to be entirely self contained and fixable here. Therefore, we will primarily handle bug issues opened in this repo and we kindly request you to create all feature and enhancement requests on the [GitHub Feedback](https://github.com/community/community/discussions/categories/actions) page. [Read more about our guidelines here](docs/contribute.md) before contributing.

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,6 +1,6 @@
 # Contributions
 
-We welcome contributions in the form of issues and pull requests. We view the contributions and the process as the same for github and external contributors.Please note the runner typically requires changes across the entire system and we aim for issues in the runner to be entirely self contained and fixable here. Therefore, we will primarily handle bug issues opened in this repo and we kindly request you to create all feature and enhancement requests on the [GitHub Feedback](https://github.com/community/community/discussions/categories/actions-and-packages) page. 
+We welcome contributions in the form of issues and pull requests. We view the contributions and the process as the same for github and external contributors.Please note the runner typically requires changes across the entire system and we aim for issues in the runner to be entirely self contained and fixable here. Therefore, we will primarily handle bug issues opened in this repo and we kindly request you to create all feature and enhancement requests on the [GitHub Feedback](https://github.com/community/community/discussions/categories/actions) page.
 
 > IMPORTANT: Building your own runner is critical for the dev inner loop process when contributing changes.  However, only runners built and distributed by GitHub (releases) are supported in production.  Be aware that workflows and orchestrations run service side with the runner being a remote process to run steps.  For that reason, the service can pull the runner forward so customizations can be lost.
 
@@ -58,11 +58,11 @@ If you're using VS Code, you can follow [these](contribute/vscode.md) steps inst
 
 Navigate to the `src` directory and run the following command:
 
-![Win](res/win_sm.png) `dev {command}`  
+![Win](res/win_sm.png) `dev {command}`
 
 ![*nix](res/linux_sm.png) `./dev.sh {command}`
-  
-**Commands:**  
+
+**Commands:**
 
 * `layout` (`l`):  Run first time to create a full runner layout in `{root}/_layout`
 * `build` (`b`):   Build everything and update runner layout folder
@@ -152,7 +152,7 @@ cat (Runner/Worker)_TIMESTAMP.log # view your log file
 ## Editors
 
 [Using Visual Studio Code](https://code.visualstudio.com/)
-[Using Visual Studio](https://code.visualstudio.com/docs)  
+[Using Visual Studio](https://code.visualstudio.com/docs)
 
 ## Styling
 


### PR DESCRIPTION
This PR corrects the [Issue Template](https://github.com/actions/runner/blob/main/.github/ISSUE_TEMPLATE/config.yml) section 

"🛑 Request a feature in the runner application
If you have feature requests for GitHub Actions, please use the Actions and Packages section on the Github Product Feedback page."

which links to https://github.com/orgs/community/discussions/categories/actions-and-packages.

This link no longer connects to any specific category and instead displays the top level https://github.com/orgs/community/discussions.

According to https://github.com/orgs/community/discussions/48284 "Actions & Packages category split"

"GitHub Actions and GitHub Packages are now two separate categories."

The relevant new link after the split is https://github.com/orgs/community/discussions/categories/actions.