### PR TITLE
Adding curl --retry-all-errors for external tool downloads

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -55,13 +55,22 @@ function acquireExternalTool() {
             # Download from source to the partial file.
             echo "Downloading $download_source"
             mkdir -p "$(dirname "$download_target")" || checkRC 'mkdir'
+
+            CURL_VERSION=$(curl --version | awk 'NR==1{print $2}')
+
             # curl -f Fail silently (no output at all) on HTTP errors (H)
             #      -k Allow connections to SSL sites without certs (H)
             #      -S Show error. With -s, make curl show errors when they occur
             #      -L Follow redirects (H)
             #      -o FILE    Write to FILE instead of stdout
             #      --retry 3   Retries transient errors 3 times (timeouts, 5xx)
-            curl -fkSL --retry 3 -o "$partial_target" "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
+            if [[ "$(printf '%s\n' "7.71.0" "$CURL_VERSION" | sort -V | head -n1)" != "7.71.0" ]]; then
+                # Curl version is greater than 7.71.0, running curl with --retry-all-errors flag
+                 curl -fkSL --retry 3 --retry-all-errors -o "$partial_target" "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
+            else
+                # Curl version is less than or equal to 7.71.0, skipping retry-all-errors flag
+                 curl -fkSL --retry 3 -o "$partial_target" "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
+            fi
 
             # Move the partial file to the download target.
             mv "$partial_target" "$download_target" || checkRC 'mv'

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -57,6 +57,7 @@ function acquireExternalTool() {
             mkdir -p "$(dirname "$download_target")" || checkRC 'mkdir'
 
             CURL_VERSION=$(curl --version | awk 'NR==1{print $2}')
+            echo "Curl version: $CURL_VERSION"
 
             # curl -f Fail silently (no output at all) on HTTP errors (H)
             #      -k Allow connections to SSL sites without certs (H)

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -66,11 +66,11 @@ function acquireExternalTool() {
             #      -o FILE    Write to FILE instead of stdout
             #      --retry 3   Retries transient errors 3 times (timeouts, 5xx)
             if [[ "$(printf '%s\n' "7.71.0" "$CURL_VERSION" | sort -V | head -n1)" != "7.71.0" ]]; then
-                # Curl version is greater than 7.71.0, running curl with --retry-all-errors flag
-                 curl -fkSL --retry 3 --retry-all-errors -o "$partial_target" "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
-            else
                 # Curl version is less than or equal to 7.71.0, skipping retry-all-errors flag
                  curl -fkSL --retry 3 -o "$partial_target" "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
+            else
+                # Curl version is greater than 7.71.0, running curl with --retry-all-errors flag
+                 curl -fkSL --retry 3 --retry-all-errors -o "$partial_target" "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
             fi
 
             # Move the partial file to the download target.


### PR DESCRIPTION
This is a follow up PR to https://github.com/actions/runner/pull/2552 to force retrying `curl` for external tool downloads.

This checks if the curl version is > `7.71.0` (when `--retry-all-errors` was [introduced](https://curl.se/docs/manpage.html#--retry-all-errors)) and uses that flag if the curl version is recent enough. 