### PR TITLE
Use a proper command to get the RUNNER_ROOT in svc.sh

### DIFF
--- a/src/Misc/layoutbin/darwin.svc.sh.template
+++ b/src/Misc/layoutbin/darwin.svc.sh.template
@@ -13,7 +13,7 @@ if [ $user_id -eq 0 ]; then
 fi
 
 SVC_CMD=$1
-RUNNER_ROOT=`pwd`
+RUNNER_ROOT=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 
 LAUNCH_PATH="${HOME}/Library/LaunchAgents"
 PLIST_PATH="${LAUNCH_PATH}/${SVC_NAME}.plist"

--- a/src/Misc/layoutbin/darwin.svc.sh.template
+++ b/src/Misc/layoutbin/darwin.svc.sh.template
@@ -2,12 +2,11 @@
 
 SVC_NAME="{{SvcNameVar}}"
 SVC_NAME=${SVC_NAME// /_}
-SVC_DESCRIPTION="{{SvcDescription}}"
 
-user_id=`id -u`
+user_id=$(id -u)
 
 # launchctl should not run as sudo for launch runners
-if [ $user_id -eq 0 ]; then
+if [ "$user_id" -eq 0 ]; then
     echo "Must not run with sudo"
     exit 1
 fi
@@ -47,7 +46,7 @@ function install()
     echo "Creating launch runner in ${PLIST_PATH}"
 
     if [ ! -d  "${LAUNCH_PATH}" ]; then
-        mkdir ${LAUNCH_PATH}
+        mkdir "${LAUNCH_PATH}"
     fi
 
     if [ -f "${PLIST_PATH}" ]; then
@@ -62,12 +61,12 @@ function install()
     echo "Creating ${log_path}"
     mkdir -p "${log_path}" || failed "failed to create ${log_path}"
 
-    echo Creating ${PLIST_PATH}
+    echo Creating "${PLIST_PATH}"
     sed "s/{{User}}/${USER:-$SUDO_USER}/g; s/{{SvcName}}/$SVC_NAME/g; s@{{RunnerRoot}}@${RUNNER_ROOT}@g; s@{{UserHome}}@$HOME@g;" "${TEMPLATE_PATH}" > "${TEMP_PATH}" || failed "failed to create replacement temp file"
     mv "${TEMP_PATH}" "${PLIST_PATH}" || failed "failed to copy plist"
 
     # Since we started with sudo, runsvc.sh will be owned by root. Change this to current login user.
-    echo Creating runsvc.sh    
+    echo Creating runsvc.sh
     cp ./bin/runsvc.sh ./runsvc.sh || failed "failed to copy runsvc.sh"
     chmod u+x ./runsvc.sh || failed "failed to set permission for runsvc.sh"
 
@@ -115,10 +114,10 @@ function status()
     fi
 
     echo
-    status_out=`launchctl list | grep "${SVC_NAME}"`
-    if [ ! -z "$status_out" ]; then
+    status_out=$(launchctl list | grep "${SVC_NAME}")
+    if [ -n "$status_out" ]; then
         echo Started:
-        echo $status_out
+        echo "$status_out"
         echo
     else
         echo Stopped

--- a/src/Misc/layoutbin/systemd.svc.sh.template
+++ b/src/Misc/layoutbin/systemd.svc.sh.template
@@ -7,7 +7,7 @@ SVC_DESCRIPTION="{{SvcDescription}}"
 SVC_CMD=$1
 arg_2=${2}
 
-RUNNER_ROOT=`pwd`
+RUNNER_ROOT=$(pwd)
 
 UNIT_PATH=/etc/systemd/system/${SVC_NAME}
 TEMPLATE_PATH=$GITHUB_ACTIONS_RUNNER_SERVICE_TEMPLATE
@@ -20,11 +20,11 @@ fi
 TEMP_PATH=./bin/actions.runner.service.temp
 CONFIG_PATH=.service
 
-user_id=`id -u`
+user_id=$(id -u)
 
 # systemctl must run as sudo
 # this script is a convenience wrapper around systemctl
-if [ $user_id -ne 0 ]; then
+if [ "$user_id" -ne 0 ]; then
     echo "Must run as sudo"
     exit 1
 fi
@@ -65,19 +65,18 @@ function install()
     run_as_user=${arg_2:-$SUDO_USER}
     echo "Run as user: ${run_as_user}"
 
-    run_as_uid=$(id -u ${run_as_user}) || failed "User does not exist"
+    run_as_uid=$(id -u "${run_as_user}") || failed "User does not exist"
     echo "Run as uid: ${run_as_uid}"
 
-    run_as_gid=$(id -g ${run_as_user}) || failed "Group not available"
+    run_as_gid=$(id -g "${run_as_user}") || failed "Group not available"
     echo "gid: ${run_as_gid}"
 
-    sed "s/{{User}}/${run_as_user}/g; s/{{Description}}/$(echo ${SVC_DESCRIPTION} | sed -e 's/[\/&]/\\&/g')/g; s/{{RunnerRoot}}/$(echo ${RUNNER_ROOT} | sed -e 's/[\/&]/\\&/g')/g;" "${TEMPLATE_PATH}" > "${TEMP_PATH}" || failed "failed to create replacement temp file"
+    sed "s/{{User}}/${run_as_user}/g; s/{{Description}}/$(echo ${SVC_DESCRIPTION} | sed -e 's/[\/&]/\\&/g')/g; s/{{RunnerRoot}}/$(echo "${RUNNER_ROOT}" | sed -e 's/[\/&]/\\&/g')/g;" "${TEMPLATE_PATH}" > "${TEMP_PATH}" || failed "failed to create replacement temp file"
     mv "${TEMP_PATH}" "${UNIT_PATH}" || failed "failed to copy unit file"
 
     # Recent Fedora based Linux (CentOS/Redhat) has SELinux enabled by default
     # We need to restore security context on the unit file we added otherwise SystemD have no access to it.
-    command -v getenforce > /dev/null
-    if [ $? -eq 0 ]
+    if command -v getenforce > /dev/null
     then
         selinuxEnabled=$(getenforce)
         if [[ $selinuxEnabled == "Enforcing" ]]
@@ -86,31 +85,31 @@ function install()
             restorecon -r -v "${UNIT_PATH}" || failed "failed to restore SELinux context on ${UNIT_PATH}"
         fi
     fi
-    
+
     # unit file should not be executable and world writable
     chmod 664 "${UNIT_PATH}" || failed "failed to set permissions on ${UNIT_PATH}"
     systemctl daemon-reload || failed "failed to reload daemons"
-    
-    # Since we started with sudo, runsvc.sh will be owned by root. Change this to current login user.    
+
+    # Since we started with sudo, runsvc.sh will be owned by root. Change this to current login user.
     cp ./bin/runsvc.sh ./runsvc.sh || failed "failed to copy runsvc.sh"
-    chown ${run_as_uid}:${run_as_gid} ./runsvc.sh || failed "failed to set owner for runsvc.sh"
+    chown "${run_as_uid}:${run_as_gid}" ./runsvc.sh || failed "failed to set owner for runsvc.sh"
     chmod 755 ./runsvc.sh || failed "failed to set permission for runsvc.sh"
 
-    systemctl enable ${SVC_NAME} || failed "failed to enable ${SVC_NAME}"
+    systemctl enable "${SVC_NAME}" || failed "failed to enable ${SVC_NAME}"
 
-    echo "${SVC_NAME}" > ${CONFIG_PATH} || failed "failed to create .service file"
-    chown ${run_as_uid}:${run_as_gid} ${CONFIG_PATH} || failed "failed to set permission for ${CONFIG_PATH}"
+    echo "${SVC_NAME}" > "${CONFIG_PATH}" || failed "failed to create .service file"
+    chown "${run_as_uid}:${run_as_gid}" "${CONFIG_PATH}" || failed "failed to set permission for ${CONFIG_PATH}"
 }
 
 function start()
 {
-    systemctl start ${SVC_NAME} || failed "failed to start ${SVC_NAME}"
-    status    
+    systemctl start "${SVC_NAME}" || failed "failed to start ${SVC_NAME}"
+    status
 }
 
 function stop()
 {
-    systemctl stop ${SVC_NAME} || failed "failed to stop ${SVC_NAME}"    
+    systemctl stop "${SVC_NAME}" || failed "failed to stop ${SVC_NAME}"
     status
 }
 
