### PR TITLE
contribute.md: Fix link to style guidelines

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -157,7 +157,7 @@ cat (Runner/Worker)_TIMESTAMP.log # view your log file
 ## Styling
 
 We use the .NET Foundation and CoreCLR style guidelines [located here](
-https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md)
+https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md)
 
 ### Format C# Code
 


### PR DESCRIPTION
[https://github.com/dotnet/corefx](https://github.com/dotnet/corefx) was archived a couple of months ago, and the canonical location of the document is now in https://github.com/dotnet/runtime instead.