### PR TITLE
feat: add support of arm64 arch runners in service creation script

### DIFF
--- a/scripts/create-latest-svc.sh
+++ b/scripts/create-latest-svc.sh
@@ -8,7 +8,7 @@ set -e
 # Configures it as a service more secure
 # Should be used on VMs and not containers
 # Works on OSX and Linux
-# Assumes x64 arch
+# Assumes x64 arch (support arm64)
 # See EXAMPLES below
 
 flags_found=false
@@ -87,6 +87,9 @@ sudo echo
 runner_plat=linux
 [ ! -z "$(which sw_vers)" ] && runner_plat=osx;
 
+runner_arch=x64
+[ ! -z "$(arch | grep arm64)" ] && runner_arch=arm64
+
 function fatal()
 {
    echo "error: $1" >&2
@@ -139,7 +142,7 @@ echo "Downloading latest runner ..."
 # For the GHES Alpha, download the runner from github.com
 latest_version_label=$(curl -s -X GET 'https://api.github.com/repos/actions/runner/releases/latest' | jq -r '.tag_name')
 latest_version=$(echo ${latest_version_label:1})
-runner_file="actions-runner-${runner_plat}-x64-${latest_version}.tar.gz"
+runner_file="actions-runner-${runner_plat}-${runner_arch}-${latest_version}.tar.gz"
 
 if [ -f "${runner_file}" ]; then
     echo "${runner_file} exists. skipping download."


### PR DESCRIPTION
Hello!

A simple PR to handle arm64 (mac mini M1) architecture in create-latest-svc script. Tested on Linux x64 and macOS arm64 and works perfectly.