### PR TITLE
Add orchestrationId to useragent for better correlation.

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -261,6 +261,7 @@ namespace GitHub.Runner.Common
                 public static readonly string AccessToken = "system.accessToken";
                 public static readonly string Culture = "system.culture";
                 public static readonly string PhaseDisplayName = "system.phaseDisplayName";
+                public static readonly string OrchestrationId = "system.orchestrationId";
             }
         }
 

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace GitHub.Runner.Common
 {

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,6 +42,13 @@ namespace GitHub.Runner.Worker
 
             DateTime jobStartTimeUtc = DateTime.UtcNow;
             IRunnerService server = null;
+
+            // add orchestration id to useragent for better correlation.
+            if (message.Variables.TryGetValue(Constants.Variables.System.OrchestrationId, out VariableValue orchestrationId) &&
+                !string.IsNullOrEmpty(orchestrationId.Value))
+            {
+                HostContext.UserAgents.Add(new ProductInfoHeaderValue("OrchestrationId", orchestrationId.Value));
+            }
 
             ServiceEndpoint systemConnection = message.Resources.Endpoints.Single(x => string.Equals(x.Name, WellKnownServiceEndpointNames.SystemVssConnection, StringComparison.OrdinalIgnoreCase));
             if (MessageUtil.IsRunServiceJob(message.MessageType))


### PR DESCRIPTION
With `OrchestrationId` in the user-agent, we can get a better correlation in our telemetry to figure out the source of each HTTP request (runner+job).