### PR TITLE
Update container-hooks to 0.3.2

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:6.0 as build
 
 ARG RUNNER_VERSION
 ARG RUNNER_ARCH="x64"
-ARG RUNNER_CONTAINER_HOOKS_VERSION=0.3.1
+ARG RUNNER_CONTAINER_HOOKS_VERSION=0.3.2
 ARG DOCKER_VERSION=20.10.23
 
 RUN apt update -y && apt install curl unzip -y


### PR DESCRIPTION
A new version of containers hooks is available and we need to release a new runner image