### PR TITLE
Adding curl retry for external tool downloads

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -61,7 +61,7 @@ function acquireExternalTool() {
             #      -L Follow redirects (H)
             #      -o FILE    Write to FILE instead of stdout
             #      --retry 3   Retries transient errors 3 times (timeouts, 5xx)
-            curl -fkSL -o "$partial_target" --retry 3 "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
+            curl -fkSL --retry 3 -o "$partial_target" "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
 
             # Move the partial file to the download target.
             mv "$partial_target" "$download_target" || checkRC 'mv'

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -60,7 +60,7 @@ function acquireExternalTool() {
             #      -S Show error. With -s, make curl show errors when they occur
             #      -L Follow redirects (H)
             #      -o FILE    Write to FILE instead of stdout
-            curl -fkSL -o "$partial_target" "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
+            curl -fkSL -o "$partial_target" --retry 3 "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
 
             # Move the partial file to the download target.
             mv "$partial_target" "$download_target" || checkRC 'mv'

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -60,6 +60,7 @@ function acquireExternalTool() {
             #      -S Show error. With -s, make curl show errors when they occur
             #      -L Follow redirects (H)
             #      -o FILE    Write to FILE instead of stdout
+            #      --retry 3   Retries transient errors 3 times (timeouts, 5xx)
             curl -fkSL -o "$partial_target" --retry 3 "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
 
             # Move the partial file to the download target.


### PR DESCRIPTION
This adds a retry on `curl` for external tool downloads which should resolve some flakiness seen in the `node-v12` tool for `linux-x64`. 