@@ -118,11 +117,11 @@ function uninstall()
 {
     if service_exists; then
         stop
-        systemctl disable ${SVC_NAME} || failed "failed to disable ${SVC_NAME}"
+        systemctl disable "${SVC_NAME}" || failed "failed to disable ${SVC_NAME}"
         rm "${UNIT_PATH}" || failed "failed to delete ${UNIT_PATH}"
     else
         echo "Service ${SVC_NAME} is not installed"
-    fi    
+    fi
     if [ -f "${CONFIG_PATH}" ]; then
       rm "${CONFIG_PATH}" || failed "failed to delete ${CONFIG_PATH}"
     fi
@@ -149,7 +148,7 @@ function status()
         exit 1
     fi
 
-    systemctl --no-pager status ${SVC_NAME}
+    systemctl --no-pager status "${SVC_NAME}"
 }
 
 function usage()
@@ -172,7 +171,6 @@ case $SVC_CMD in
    "uninstall") uninstall;;
    "start") start;;
    "stop") stop;;
-   "status") status;;
    *) usage;;
 esac
 

--- a/src/Misc/layoutbin/systemd.svc.sh.template
+++ b/src/Misc/layoutbin/systemd.svc.sh.template
@@ -7,7 +7,7 @@ SVC_DESCRIPTION="{{SvcDescription}}"
 SVC_CMD=$1
 arg_2=${2}
 
-RUNNER_ROOT=$(pwd)
+RUNNER_ROOT=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 
 UNIT_PATH=/etc/systemd/system/${SVC_NAME}
 TEMPLATE_PATH=$GITHUB_ACTIONS_RUNNER_SERVICE_TEMPLATE


### PR DESCRIPTION
The current solution has a wrong assumption that the `svc.sh` is executed as `./svc.sh` from the current directory.

The patch fixes it and allows to launch it from anywhere.