### PR TITLE
Fix issue template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,13 +1,13 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🛑 Request a feature in the runner application
-    url: https://github.com/orgs/community/discussions/categories/actions-and-packages
+    url: https://github.com/orgs/community/discussions/categories/actions
     about: If you have feature requests for GitHub Actions, please use the Actions and Packages section on the Github Product Feedback page.
   - name: ✅ Support for GitHub Actions
     url: https://github.community/c/code-to-cloud/52
     about: If you have questions about GitHub Actions or need support writing workflows, please ask in the GitHub Community Support forum.
   - name: ✅ Feedback and suggestions for GitHub Actions
-    url: https://github.com/github/feedback/discussions/categories/actions-and-packages-feedback
+    url: https://github.com/orgs/community/discussions/categories/actions
     about: If you have feedback or suggestions about GitHub Actions, please open a discussion (or add to an existing one) in the GitHub Actions Feedback.  GitHub Actions Product Managers and Engineers monitor the feedback forum.
   - name: ‼️ GitHub Security Bug Bounty
     url: https://bounty.github.com/


### PR DESCRIPTION
These links seem to be outdated or redirecting.

Based on the discussion thread below, it looks like the new link for actions is https://github.com/orgs/community/discussions/categories/actions.

- https://github.com/orgs/community/discussions/48284