### PR TITLE
Add build improvements

### DIFF
--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -15,6 +15,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -210,7 +210,7 @@ function runtest ()
 function coverage ()
 {
     heading "Coverage ..."
-    cd Test && dotnet test --collect:"XPlat Code Coverage"
+    cd Test && dotnet test --collect:"XPlat Code Coverage;Format=json"
 }
 
 function format()

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -194,6 +194,10 @@ function layout ()
 
 function runtest ()
 {
+    if [[ ! -d "$LAYOUT_DIR" ]]; then
+        echo "$LAYOUT_DIR doesn't exist. Generating it now ..."
+        layout
+    fi
     heading "Testing ..."
 
     if [[ ("$CURRENT_PLATFORM" == "linux") || ("$CURRENT_PLATFORM" == "darwin") ]]; then

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -203,6 +203,12 @@ function runtest ()
     dotnet msbuild -t:test -p:PackageRuntime="${RUNTIME_ID}" -p:BUILDCONFIG="${BUILD_CONFIG}" -p:RunnerVersion="${RUNNER_VERSION}" ./dir.proj || failed "failed tests"
 }
 
+function coverage ()
+{
+    heading "Coverage ..."
+    cd Test && dotnet test --collect:"XPlat Code Coverage"
+}
+
 function format()
 {
     heading "Formatting..."
@@ -369,6 +375,7 @@ case $DEV_CMD in
     "p") package;;
     "format") format;;
     "f") format;;
+    "c") coverage;;
     *) echo "Invalid cmd.  Use build(b), test(t), layout(l), package(p), or format(f)";;
 esac
 

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -211,6 +211,7 @@ function coverage ()
 {
     heading "Coverage ..."
     cd Test && dotnet test --collect:"XPlat Code Coverage;Format=json"
+    # reportgenerator -reports:"/workspaces/runner/src/Test/TestResults/ecf2bd75-83e9-489a-9339-d61293abf98b/coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:Html
 }
 
 function format()


### PR DESCRIPTION
This PR:

- Adds code coverage generation script
- Adds **_layout** generation in test phase if not found

Todo:

- [ ] Generate html coverage report
- [ ] Use above stats in the repo main page

References:
- https://github.com/coverlet-coverage/coverlet
- https://github.com/danielpalme/ReportGenerator

Side note: currently total code coverage is **27%**.