### PR TITLE
Run Service: Only add StepResult for Tasks, not the Job itself

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -477,28 +477,32 @@ namespace GitHub.Runner.Worker
 
             PublishStepTelemetry();
 
-            var stepResult = new StepResult
+            if (_record.RecordType == "Task")
             {
-                ExternalID = _record.Id,
-                Conclusion = _record.Result ?? TaskResult.Succeeded,
-                Status = _record.State,
-                Number = _record.Order,
-                Name = _record.Name,
-                StartedAt = _record.StartTime,
-                CompletedAt = _record.FinishTime,
-                Annotations = new List<Annotation>()
-            };
-
-            _record.Issues?.ForEach(issue =>
-            {
-                var annotation = issue.ToAnnotation();
-                if (annotation != null)
+                var stepResult = new StepResult
                 {
-                    stepResult.Annotations.Add(annotation.Value);
-                }
-            });
+                    ExternalID = _record.Id,
+                    Conclusion = _record.Result ?? TaskResult.Succeeded,
+                    Status = _record.State,
+                    Number = _record.Order,
+                    Name = _record.Name,
+                    StartedAt = _record.StartTime,
+                    CompletedAt = _record.FinishTime,
+                    Annotations = new List<Annotation>()
+                };
 
-            Global.StepsResult.Add(stepResult);
+                _record.Issues?.ForEach(issue =>
+                {
+                    var annotation = issue.ToAnnotation();
+                    if (annotation != null)
+                    {
+                        stepResult.Annotations.Add(annotation.Value);
+                    }
+                });
+
+                Global.StepsResult.Add(stepResult);
+            }
+
 
             if (Root != this)
             {

--- a/src/Test/L0/Worker/ExecutionContextL0.cs
+++ b/src/Test/L0/Worker/ExecutionContextL0.cs
@@ -821,8 +821,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 ec.Complete();
 
                 // Assert.
-                Assert.Equal(1, ec.Global.StepsResult.Count);
-                Assert.Equal(TaskResult.Succeeded, ec.Global.StepsResult.Single().Conclusion);
+                Assert.Equal(0, ec.Global.StepsResult.Count);
             }
         }
 


### PR DESCRIPTION
This is an attempt to remove an extra Job Step that is coming through to the Run Service `/completejob` endpoint:

![CleanShot 2023-05-23 at 13 47 41](https://github.com/actions/runner/assets/836/e6a2a682-1020-458b-a3ac-c679f3dd69c1)

In a codespace, this does correct the issue:

![CleanShot 2023-05-23 at 13 48 41](https://github.com/actions/runner/assets/836/cbd31a43-5d00-4d8a-a1a5-9d7d1d70a102)

I don't think how I got the tests to 🟢 is really correct. With this code change `ec.Global.StepsResult.Count` is stuck at 0 in the test case. I think I somehow need to ensure that the Job being run by the test case has a step, and I don't think the `embeddedStep` is doing that correctly? Looking for advice on how to wire it up.

Additionally, I wonder if instead of moving the code inside a the `if (_record.RecordType == "Task")` conditional, it could just go inside the `if (Root != this)` which is right underneath?