### PR TITLE
Dont log template errors

### DIFF
--- a/src/Runner.Common/JobServerQueue.cs
+++ b/src/Runner.Common/JobServerQueue.cs
@@ -799,6 +799,7 @@ namespace GitHub.Runner.Common
                 Trace.Verbose($"    Record: t={record.RecordType}, n={record.Name}, s={record.State}, st={record.StartTime}, {record.PercentComplete}%, ft={record.FinishTime}, r={record.Result}: {record.CurrentOperation}");
                 if (record.Issues != null)
                 {
+                    removeDuplicatedIssues(record);
                     foreach (var issue in record.Issues)
                     {
                         String source;
@@ -817,6 +818,18 @@ namespace GitHub.Runner.Common
             }
 
             return mergedRecords;
+        }
+
+        private void removeDuplicatedIssues(TimelineRecord timelineRecord)
+        {
+            Dictionary<string, Issue> issuesMap = new Dictionary<string, Issue>();
+            foreach (var i in timelineRecord.Issues)
+            {
+                issuesMap.TryAdd(i.Message, i);
+            }
+            timelineRecord.Issues.Clear();
+
+            timelineRecord.Issues.AddRange(issuesMap.Select(entry => entry.Value).ToList());
         }
 
         private async Task UploadFile(UploadFileInfo file)

--- a/src/Runner.Common/JobServerQueue.cs
+++ b/src/Runner.Common/JobServerQueue.cs
@@ -799,7 +799,7 @@ namespace GitHub.Runner.Common
                 Trace.Verbose($"    Record: t={record.RecordType}, n={record.Name}, s={record.State}, st={record.StartTime}, {record.PercentComplete}%, ft={record.FinishTime}, r={record.Result}: {record.CurrentOperation}");
                 if (record.Issues != null)
                 {
-                    removeDuplicatedIssues(record);
+                    RemoveDuplicatedIssues(record);
                     foreach (var issue in record.Issues)
                     {
                         String source;
@@ -820,7 +820,7 @@ namespace GitHub.Runner.Common
             return mergedRecords;
         }
 
-        private void removeDuplicatedIssues(TimelineRecord timelineRecord)
+        private void RemoveDuplicatedIssues(TimelineRecord timelineRecord)
         {
             Dictionary<string, Issue> issuesMap = new Dictionary<string, Issue>();
             foreach (var i in timelineRecord.Issues)

--- a/src/Runner.Common/JobServerQueue.cs
+++ b/src/Runner.Common/JobServerQueue.cs
@@ -799,7 +799,6 @@ namespace GitHub.Runner.Common
                 Trace.Verbose($"    Record: t={record.RecordType}, n={record.Name}, s={record.State}, st={record.StartTime}, {record.PercentComplete}%, ft={record.FinishTime}, r={record.Result}: {record.CurrentOperation}");
                 if (record.Issues != null)
                 {
-                    RemoveDuplicatedIssues(record);
                     foreach (var issue in record.Issues)
                     {
                         String source;
@@ -819,19 +818,6 @@ namespace GitHub.Runner.Common
 
             return mergedRecords;
         }
-
-        private void RemoveDuplicatedIssues(TimelineRecord timelineRecord)
-        {
-            Dictionary<string, Issue> issuesMap = new Dictionary<string, Issue>();
-            foreach (var i in timelineRecord.Issues)
-            {
-                issuesMap.TryAdd(i.Message, i);
-            }
-            timelineRecord.Issues.Clear();
-
-            timelineRecord.Issues.AddRange(issuesMap.Select(entry => entry.Value).ToList());
-        }
-
         private async Task UploadFile(UploadFileInfo file)
         {
             bool uploadSucceed = false;

--- a/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateContext.cs
+++ b/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -163,7 +163,6 @@ namespace GitHub.DistributedTask.ObjectTemplating
                 message = $"{prefix} {message}";
             }
 
-            Errors.Add(message);
             TraceWriter.Error(message);
         }
 


### PR DESCRIPTION
### Context:
When evaluating composite actions template issues are logged twice (they're added to _timelineUpdateQueue and to _webConsoleLineQueue). This pr removes the issue duplicates when merging timelines.
Closes https://github.com/github/c2c-actions-runtime/issues/2381 

### Before the fix, we can see duplicated annotations
![Screenshot 2023-05-17 at 10 45 48](https://github.com/actions/runner/assets/67866556/2356b0ff-27c5-4374-b834-b0581176de18)
### After the fix
![Screenshot 2023-05-17 at 10 41 44](https://github.com/actions/runner/assets/67866556/f02c86c8-db33-4309-a706-8b650da7d96c)

### Todo:
- [ ] Add more tests for composite template with full template evaluation
- [ ] Better document handling of composite actions - when the template has errors it fails on template load. The embedded context is not even created and CompositeActionsHandler is not used 
