### PR TITLE
Trace WebSocket exception into verbose level to reduce noise in diag log.

### DIFF
--- a/src/Runner.Common/JobServer.cs
+++ b/src/Runner.Common/JobServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Runner.Common/JobServer.cs
+++ b/src/Runner.Common/JobServer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Sdk;
 using GitHub.Services.Common;
+using GitHub.Services.OAuth;
+using GitHub.Services.Results.Client;
 using GitHub.Services.WebApi;
 using GitHub.Services.WebApi.Utilities.Internal;
-using GitHub.Services.Results.Client;
-using GitHub.Services.OAuth;
 
 namespace GitHub.Runner.Common
 {
@@ -254,7 +254,7 @@ namespace GitHub.Runner.Common
                 {
                     failedAttemptsToPostBatchedLinesByWebsocket++;
                     Trace.Info($"Caught exception during append web console line to websocket, let's fallback to sending via non-websocket call (total calls: {totalBatchedLinesAttemptedByWebsocket}, failed calls: {failedAttemptsToPostBatchedLinesByWebsocket}, websocket state: {this._websocketClient?.State}).");
-                    Trace.Error(ex);
+                    Trace.Verbose(ex.ToString());
                     if (totalBatchedLinesAttemptedByWebsocket > _minWebsocketBatchedLinesCountToConsider)
                     {
                         // let's consider failure percentage

--- a/src/Runner.Common/ResultsServer.cs
+++ b/src/Runner.Common/ResultsServer.cs
@@ -222,7 +222,7 @@ namespace GitHub.Runner.Common
                         {
                             var delay = BackoffTimerHelper.GetRandomBackoff(MinDelayForWebsocketReconnect, MaxDelayForWebsocketReconnect);
                             Trace.Info($"Websocket is not open, let's attempt to connect back again with random backoff {delay} ms.");
-                            Trace.Error(ex);
+                            Trace.Verbose(ex.ToString());
                             retries++;
                             InitializeWebsocketClient(_liveConsoleFeedUrl, _token, delay);
                         }


### PR DESCRIPTION
Live console output are best effort.
We use websocket to send out those console output, the websocket will be closed by the service once every 30 minutes and cause some huge non-actionable exception message get traced in the diag log.

I am moving the exception trace into `Verbose` level, so it' only shows up in when tracelevel set to `debug` (Not the default).

https://github.com/github/c2c-actions-runtime/issues/2439