### PR TITLE
Fixed a bug where a misplaced `=` character could bypass heredoc-style processing.

### DIFF
--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -322,21 +322,9 @@ namespace GitHub.Runner.Worker
                     var equalsIndex = line.IndexOf("=", StringComparison.Ordinal);
                     var heredocIndex = line.IndexOf("<<", StringComparison.Ordinal);
 
-                    // Normal style NAME=VALUE
-                    if (equalsIndex >= 0 && (heredocIndex < 0 || equalsIndex < heredocIndex))
-                    {
-                        var split = line.Split(new[] { '=' }, 2, StringSplitOptions.None);
-                        if (string.IsNullOrEmpty(line))
-                        {
-                            throw new Exception($"Invalid format '{line}'. Name must not be empty");
-                        }
-
-                        key = split[0];
-                        output = split[1];
-                    }
-
-                    // Heredoc style NAME<<EOF
-                    else if (heredocIndex >= 0 && (equalsIndex < 0 || heredocIndex < equalsIndex))
+                    // Heredoc style NAME<<EOF (where EOF is typically randomly-generated Base64 and may include an '=' character)
+                    // see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+                    if (heredocIndex >= 0 && (equalsIndex < 0 || heredocIndex < equalsIndex))
                     {
                         var split = line.Split(new[] { "<<" }, 2, StringSplitOptions.None);
                         if (string.IsNullOrEmpty(split[0]) || string.IsNullOrEmpty(split[1]))
@@ -363,6 +351,18 @@ namespace GitHub.Runner.Worker
                         }
 
                         output = endIndex > startIndex ? text.Substring(startIndex, endIndex - startIndex) : string.Empty;
+                    }
+                    // Normal style NAME=VALUE
+                    else if (equalsIndex >= 0 && heredocIndex < 0)
+                    {
+                        var split = line.Split(new[] { '=' }, 2, StringSplitOptions.None);
+                        if (string.IsNullOrEmpty(line))
+                        {
+                            throw new Exception($"Invalid format '{line}'. Name must not be empty");
+                        }
+
+                        key = split[0];
+                        output = split[1];
                     }
                     else
                     {

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -281,7 +281,7 @@ namespace GitHub.Runner.Worker
         }
     }
 
-    public sealed class EnvFileKeyValuePairs: IEnumerable<KeyValuePair<string, string>>
+    public sealed class EnvFileKeyValuePairs : IEnumerable<KeyValuePair<string, string>>
     {
         private IExecutionContext _context;
         private string _filePath;

--- a/src/Test/L0/TestUtil.cs
+++ b/src/Test/L0/TestUtil.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -12,7 +12,7 @@ namespace GitHub.Runner.Common.Tests
     public enum LineEndingType
     {
         Native,
-        Linux   = 0x__0A,
+        Linux = 0x__0A,
         Windows = 0x0D0A
     }
 
@@ -62,7 +62,7 @@ namespace GitHub.Runner.Common.Tests
         {
             string newline = lineEnding switch
             {
-                LineEndingType.Linux   => "\n",
+                LineEndingType.Linux => "\n",
                 LineEndingType.Windows => "\r\n",
                 _ => Environment.NewLine,
             };

--- a/src/Test/L0/TestUtil.cs
+++ b/src/Test/L0/TestUtil.cs
@@ -1,10 +1,21 @@
-﻿using System.IO;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
 using Xunit;
 using GitHub.Runner.Sdk;
-using System.Runtime.CompilerServices;
+using System.Linq;
 
 namespace GitHub.Runner.Common.Tests
 {
+    public enum LineEndingType
+    {
+        Native,
+        Linux   = 0x__0A,
+        Windows = 0x0D0A
+    }
+
     public static class TestUtil
     {
         private const string Src = "src";
@@ -41,5 +52,24 @@ namespace GitHub.Runner.Common.Tests
             Assert.True(Directory.Exists(testDataDir));
             return testDataDir;
         }
+
+        public static void WriteContent(string path, string content, LineEndingType lineEnding = LineEndingType.Native)
+        {
+            WriteContent(path, Enumerable.Repeat(content, 1), lineEnding);
+        }
+
+        public static void WriteContent(string path, IEnumerable<string> content, LineEndingType lineEnding = LineEndingType.Native)
+        {
+            string newline = lineEnding switch
+            {
+                LineEndingType.Linux   => "\n",
+                LineEndingType.Windows => "\r\n",
+                _ => Environment.NewLine,
+            };
+            var encoding = new UTF8Encoding(true); // Emit BOM
+            var contentStr = string.Join(newline, content);
+            File.WriteAllText(path, contentStr, encoding);
+        }
+
     }
 }

--- a/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
+++ b/src/Test/L0/Worker/CreateStepSummaryCommandL0.cs
@@ -124,7 +124,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "",
                     "## This is more markdown content",
                 };
-                WriteContent(stepSummaryFile, content);
+                TestUtil.WriteContent(stepSummaryFile, content);
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
                 _jobExecutionContext.Complete();
@@ -153,7 +153,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "",
                     "# GITHUB_TOKEN ghs_verysecuretoken",
                 };
-                WriteContent(stepSummaryFile, content);
+                TestUtil.WriteContent(stepSummaryFile, content);
 
                 _createStepCommand.ProcessCommand(_executionContext.Object, stepSummaryFile, null);
 
@@ -165,21 +165,6 @@ namespace GitHub.Runner.Common.Tests.Worker
                 _jobServerQueue.Verify(x => x.QueueFileUpload(It.IsAny<Guid>(), It.IsAny<Guid>(), ChecksAttachmentType.StepSummary, _executionContext.Object.Id.ToString(), scrubbedFile, It.IsAny<bool>()), Times.Once());
                 Assert.Equal(0, _issues.Count);
             }
-        }
-
-        private void WriteContent(
-            string path,
-            List<string> content,
-            string newline = null)
-        {
-            if (string.IsNullOrEmpty(newline))
-            {
-                newline = Environment.NewLine;
-            }
-
-            var encoding = new UTF8Encoding(true); // Emit BOM
-            var contentStr = string.Join(newline, content);
-            File.WriteAllText(path, contentStr, encoding);
         }
 
         private TestHostContext Setup([CallerMemberName] string name = "")

--- a/src/Test/L0/Worker/FileCommandTestBase.cs
+++ b/src/Test/L0/Worker/FileCommandTestBase.cs
@@ -410,11 +410,11 @@ namespace GitHub.Runner.Common.Tests.Worker
 
         protected static readonly string BREAK = Environment.NewLine;
 
-        protected IFileCommandExtension _fileCmdExtension {get; private set; }
-        protected Mock<IExecutionContext> _executionContext {get; private set; }
-        protected List<Tuple<DTWebApi.Issue, string>> _issues {get; private set; }
+        protected IFileCommandExtension _fileCmdExtension { get; private set; }
+        protected Mock<IExecutionContext> _executionContext { get; private set; }
+        protected List<Tuple<DTWebApi.Issue, string>> _issues { get; private set; }
         protected IDictionary<string, string> _store { get; private set; }
-        protected string _rootDirectory {get; private set; }
-        protected ITraceWriter _trace {get; private set; }
+        protected string _rootDirectory { get; private set; }
+        protected ITraceWriter _trace { get; private set; }
     }
 }

--- a/src/Test/L0/Worker/FileCommandTestBase.cs
+++ b/src/Test/L0/Worker/FileCommandTestBase.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using GitHub.Runner.Common.Util;
+using GitHub.Runner.Sdk;
+using GitHub.Runner.Worker;
+using Moq;
+using Xunit;
+using DTWebApi = GitHub.DistributedTask.WebApi;
+
+namespace GitHub.Runner.Common.Tests.Worker
+{
+    public class FileCommandTestBase
+    {
+        protected static readonly string BREAK = Environment.NewLine;
+    }
+}

--- a/src/Test/L0/Worker/FileCommandTestBase.cs
+++ b/src/Test/L0/Worker/FileCommandTestBase.cs
@@ -12,8 +12,409 @@ using DTWebApi = GitHub.DistributedTask.WebApi;
 
 namespace GitHub.Runner.Common.Tests.Worker
 {
-    public class FileCommandTestBase
+    public abstract class FileCommandTestBase<T>
+        where T : IFileCommandExtension, new()
     {
+
+        protected void TestDirectoryNotFound()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "directory-not-found", "env");
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(0, _store.Count);
+            }
+        }
+
+        protected void TestNotFound()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "file-not-found");
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(0, _store.Count);
+            }
+        }
+
+        protected void TestEmptyFile()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "empty-file");
+                var content = new List<string>();
+                TestUtil.WriteContent(stateFile, content);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(0, _store.Count);
+            }
+        }
+
+        protected void TestSimple()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "simple");
+                var content = new List<string>
+                {
+                    "MY_KEY=MY VALUE",
+                };
+                TestUtil.WriteContent(stateFile, content);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(1, _store.Count);
+                Assert.Equal("MY VALUE", _store["MY_KEY"]);
+            }
+        }
+
+        protected void TestSimple_SkipEmptyLines()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "simple");
+                var content = new List<string>
+                {
+                    string.Empty,
+                    "MY_KEY=my value",
+                    string.Empty,
+                    "MY_KEY_2=my second value",
+                    string.Empty,
+                };
+                TestUtil.WriteContent(stateFile, content);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(2, _store.Count);
+                Assert.Equal("my value", _store["MY_KEY"]);
+                Assert.Equal("my second value", _store["MY_KEY_2"]);
+            }
+        }
+
+        protected void TestSimple_EmptyValue()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "simple-empty-value");
+                var content = new List<string>
+                {
+                    "MY_KEY=",
+                };
+                TestUtil.WriteContent(stateFile, content);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(1, _store.Count);
+                Assert.Equal(string.Empty, _store["MY_KEY"]);
+            }
+        }
+
+        protected void TestSimple_MultipleValues()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "simple");
+                var content = new List<string>
+                {
+                    "MY_KEY=my value",
+                    "MY_KEY_2=",
+                    "MY_KEY_3=my third value",
+                };
+                TestUtil.WriteContent(stateFile, content);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(3, _store.Count);
+                Assert.Equal("my value", _store["MY_KEY"]);
+                Assert.Equal(string.Empty, _store["MY_KEY_2"]);
+                Assert.Equal("my third value", _store["MY_KEY_3"]);
+            }
+        }
+
+        protected void TestSimple_SpecialCharacters()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "simple");
+                var content = new List<string>
+                {
+                    "MY_KEY==abc",
+                    "MY_KEY_2=def=ghi",
+                    "MY_KEY_3=jkl=",
+                };
+                TestUtil.WriteContent(stateFile, content);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(3, _store.Count);
+                Assert.Equal("=abc", _store["MY_KEY"]);
+                Assert.Equal("def=ghi", _store["MY_KEY_2"]);
+                Assert.Equal("jkl=", _store["MY_KEY_3"]);
+            }
+        }
+
+        protected void TestHeredoc()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "heredoc");
+                var content = new List<string>
+                {
+                    "MY_KEY<<EOF",
+                    "line one",
+                    "line two",
+                    "line three",
+                    "EOF",
+                };
+                TestUtil.WriteContent(stateFile, content);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(1, _store.Count);
+                Assert.Equal($"line one{BREAK}line two{BREAK}line three", _store["MY_KEY"]);
+            }
+        }
+
+        protected void TestHeredoc_EmptyValue()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "heredoc");
+                var content = new List<string>
+                {
+                    "MY_KEY<<EOF",
+                    "EOF",
+                };
+                TestUtil.WriteContent(stateFile, content);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(1, _store.Count);
+                Assert.Equal(string.Empty, _store["MY_KEY"]);
+            }
+        }
+
+        protected void TestHeredoc_SkipEmptyLines()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "heredoc");
+                var content = new List<string>
+                {
+                    string.Empty,
+                    "MY_KEY<<EOF",
+                    "hello",
+                    "world",
+                    "EOF",
+                    string.Empty,
+                    "MY_KEY_2<<EOF",
+                    "HELLO",
+                    "AGAIN",
+                    "EOF",
+                    string.Empty,
+                };
+                TestUtil.WriteContent(stateFile, content);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(2, _store.Count);
+                Assert.Equal($"hello{BREAK}world", _store["MY_KEY"]);
+                Assert.Equal($"HELLO{BREAK}AGAIN", _store["MY_KEY_2"]);
+            }
+        }
+
+        protected void TestHeredoc_EdgeCases()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "heredoc");
+                var content = new List<string>
+                {
+                    "MY_KEY_1<<EOF",
+                    "hello",
+                    string.Empty,
+                    "three",
+                    string.Empty,
+                    "EOF",
+                    "MY_KEY_2<<EOF",
+                    "hello=two",
+                    "EOF",
+                    "MY_KEY_3<<EOF",
+                    " EOF",
+                    "EOF",
+                    "MY_KEY_4<<EOF",
+                    "EOF EOF",
+                    "EOF",
+                };
+                TestUtil.WriteContent(stateFile, content);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(4, _store.Count);
+                Assert.Equal($"hello{BREAK}{BREAK}three{BREAK}", _store["MY_KEY_1"]);
+                Assert.Equal($"hello=two", _store["MY_KEY_2"]);
+                Assert.Equal($" EOF", _store["MY_KEY_3"]);
+                Assert.Equal($"EOF EOF", _store["MY_KEY_4"]);
+            }
+        }
+
+        protected void TestHeredoc_EndMarkerVariations(string validEndMarker)
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "heredoc");
+                string eof = validEndMarker;
+                var content = new List<string>
+                {
+                    $"MY_KEY_1<<{eof}",
+                    $"hello",
+                    $"one",
+                    $"{eof}",
+                    $"MY_KEY_2<<{eof}",
+                    $"hello=two",
+                    $"{eof}",
+                    $"MY_KEY_3<<{eof}",
+                    $" {eof}",
+                    $"{eof}",
+                    $"MY_KEY_4<<{eof}",
+                    $"{eof} {eof}",
+                    $"{eof}",
+                };
+                TestUtil.WriteContent(stateFile, content);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(4, _store.Count);
+                Assert.Equal($"hello{BREAK}one", _store["MY_KEY_1"]);
+                Assert.Equal($"hello=two", _store["MY_KEY_2"]);
+                Assert.Equal($" {eof}", _store["MY_KEY_3"]);
+                Assert.Equal($"{eof} {eof}", _store["MY_KEY_4"]);
+            }
+        }
+
+        protected void TestHeredoc_EqualBeforeMultilineIndicator()
+        {
+            using var hostContext = Setup();
+            var stateFile = Path.Combine(_rootDirectory, "heredoc");
+
+            // Define a hypothetical injectable payload that just happens to contain the '=' character.
+            string contrivedGitHubIssueTitle = "Issue 999:  Better handling for the `=` character";
+
+            // The docs recommend using randomly-generated EOF markers.
+            // Here's a randomly-generated base64 EOF marker that just happens to contain an '=' character.  ('=' is a padding character in base64.)
+            // see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+            string randomizedEOF = "khkIhPxsVA==";
+            var content = new List<string>
+            {
+                // In a real world scenario, "%INJECT%" might instead be something like "${{ github.event.issue.title }}"
+                $"PREFIX_%INJECT%<<{randomizedEOF}".Replace("%INJECT%", contrivedGitHubIssueTitle),
+                "RandomDataThatJustHappensToContainAnEquals=Character",
+                randomizedEOF,
+            };
+            TestUtil.WriteContent(stateFile, content);
+            var ex = Assert.Throws<Exception>(() => _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null));
+            Assert.StartsWith("Invalid format", ex.Message);
+        }
+
+        protected void TestHeredoc_MissingNewLine()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "heredoc");
+                string content = "MY_KEY<<EOF line one line two line three EOF";
+                TestUtil.WriteContent(stateFile, content);
+                var ex = Assert.Throws<Exception>(() => _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null));
+                Assert.Contains("Matching delimiter not found", ex.Message);
+            }
+        }
+
+        protected void TestHeredoc_MissingNewLineMultipleLines()
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "heredoc");
+                string multilineFragment = @"line one
+                                             line two
+                                             line three";
+
+                // Note that the final EOF does not appear on it's own line.
+                string content = $"MY_KEY<<EOF {multilineFragment} EOF";
+                TestUtil.WriteContent(stateFile, content);
+                var ex = Assert.Throws<Exception>(() => _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null));
+                Assert.Contains("EOF marker missing new line", ex.Message);
+            }
+        }
+
+        protected void TestHeredoc_PreservesNewline()
+        {
+            using (var hostContext = Setup())
+            {
+                var newline = "\n";
+                var stateFile = Path.Combine(_rootDirectory, "heredoc");
+                var content = new List<string>
+                {
+                    "MY_KEY<<EOF",
+                    "hello",
+                    "world",
+                    "EOF",
+                };
+                TestUtil.WriteContent(stateFile, content, LineEndingType.Linux);
+                _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(0, _issues.Count);
+                Assert.Equal(1, _store.Count);
+                Assert.Equal($"hello{newline}world", _store["MY_KEY"]);
+            }
+        }
+
+        protected TestHostContext Setup([CallerMemberName] string name = "")
+        {
+            _issues = new List<Tuple<DTWebApi.Issue, string>>();
+
+            var hostContext = new TestHostContext(this, name);
+
+            // Trace
+            _trace = hostContext.GetTrace();
+
+            // Directory for test data
+            var workDirectory = hostContext.GetDirectory(WellKnownDirectory.Work);
+            ArgUtil.NotNullOrEmpty(workDirectory, nameof(workDirectory));
+            Directory.CreateDirectory(workDirectory);
+            _rootDirectory = Path.Combine(workDirectory, nameof(T));
+            Directory.CreateDirectory(_rootDirectory);
+
+            // Execution context
+            _executionContext = new Mock<IExecutionContext>();
+            _executionContext.Setup(x => x.Global)
+                .Returns(new GlobalContext
+                {
+                    EnvironmentVariables = new Dictionary<string, string>(VarUtil.EnvironmentVariableKeyComparer),
+                    WriteDebug = true,
+                });
+            _executionContext.Setup(x => x.AddIssue(It.IsAny<DTWebApi.Issue>(), It.IsAny<ExecutionContextLogOptions>()))
+                .Callback((DTWebApi.Issue issue, ExecutionContextLogOptions logOptions) =>
+                {
+                    var resolvedMessage = issue.Message;
+                    if (logOptions.WriteToLog && !string.IsNullOrEmpty(logOptions.LogMessageOverride))
+                    {
+                        resolvedMessage = logOptions.LogMessageOverride;
+                    }
+                    _issues.Add(new(issue, resolvedMessage));
+                    _trace.Info($"Issue '{issue.Type}': {resolvedMessage}");
+                });
+            _executionContext.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback((string tag, string message) =>
+                {
+                    _trace.Info($"{tag}{message}");
+                });
+
+            _store = PostSetup();
+
+            _fileCmdExtension = new T();
+            _fileCmdExtension.Initialize(hostContext);
+
+            return hostContext;
+        }
+
+        protected abstract IDictionary<string, string> PostSetup();
+
         protected static readonly string BREAK = Environment.NewLine;
+
+        protected IFileCommandExtension _fileCmdExtension {get; private set; }
+        protected Mock<IExecutionContext> _executionContext {get; private set; }
+        protected List<Tuple<DTWebApi.Issue, string>> _issues {get; private set; }
+        protected IDictionary<string, string> _store { get; private set; }
+        protected string _rootDirectory {get; private set; }
+        protected ITraceWriter _trace {get; private set; }
     }
 }

--- a/src/Test/L0/Worker/SaveStateFileCommandL0.cs
+++ b/src/Test/L0/Worker/SaveStateFileCommandL0.cs
@@ -64,7 +64,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             {
                 var stateFile = Path.Combine(_rootDirectory, "empty-file");
                 var content = new List<string>();
-                WriteContent(stateFile, content);
+                TestUtil.WriteContent(stateFile, content);
                 _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(0, _intraActionState.Count);
@@ -83,7 +83,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     "MY_STATE=MY VALUE",
                 };
-                WriteContent(stateFile, content);
+                TestUtil.WriteContent(stateFile, content);
                 _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(1, _intraActionState.Count);
@@ -107,7 +107,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "MY_STATE_2=my second value",
                     string.Empty,
                 };
-                WriteContent(stateFile, content);
+                TestUtil.WriteContent(stateFile, content);
                 _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(2, _intraActionState.Count);
@@ -128,7 +128,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 {
                     "MY_STATE=",
                 };
-                WriteContent(stateFile, content);
+                TestUtil.WriteContent(stateFile, content);
                 _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(1, _intraActionState.Count);
@@ -150,7 +150,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "MY_STATE_2=",
                     "MY_STATE_3=my third value",
                 };
-                WriteContent(stateFile, content);
+                TestUtil.WriteContent(stateFile, content);
                 _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(3, _intraActionState.Count);
@@ -174,7 +174,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "MY_STATE_2=def=ghi",
                     "MY_STATE_3=jkl=",
                 };
-                WriteContent(stateFile, content);
+                TestUtil.WriteContent(stateFile, content);
                 _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(3, _intraActionState.Count);
@@ -200,7 +200,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "line three",
                     "EOF",
                 };
-                WriteContent(stateFile, content);
+                TestUtil.WriteContent(stateFile, content);
                 _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(1, _intraActionState.Count);
@@ -221,7 +221,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "MY_STATE<<EOF",
                     "EOF",
                 };
-                WriteContent(stateFile, content);
+                TestUtil.WriteContent(stateFile, content);
                 _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(1, _intraActionState.Count);
@@ -251,7 +251,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "EOF",
                     string.Empty,
                 };
-                WriteContent(stateFile, content);
+                TestUtil.WriteContent(stateFile, content);
                 _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(2, _intraActionState.Count);
@@ -291,7 +291,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     " EOF",
                     "EOF",
                 };
-                WriteContent(stateFile, content);
+                TestUtil.WriteContent(stateFile, content);
                 _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(5, _intraActionState.Count);
@@ -311,15 +311,8 @@ namespace GitHub.Runner.Common.Tests.Worker
             using (var hostContext = Setup())
             {
                 var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_STATE<<EOF",
-                    "line one",
-                    "line two",
-                    "line three",
-                    "EOF",
-                };
-                WriteContent(stateFile, content, " ");
+                string content = "MY_OUTPUT<<EOF line one line two line three EOF";
+                TestUtil.WriteContent(stateFile, content);
                 var ex = Assert.Throws<Exception>(() => _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null));
                 Assert.Contains("Matching delimiter not found", ex.Message);
             }
@@ -333,15 +326,13 @@ namespace GitHub.Runner.Common.Tests.Worker
             using (var hostContext = Setup())
             {
                 var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_STATE<<EOF",
-                    @"line one
-                    line two
-                    line three",
-                    "EOF",
-                };
-                WriteContent(stateFile, content, " ");
+                string multilineFragment = @"line one
+                                             line two
+                                             line three";
+
+                // Note that the final EOF does not appear on it's own line.
+                string content = $"MY_OUTPUT<<EOF {multilineFragment} EOF";
+                TestUtil.WriteContent(stateFile, content);
                 var ex = Assert.Throws<Exception>(() => _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null));
                 Assert.Contains("EOF marker missing new line", ex.Message);
             }
@@ -364,7 +355,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "world",
                     "EOF",
                 };
-                WriteContent(stateFile, content, newline: newline);
+                TestUtil.WriteContent(stateFile, content, LineEndingType.Linux);
                 _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(1, _intraActionState.Count);
@@ -373,20 +364,6 @@ namespace GitHub.Runner.Common.Tests.Worker
         }
 #endif
 
-        private void WriteContent(
-            string path,
-            List<string> content,
-            string newline = null)
-        {
-            if (string.IsNullOrEmpty(newline))
-            {
-                newline = Environment.NewLine;
-            }
-
-            var encoding = new UTF8Encoding(true); // Emit BOM
-            var contentStr = string.Join(newline, content);
-            File.WriteAllText(path, contentStr, encoding);
-        }
 
         private TestHostContext Setup([CallerMemberName] string name = "")
         {

--- a/src/Test/L0/Worker/SaveStateFileCommandL0.cs
+++ b/src/Test/L0/Worker/SaveStateFileCommandL0.cs
@@ -1,38 +1,27 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using GitHub.Runner.Common.Util;
-using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker;
-using Moq;
 using Xunit;
-using DTWebApi = GitHub.DistributedTask.WebApi;
 
 namespace GitHub.Runner.Common.Tests.Worker
 {
-    public sealed class SaveStateFileCommandL0 : FileCommandTestBase
+    public sealed class SaveStateFileCommandL0 : FileCommandTestBase<SaveStateFileCommand>
     {
-        private Mock<IExecutionContext> _executionContext;
-        private List<Tuple<DTWebApi.Issue, string>> _issues;
-        private string _rootDirectory;
-        private SaveStateFileCommand _saveStateFileCommand;
-        private Dictionary<string, string> _intraActionState;
-        private ITraceWriter _trace;
+
+        protected override IDictionary<string, string> PostSetup()
+        {
+            var intraActionState = new Dictionary<string, string>();
+            _executionContext.Setup(x => x.IntraActionState).Returns(intraActionState);
+            return intraActionState;
+        }
 
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_DirectoryNotFound()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "directory-not-found", "env");
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(0, _intraActionState.Count);
-            }
+            base.TestDirectoryNotFound();
         }
 
         [Fact]
@@ -40,13 +29,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_NotFound()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "file-not-found");
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(0, _intraActionState.Count);
-            }
+            base.TestNotFound();
         }
 
         [Fact]
@@ -54,15 +37,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_EmptyFile()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "empty-file");
-                var content = new List<string>();
-                TestUtil.WriteContent(stateFile, content);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(0, _intraActionState.Count);
-            }
+            base.TestEmptyFile();
         }
 
         [Fact]
@@ -70,19 +45,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Simple()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    "MY_STATE=MY VALUE",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _intraActionState.Count);
-                Assert.Equal("MY VALUE", _intraActionState["MY_STATE"]);
-            }
+            base.TestSimple();
         }
 
         [Fact]
@@ -90,24 +53,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Simple_SkipEmptyLines()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    string.Empty,
-                    "MY_STATE=my value",
-                    string.Empty,
-                    "MY_STATE_2=my second value",
-                    string.Empty,
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(2, _intraActionState.Count);
-                Assert.Equal("my value", _intraActionState["MY_STATE"]);
-                Assert.Equal("my second value", _intraActionState["MY_STATE_2"]);
-            }
+            base.TestSimple_SkipEmptyLines();
         }
 
         [Fact]
@@ -115,19 +61,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Simple_EmptyValue()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "simple-empty-value");
-                var content = new List<string>
-                {
-                    "MY_STATE=",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _intraActionState.Count);
-                Assert.Equal(string.Empty, _intraActionState["MY_STATE"]);
-            }
+            base.TestSimple_EmptyValue();
         }
 
         [Fact]
@@ -135,23 +69,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Simple_MultipleValues()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    "MY_STATE=my value",
-                    "MY_STATE_2=",
-                    "MY_STATE_3=my third value",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(3, _intraActionState.Count);
-                Assert.Equal("my value", _intraActionState["MY_STATE"]);
-                Assert.Equal(string.Empty, _intraActionState["MY_STATE_2"]);
-                Assert.Equal("my third value", _intraActionState["MY_STATE_3"]);
-            }
+            base.TestSimple_MultipleValues();
         }
 
         [Fact]
@@ -159,23 +77,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Simple_SpecialCharacters()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    "MY_STATE==abc",
-                    "MY_STATE_2=def=ghi",
-                    "MY_STATE_3=jkl=",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(3, _intraActionState.Count);
-                Assert.Equal("=abc", _intraActionState["MY_STATE"]);
-                Assert.Equal("def=ghi", _intraActionState["MY_STATE_2"]);
-                Assert.Equal("jkl=", _intraActionState["MY_STATE_3"]);
-            }
+            base.TestSimple_SpecialCharacters();
         }
 
         [Fact]
@@ -183,23 +85,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Heredoc()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_STATE<<EOF",
-                    "line one",
-                    "line two",
-                    "line three",
-                    "EOF",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _intraActionState.Count);
-                Assert.Equal($"line one{BREAK}line two{BREAK}line three", _intraActionState["MY_STATE"]);
-            }
+            base.TestHeredoc();
         }
 
         [Fact]
@@ -207,20 +93,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Heredoc_EmptyValue()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_STATE<<EOF",
-                    "EOF",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _intraActionState.Count);
-                Assert.Equal(string.Empty, _intraActionState["MY_STATE"]);
-            }
+            base.TestHeredoc_EmptyValue();
         }
 
         [Fact]
@@ -228,30 +101,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Heredoc_SkipEmptyLines()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    string.Empty,
-                    "MY_STATE<<EOF",
-                    "hello",
-                    "world",
-                    "EOF",
-                    string.Empty,
-                    "MY_STATE_2<<EOF",
-                    "HELLO",
-                    "AGAIN",
-                    "EOF",
-                    string.Empty,
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(2, _intraActionState.Count);
-                Assert.Equal($"hello{BREAK}world", _intraActionState["MY_STATE"]);
-                Assert.Equal($"HELLO{BREAK}AGAIN", _intraActionState["MY_STATE_2"]);
-            }
+            base.TestHeredoc_SkipEmptyLines();
         }
 
         [Fact]
@@ -259,36 +109,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Heredoc_EdgeCases()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_STATE_1<<EOF",
-                    "hello",
-                    string.Empty,
-                    "three",
-                    string.Empty,
-                    "EOF",
-                    "MY_STATE_2<<EOF",
-                    "hello=two",
-                    "EOF",
-                    "MY_STATE_3<<EOF",
-                    " EOF",
-                    "EOF",
-                    "MY_STATE_4<<EOF",
-                    "EOF EOF",
-                    "EOF",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(4, _intraActionState.Count);
-                Assert.Equal($"hello{BREAK}{BREAK}three{BREAK}", _intraActionState["MY_STATE_1"]);
-                Assert.Equal($"hello=two", _intraActionState["MY_STATE_2"]);
-                Assert.Equal($" EOF", _intraActionState["MY_STATE_3"]);
-                Assert.Equal($"EOF EOF", _intraActionState["MY_STATE_4"]);
-            }
+            base.TestHeredoc_EdgeCases();
         }
 
         [Theory]
@@ -317,35 +138,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [InlineData("ZvnAEW+9O0tXp3Fmb3Oh")]
         public void SaveStateFileCommand_Heredoc_EndMarkerVariations(string validEndMarker)
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                string eof = validEndMarker;
-                var content = new List<string>
-                {
-                    $"MY_STATE_1<<{eof}",
-                    $"hello",
-                    $"one",
-                    $"{eof}",
-                    $"MY_STATE_2<<{eof}",
-                    $"hello=two",
-                    $"{eof}",
-                    $"MY_STATE_3<<{eof}",
-                    $" {eof}",
-                    $"{eof}",
-                    $"MY_STATE_4<<{eof}",
-                    $"{eof} {eof}",
-                    $"{eof}",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(4, _intraActionState.Count);
-                Assert.Equal($"hello{BREAK}one", _intraActionState["MY_STATE_1"]);
-                Assert.Equal($"hello=two", _intraActionState["MY_STATE_2"]);
-                Assert.Equal($" {eof}", _intraActionState["MY_STATE_3"]);
-                Assert.Equal($"{eof} {eof}", _intraActionState["MY_STATE_4"]);
-            }
+            base.TestHeredoc_EndMarkerVariations(validEndMarker);
         }
 
         [Fact]
@@ -353,26 +146,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Heredoc_EqualBeforeMultilineIndicator()
         {
-            using var hostContext = Setup();
-            var stateFile = Path.Combine(_rootDirectory, "heredoc");
-
-            // Define a hypothetical injectable payload that just happens to contain the '=' character.
-            string contrivedGitHubIssueTitle = "Issue 999:  Better handling for the `=` character";
-
-            // The docs recommend using randomly-generated EOF markers.
-            // Here's a randomly-generated base64 EOF marker that just happens to contain an '=' character.  ('=' is a padding character in base64.)
-            // see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-            string randomizedEOF = "khkIhPxsVA==";
-            var content = new List<string>
-            {
-                // In a real world scenario, "%INJECT%" might instead be something like "${{ github.event.issue.title }}"
-                $"PREFIX_%INJECT%<<{randomizedEOF}".Replace("%INJECT%", contrivedGitHubIssueTitle),
-                "RandomDataThatJustHappensToContainAnEquals=Character",
-                randomizedEOF,
-            };
-            TestUtil.WriteContent(stateFile, content);
-            var ex = Assert.Throws<Exception>(() => _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null));
-            Assert.StartsWith("Invalid format", ex.Message);
+            base.TestHeredoc_EqualBeforeMultilineIndicator();
         }
 
         [Fact]
@@ -380,14 +154,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Heredoc_MissingNewLine()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                string content = "MY_OUTPUT<<EOF line one line two line three EOF";
-                TestUtil.WriteContent(stateFile, content);
-                var ex = Assert.Throws<Exception>(() => _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null));
-                Assert.Contains("Matching delimiter not found", ex.Message);
-            }
+            base.TestHeredoc_MissingNewLine();
         }
 
         [Fact]
@@ -395,19 +162,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Heredoc_MissingNewLineMultipleLines()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                string multilineFragment = @"line one
-                                             line two
-                                             line three";
-
-                // Note that the final EOF does not appear on it's own line.
-                string content = $"MY_OUTPUT<<EOF {multilineFragment} EOF";
-                TestUtil.WriteContent(stateFile, content);
-                var ex = Assert.Throws<Exception>(() => _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null));
-                Assert.Contains("EOF marker missing new line", ex.Message);
-            }
+            base.TestHeredoc_MissingNewLineMultipleLines();
         }
 
 #if OS_WINDOWS
@@ -416,76 +171,9 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SaveStateFileCommand_Heredoc_PreservesNewline()
         {
-            using (var hostContext = Setup())
-            {
-                var newline = "\n";
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_STATE<<EOF",
-                    "hello",
-                    "world",
-                    "EOF",
-                };
-                TestUtil.WriteContent(stateFile, content, LineEndingType.Linux);
-                _saveStateFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _intraActionState.Count);
-                Assert.Equal($"hello{newline}world", _intraActionState["MY_STATE"]);
-            }
+            base.TestHeredoc_PreservesNewline();
         }
 #endif
 
-
-        private TestHostContext Setup([CallerMemberName] string name = "")
-        {
-            _issues = new List<Tuple<DTWebApi.Issue, string>>();
-            _intraActionState = new Dictionary<string, string>();
-
-            var hostContext = new TestHostContext(this, name);
-
-            // Trace
-            _trace = hostContext.GetTrace();
-
-            // Directory for test data
-            var workDirectory = hostContext.GetDirectory(WellKnownDirectory.Work);
-            ArgUtil.NotNullOrEmpty(workDirectory, nameof(workDirectory));
-            Directory.CreateDirectory(workDirectory);
-            _rootDirectory = Path.Combine(workDirectory, nameof(SaveStateFileCommandL0));
-            Directory.CreateDirectory(_rootDirectory);
-
-            // Execution context
-            _executionContext = new Mock<IExecutionContext>();
-            _executionContext.Setup(x => x.Global)
-                .Returns(new GlobalContext
-                {
-                    EnvironmentVariables = new Dictionary<string, string>(VarUtil.EnvironmentVariableKeyComparer),
-                    WriteDebug = true,
-                });
-            _executionContext.Setup(x => x.AddIssue(It.IsAny<DTWebApi.Issue>(), It.IsAny<ExecutionContextLogOptions>()))
-                .Callback((DTWebApi.Issue issue, ExecutionContextLogOptions logOptions) =>
-                {
-                    var resolvedMessage = issue.Message;
-                    if (logOptions.WriteToLog && !string.IsNullOrEmpty(logOptions.LogMessageOverride))
-                    {
-                        resolvedMessage = logOptions.LogMessageOverride;
-                    }
-                    _issues.Add(new(issue, resolvedMessage));
-                    _trace.Info($"Issue '{issue.Type}': {resolvedMessage}");
-                });
-            _executionContext.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>()))
-                .Callback((string tag, string message) =>
-                {
-                    _trace.Info($"{tag}{message}");
-                });
-            _executionContext.Setup(x => x.IntraActionState)
-              .Returns(_intraActionState);
-
-            // SaveStateFileCommand
-            _saveStateFileCommand = new SaveStateFileCommand();
-            _saveStateFileCommand.Initialize(hostContext);
-
-            return hostContext;
-        }
     }
 }

--- a/src/Test/L0/Worker/SetEnvFileCommandL0.cs
+++ b/src/Test/L0/Worker/SetEnvFileCommandL0.cs
@@ -1,37 +1,25 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using GitHub.Runner.Common.Util;
-using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker;
-using Moq;
 using Xunit;
-using DTWebApi = GitHub.DistributedTask.WebApi;
 
 namespace GitHub.Runner.Common.Tests.Worker
 {
-    public sealed class SetEnvFileCommandL0 : FileCommandTestBase
+    public sealed class SetEnvFileCommandL0 : FileCommandTestBase<SetEnvFileCommand>
     {
-        private Mock<IExecutionContext> _executionContext;
-        private List<Tuple<DTWebApi.Issue, string>> _issues;
-        private string _rootDirectory;
-        private SetEnvFileCommand _setEnvFileCommand;
-        private ITraceWriter _trace;
+
+        protected override IDictionary<string, string> PostSetup()
+        {
+            return _executionContext.Object.Global.EnvironmentVariables;
+        }
 
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_DirectoryNotFound()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "directory-not-found", "env");
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(0, _executionContext.Object.Global.EnvironmentVariables.Count);
-            }
+            base.TestDirectoryNotFound();
         }
 
         [Fact]
@@ -39,13 +27,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_NotFound()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "file-not-found");
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(0, _executionContext.Object.Global.EnvironmentVariables.Count);
-            }
+            base.TestNotFound();
         }
 
         [Fact]
@@ -53,15 +35,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_EmptyFile()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "empty-file");
-                var content = new List<string>();
-                TestUtil.WriteContent(envFile, content);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(0, _executionContext.Object.Global.EnvironmentVariables.Count);
-            }
+            base.TestEmptyFile();
         }
 
         [Fact]
@@ -69,19 +43,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Simple()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    "MY_ENV=MY VALUE",
-                };
-                TestUtil.WriteContent(envFile, content);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _executionContext.Object.Global.EnvironmentVariables.Count);
-                Assert.Equal("MY VALUE", _executionContext.Object.Global.EnvironmentVariables["MY_ENV"]);
-            }
+            base.TestSimple();
         }
 
         [Fact]
@@ -89,24 +51,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Simple_SkipEmptyLines()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    string.Empty,
-                    "MY_ENV=my value",
-                    string.Empty,
-                    "MY_ENV_2=my second value",
-                    string.Empty,
-                };
-                TestUtil.WriteContent(envFile, content);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(2, _executionContext.Object.Global.EnvironmentVariables.Count);
-                Assert.Equal("my value", _executionContext.Object.Global.EnvironmentVariables["MY_ENV"]);
-                Assert.Equal("my second value", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_2"]);
-            }
+            base.TestSimple_SkipEmptyLines();
         }
 
         [Fact]
@@ -114,19 +59,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Simple_EmptyValue()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "simple-empty-value");
-                var content = new List<string>
-                {
-                    "MY_ENV=",
-                };
-                TestUtil.WriteContent(envFile, content);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _executionContext.Object.Global.EnvironmentVariables.Count);
-                Assert.Equal(string.Empty, _executionContext.Object.Global.EnvironmentVariables["MY_ENV"]);
-            }
+            base.TestSimple_EmptyValue();
         }
 
         [Fact]
@@ -134,23 +67,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Simple_MultipleValues()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    "MY_ENV=my value",
-                    "MY_ENV_2=",
-                    "MY_ENV_3=my third value",
-                };
-                TestUtil.WriteContent(envFile, content);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(3, _executionContext.Object.Global.EnvironmentVariables.Count);
-                Assert.Equal("my value", _executionContext.Object.Global.EnvironmentVariables["MY_ENV"]);
-                Assert.Equal(string.Empty, _executionContext.Object.Global.EnvironmentVariables["MY_ENV_2"]);
-                Assert.Equal("my third value", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_3"]);
-            }
+            base.TestSimple_MultipleValues();
         }
 
         [Fact]
@@ -158,23 +75,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Simple_SpecialCharacters()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    "MY_ENV==abc",
-                    "MY_ENV_2=def=ghi",
-                    "MY_ENV_3=jkl=",
-                };
-                TestUtil.WriteContent(envFile, content);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(3, _executionContext.Object.Global.EnvironmentVariables.Count);
-                Assert.Equal("=abc", _executionContext.Object.Global.EnvironmentVariables["MY_ENV"]);
-                Assert.Equal("def=ghi", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_2"]);
-                Assert.Equal("jkl=", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_3"]);
-            }
+            base.TestSimple_SpecialCharacters();
         }
 
         [Fact]
@@ -182,23 +83,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Heredoc()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_ENV<<EOF",
-                    "line one",
-                    "line two",
-                    "line three",
-                    "EOF",
-                };
-                TestUtil.WriteContent(envFile, content);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _executionContext.Object.Global.EnvironmentVariables.Count);
-                Assert.Equal($"line one{BREAK}line two{BREAK}line three", _executionContext.Object.Global.EnvironmentVariables["MY_ENV"]);
-            }
+            base.TestHeredoc();
         }
 
         [Fact]
@@ -206,20 +91,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Heredoc_EmptyValue()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_ENV<<EOF",
-                    "EOF",
-                };
-                TestUtil.WriteContent(envFile, content);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _executionContext.Object.Global.EnvironmentVariables.Count);
-                Assert.Equal(string.Empty, _executionContext.Object.Global.EnvironmentVariables["MY_ENV"]);
-            }
+            base.TestHeredoc_EmptyValue();
         }
 
         [Fact]
@@ -227,30 +99,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Heredoc_SkipEmptyLines()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    string.Empty,
-                    "MY_ENV<<EOF",
-                    "hello",
-                    "world",
-                    "EOF",
-                    string.Empty,
-                    "MY_ENV_2<<EOF",
-                    "HELLO",
-                    "AGAIN",
-                    "EOF",
-                    string.Empty,
-                };
-                TestUtil.WriteContent(envFile, content);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(2, _executionContext.Object.Global.EnvironmentVariables.Count);
-                Assert.Equal($"hello{BREAK}world", _executionContext.Object.Global.EnvironmentVariables["MY_ENV"]);
-                Assert.Equal($"HELLO{BREAK}AGAIN", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_2"]);
-            }
+            base.TestHeredoc_SkipEmptyLines();
         }
 
         [Fact]
@@ -258,36 +107,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Heredoc_EdgeCases()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_ENV_1<<EOF",
-                    "hello",
-                    string.Empty,
-                    "three",
-                    string.Empty,
-                    "EOF",
-                    "MY_ENV_2<<EOF",
-                    "hello=two",
-                    "EOF",
-                    "MY_ENV_3<<EOF",
-                    " EOF",
-                    "EOF",
-                    "MY_ENV_4<<EOF",
-                    "EOF EOF",
-                    "EOF",
-                };
-                TestUtil.WriteContent(envFile, content);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(4, _executionContext.Object.Global.EnvironmentVariables.Count);
-                Assert.Equal($"hello{BREAK}{BREAK}three{BREAK}", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_1"]);
-                Assert.Equal($"hello=two", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_2"]);
-                Assert.Equal($" EOF", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_3"]);
-                Assert.Equal($"EOF EOF", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_4"]);
-            }
+            base.TestHeredoc_EdgeCases();
         }
 
         [Theory]
@@ -316,35 +136,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [InlineData("ZvnAEW+9O0tXp3Fmb3Oh")]
         public void SetEnvFileCommand_Heredoc_EndMarkerVariations(string validEndMarker)
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "heredoc");
-                string eof = validEndMarker;
-                var content = new List<string>
-                {
-                    $"MY_ENV_1<<{eof}",
-                    $"hello",
-                    $"one",
-                    $"{eof}",
-                    $"MY_ENV_2<<{eof}",
-                    $"hello=two",
-                    $"{eof}",
-                    $"MY_ENV_3<<{eof}",
-                    $" {eof}",
-                    $"{eof}",
-                    $"MY_ENV_4<<{eof}",
-                    $"{eof} {eof}",
-                    $"{eof}",
-                };
-                TestUtil.WriteContent(envFile, content);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(4, _executionContext.Object.Global.EnvironmentVariables.Count);
-                Assert.Equal($"hello{BREAK}one", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_1"]);
-                Assert.Equal($"hello=two", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_2"]);
-                Assert.Equal($" {eof}", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_3"]);
-                Assert.Equal($"{eof} {eof}", _executionContext.Object.Global.EnvironmentVariables["MY_ENV_4"]);
-            }
+            base.TestHeredoc_EndMarkerVariations(validEndMarker);
         }
 
         [Fact]
@@ -352,26 +144,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Heredoc_EqualBeforeMultilineIndicator()
         {
-            using var hostContext = Setup();
-            var envFile = Path.Combine(_rootDirectory, "heredoc");
-
-            // Define a hypothetical injectable payload that just happens to contain the '=' character.
-            string contrivedGitHubIssueTitle = "Issue 999:  Better handling for the `=` character";
-
-            // The docs recommend using randomly-generated EOF markers.
-            // Here's a randomly-generated base64 EOF marker that just happens to contain an '=' character.  ('=' is a padding character in base64.)
-            // see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-            string randomizedEOF = "khkIhPxsVA==";
-            var content = new List<string>
-            {
-                // In a real world scenario, "%INJECT%" might instead be something like "${{ github.event.issue.title }}"
-                $"PREFIX_%INJECT%<<{randomizedEOF}".Replace("%INJECT%", contrivedGitHubIssueTitle),
-                "RandomDataThatJustHappensToContainAnEquals=Character",
-                randomizedEOF,
-            };
-            TestUtil.WriteContent(envFile, content);
-            var ex = Assert.Throws<Exception>(() => _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null));
-            Assert.StartsWith("Invalid format", ex.Message);
+            base.TestHeredoc_EqualBeforeMultilineIndicator();
         }
 
         [Fact]
@@ -379,34 +152,15 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Heredoc_MissingNewLine()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "heredoc");
-                string content = "MY_OUTPUT<<EOF line one line two line three EOF";
-                TestUtil.WriteContent(envFile, content);
-                var ex = Assert.Throws<Exception>(() => _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null));
-                Assert.Contains("Matching delimiter not found", ex.Message);
-            }
+            base.TestHeredoc_MissingNewLine();
         }
 
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public void SetEnvFileCommand_Heredoc_MissingNewLineMultipleLinesEnv()
+        public void SetEnvFileCommand_Heredoc_MissingNewLineMultipleLines()
         {
-            using (var hostContext = Setup())
-            {
-                var envFile = Path.Combine(_rootDirectory, "heredoc");
-                string multilineFragment = @"line one
-                                             line two
-                                             line three";
-
-                // Note that the final EOF does not appear on it's own line.
-                string content = $"MY_OUTPUT<<EOF {multilineFragment} EOF";
-                TestUtil.WriteContent(envFile, content);
-                var ex = Assert.Throws<Exception>(() => _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null));
-                Assert.Contains("EOF marker missing new line", ex.Message);
-            }
+            base.TestHeredoc_MissingNewLineMultipleLines();
         }
 
 #if OS_WINDOWS
@@ -415,72 +169,9 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetEnvFileCommand_Heredoc_PreservesNewline()
         {
-            using (var hostContext = Setup())
-            {
-                var newline = "\n";
-                var envFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_ENV<<EOF",
-                    "hello",
-                    "world",
-                    "EOF",
-                };
-                TestUtil.WriteContent(envFile, content, LineEndingType.Linux);
-                _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _executionContext.Object.Global.EnvironmentVariables.Count);
-                Assert.Equal($"hello{newline}world", _executionContext.Object.Global.EnvironmentVariables["MY_ENV"]);
-            }
+            base.TestHeredoc_PreservesNewline();
         }
 #endif
 
-        private TestHostContext Setup([CallerMemberName] string name = "")
-        {
-            _issues = new List<Tuple<DTWebApi.Issue, string>>();
-
-            var hostContext = new TestHostContext(this, name);
-
-            // Trace
-            _trace = hostContext.GetTrace();
-
-            // Directory for test data
-            var workDirectory = hostContext.GetDirectory(WellKnownDirectory.Work);
-            ArgUtil.NotNullOrEmpty(workDirectory, nameof(workDirectory));
-            Directory.CreateDirectory(workDirectory);
-            _rootDirectory = Path.Combine(workDirectory, nameof(SetEnvFileCommandL0));
-            Directory.CreateDirectory(_rootDirectory);
-
-            // Execution context
-            _executionContext = new Mock<IExecutionContext>();
-            _executionContext.Setup(x => x.Global)
-                .Returns(new GlobalContext
-                {
-                    EnvironmentVariables = new Dictionary<string, string>(VarUtil.EnvironmentVariableKeyComparer),
-                    WriteDebug = true,
-                });
-            _executionContext.Setup(x => x.AddIssue(It.IsAny<DTWebApi.Issue>(), It.IsAny<ExecutionContextLogOptions>()))
-                .Callback((DTWebApi.Issue issue, ExecutionContextLogOptions logOptions) =>
-                {
-                    var resolvedMessage = issue.Message;
-                    if (logOptions.WriteToLog && !string.IsNullOrEmpty(logOptions.LogMessageOverride))
-                    {
-                        resolvedMessage = logOptions.LogMessageOverride;
-                    }
-                    _issues.Add(new(issue, resolvedMessage));
-                    _trace.Info($"Issue '{issue.Type}': {resolvedMessage}");
-                });
-            _executionContext.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>()))
-                .Callback((string tag, string message) =>
-                {
-                    _trace.Info($"{tag}{message}");
-                });
-
-            // SetEnvFileCommand
-            _setEnvFileCommand = new SetEnvFileCommand();
-            _setEnvFileCommand.Initialize(hostContext);
-
-            return hostContext;
-        }
     }
 }

--- a/src/Test/L0/Worker/SetEnvFileCommandL0.cs
+++ b/src/Test/L0/Worker/SetEnvFileCommandL0.cs
@@ -298,10 +298,12 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         // All of the following are not only valid, but quite plausible end markers.
         // Most are derived straight from the example at https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+#pragma warning disable format
         [InlineData("=EOF")][InlineData("==EOF")][InlineData("EO=F")][InlineData("EO==F")][InlineData("EOF=")][InlineData("EOF==")]
         [InlineData("<EOF")][InlineData("<<EOF")][InlineData("EO<F")][InlineData("EO<<F")][InlineData("EOF<")][InlineData("EOF<<")]
         [InlineData("+EOF")][InlineData("++EOF")][InlineData("EO+F")][InlineData("EO++F")][InlineData("EOF+")][InlineData("EOF++")]
         [InlineData("/EOF")][InlineData("//EOF")][InlineData("EO/F")][InlineData("EO//F")][InlineData("EOF/")][InlineData("EOF//")]
+#pragma warning restore format
         [InlineData("<<//++==")]
         [InlineData("contrivedBase64==")]
         [InlineData("khkIhPxsVA==")]

--- a/src/Test/L0/Worker/SetEnvFileCommandL0.cs
+++ b/src/Test/L0/Worker/SetEnvFileCommandL0.cs
@@ -429,7 +429,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "world",
                     "EOF",
                 };
-                TestUtil.WriteContent(stateFile, content, LineEndingType.Linux);
+                TestUtil.WriteContent(envFile, content, LineEndingType.Linux);
                 _setEnvFileCommand.ProcessCommand(_executionContext.Object, envFile, null);
                 Assert.Equal(0, _issues.Count);
                 Assert.Equal(1, _executionContext.Object.Global.EnvironmentVariables.Count);

--- a/src/Test/L0/Worker/SetEnvFileCommandL0.cs
+++ b/src/Test/L0/Worker/SetEnvFileCommandL0.cs
@@ -12,11 +12,8 @@ using DTWebApi = GitHub.DistributedTask.WebApi;
 
 namespace GitHub.Runner.Common.Tests.Worker
 {
-    public sealed class SetEnvFileCommandL0
+    public sealed class SetEnvFileCommandL0 : FileCommandTestBase
     {
-
-        private static readonly string BREAK = Environment.NewLine;
-
         private Mock<IExecutionContext> _executionContext;
         private List<Tuple<DTWebApi.Issue, string>> _issues;
         private string _rootDirectory;

--- a/src/Test/L0/Worker/SetOutputFileCommandL0.cs
+++ b/src/Test/L0/Worker/SetOutputFileCommandL0.cs
@@ -1,38 +1,36 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using GitHub.Runner.Common.Util;
-using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker;
 using Moq;
 using Xunit;
-using DTWebApi = GitHub.DistributedTask.WebApi;
 
 namespace GitHub.Runner.Common.Tests.Worker
 {
-    public sealed class SetOutputFileCommandL0 : FileCommandTestBase
+    public sealed class SetOutputFileCommandL0 : FileCommandTestBase<SetOutputFileCommand>
     {
-        private Mock<IExecutionContext> _executionContext;
-        private List<Tuple<DTWebApi.Issue, string>> _issues;
-        private Dictionary<string, string> _outputs;
-        private string _rootDirectory;
-        private SetOutputFileCommand _setOutputFileCommand;
-        private ITraceWriter _trace;
+
+        protected override IDictionary<string, string> PostSetup()
+        {
+            var outputs = new Dictionary<string, string>();
+            var reference = string.Empty;
+            _executionContext.Setup(x => x.SetOutput(It.IsAny<string>(), It.IsAny<string>(), out reference))
+              .Callback((string name, string value, out string reference) =>
+              {
+                  reference = value;
+                  outputs[name] = value;
+              });
+
+            return outputs;
+
+        }
 
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_DirectoryNotFound()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "directory-not-found", "env");
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(0, _outputs.Count);
-            }
+            base.TestDirectoryNotFound();
         }
 
         [Fact]
@@ -40,13 +38,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_NotFound()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "file-not-found");
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(0, _outputs.Count);
-            }
+            base.TestNotFound();
         }
 
         [Fact]
@@ -54,15 +46,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_EmptyFile()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "empty-file");
-                var content = new List<string>();
-                TestUtil.WriteContent(stateFile, content);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(0, _outputs.Count);
-            }
+            base.TestEmptyFile();
         }
 
         [Fact]
@@ -70,19 +54,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_Simple()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    "MY_OUTPUT=MY VALUE",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _outputs.Count);
-                Assert.Equal("MY VALUE", _outputs["MY_OUTPUT"]);
-            }
+            base.TestSimple();
         }
 
         [Fact]
@@ -90,24 +62,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_Simple_SkipEmptyLines()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    string.Empty,
-                    "MY_OUTPUT=my value",
-                    string.Empty,
-                    "MY_OUTPUT_2=my second value",
-                    string.Empty,
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(2, _outputs.Count);
-                Assert.Equal("my value", _outputs["MY_OUTPUT"]);
-                Assert.Equal("my second value", _outputs["MY_OUTPUT_2"]);
-            }
+            base.TestSimple_SkipEmptyLines();
         }
 
         [Fact]
@@ -115,19 +70,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_Simple_EmptyValue()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "simple-empty-value");
-                var content = new List<string>
-                {
-                    "MY_OUTPUT=",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _outputs.Count);
-                Assert.Equal(string.Empty, _outputs["MY_OUTPUT"]);
-            }
+            base.TestSimple_EmptyValue();
         }
 
         [Fact]
@@ -135,23 +78,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_Simple_MultipleValues()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    "MY_OUTPUT=my value",
-                    "MY_OUTPUT_2=",
-                    "MY_OUTPUT_3=my third value",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(3, _outputs.Count);
-                Assert.Equal("my value", _outputs["MY_OUTPUT"]);
-                Assert.Equal(string.Empty, _outputs["MY_OUTPUT_2"]);
-                Assert.Equal("my third value", _outputs["MY_OUTPUT_3"]);
-            }
+            base.TestSimple_MultipleValues();
         }
 
         [Fact]
@@ -159,23 +86,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_Simple_SpecialCharacters()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "simple");
-                var content = new List<string>
-                {
-                    "MY_OUTPUT==abc",
-                    "MY_OUTPUT_2=def=ghi",
-                    "MY_OUTPUT_3=jkl=",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(3, _outputs.Count);
-                Assert.Equal("=abc", _outputs["MY_OUTPUT"]);
-                Assert.Equal("def=ghi", _outputs["MY_OUTPUT_2"]);
-                Assert.Equal("jkl=", _outputs["MY_OUTPUT_3"]);
-            }
+            base.TestSimple_SpecialCharacters();
         }
 
         [Fact]
@@ -183,23 +94,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_Heredoc()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_OUTPUT<<EOF",
-                    "line one",
-                    "line two",
-                    "line three",
-                    "EOF",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _outputs.Count);
-                Assert.Equal($"line one{Environment.NewLine}line two{Environment.NewLine}line three", _outputs["MY_OUTPUT"]);
-            }
+            base.TestHeredoc();
         }
 
         [Fact]
@@ -207,20 +102,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_Heredoc_EmptyValue()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_OUTPUT<<EOF",
-                    "EOF",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _outputs.Count);
-                Assert.Equal(string.Empty, _outputs["MY_OUTPUT"]);
-            }
+            base.TestHeredoc_EmptyValue();
         }
 
         [Fact]
@@ -228,67 +110,15 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_Heredoc_SkipEmptyLines()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    string.Empty,
-                    "MY_OUTPUT<<EOF",
-                    "hello",
-                    "world",
-                    "EOF",
-                    string.Empty,
-                    "MY_OUTPUT_2<<EOF",
-                    "HELLO",
-                    "AGAIN",
-                    "EOF",
-                    string.Empty,
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(2, _outputs.Count);
-                Assert.Equal($"hello{Environment.NewLine}world", _outputs["MY_OUTPUT"]);
-                Assert.Equal($"HELLO{Environment.NewLine}AGAIN", _outputs["MY_OUTPUT_2"]);
-            }
+            base.TestHeredoc_SkipEmptyLines();
         }
 
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public void SaveOutputFileCommand_Heredoc_EdgeCases()
+        public void SetOutputFileCommand_Heredoc_EdgeCases()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_OUTPUT_1<<EOF",
-                    "hello",
-                    string.Empty,
-                    "three",
-                    string.Empty,
-                    "EOF",
-                    "MY_OUTPUT_2<<EOF",
-                    "hello=two",
-                    "EOF",
-                    "MY_OUTPUT_3<<EOF",
-                    " EOF",
-                    "EOF",
-                    "MY_OUTPUT_4<<EOF",
-                    "EOF EOF",
-                    "EOF",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(4, _outputs.Count);
-                Assert.Equal($"hello{BREAK}{BREAK}three{BREAK}", _outputs["MY_OUTPUT_1"]);
-                Assert.Equal($"hello=two", _outputs["MY_OUTPUT_2"]);
-                Assert.Equal($" EOF", _outputs["MY_OUTPUT_3"]);
-                Assert.Equal($"EOF EOF", _outputs["MY_OUTPUT_4"]);
-            }
+            base.TestHeredoc_EdgeCases();
         }
 
         [Theory]
@@ -315,64 +145,17 @@ namespace GitHub.Runner.Common.Tests.Worker
         [InlineData("jk/UMjIx/N0eVcQYOUfw")]
         [InlineData("/n5lsw73Cwl35Hfuscdz")]
         [InlineData("ZvnAEW+9O0tXp3Fmb3Oh")]
-        public void SaveOutputFileCommand_Heredoc_EndMarkerVariations(string validEndMarker)
+        public void SetOutputFileCommand_Heredoc_EndMarkerVariations(string validEndMarker)
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                string eof = validEndMarker;
-                var content = new List<string>
-                {
-                    $"MY_OUTPUT_1<<{eof}",
-                    $"hello",
-                    $"one",
-                    $"{eof}",
-                    $"MY_OUTPUT_2<<{eof}",
-                    $"hello=two",
-                    $"{eof}",
-                    $"MY_OUTPUT_3<<{eof}",
-                    $" {eof}",
-                    $"{eof}",
-                    $"MY_OUTPUT_4<<{eof}",
-                    $"{eof} {eof}",
-                    $"{eof}",
-                };
-                TestUtil.WriteContent(stateFile, content);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(4, _outputs.Count);
-                Assert.Equal($"hello{BREAK}one", _outputs["MY_OUTPUT_1"]);
-                Assert.Equal($"hello=two", _outputs["MY_OUTPUT_2"]);
-                Assert.Equal($" {eof}", _outputs["MY_OUTPUT_3"]);
-                Assert.Equal($"{eof} {eof}", _outputs["MY_OUTPUT_4"]);
-            }
+            base.TestHeredoc_EndMarkerVariations(validEndMarker);
         }
 
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public void SaveOutputFileCommand_Heredoc_EqualBeforeMultilineIndicator()
+        public void SetOutputFileCommand_Heredoc_EqualBeforeMultilineIndicator()
         {
-            using var hostContext = Setup();
-            var stateFile = Path.Combine(_rootDirectory, "heredoc");
-
-            // Define a hypothetical injectable payload that just happens to contain the '=' character.
-            string contrivedGitHubIssueTitle = "Issue 999:  Better handling for the `=` character";
-
-            // The docs recommend using randomly-generated EOF markers.
-            // Here's a randomly-generated base64 EOF marker that just happens to contain an '=' character.  ('=' is a padding character in base64.)
-            // see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-            string randomizedEOF = "khkIhPxsVA==";
-            var content = new List<string>
-            {
-                // In a real world scenario, "%INJECT%" might instead be something like "${{ github.event.issue.title }}"
-                $"PREFIX_%INJECT%<<{randomizedEOF}".Replace("%INJECT%", contrivedGitHubIssueTitle),
-                "RandomDataThatJustHappensToContainAnEquals=Character",
-                randomizedEOF,
-            };
-            TestUtil.WriteContent(stateFile, content);
-            var ex = Assert.Throws<Exception>(() => _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null));
-            Assert.StartsWith("Invalid format", ex.Message);
+            base.TestHeredoc_EqualBeforeMultilineIndicator();
         }
 
         [Fact]
@@ -380,14 +163,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_Heredoc_MissingNewLine()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                string content = "MY_OUTPUT<<EOF line one line two line three EOF";
-                TestUtil.WriteContent(stateFile, content);
-                var ex = Assert.Throws<Exception>(() => _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null));
-                Assert.Contains("Matching delimiter not found", ex.Message);
-            }
+            base.TestHeredoc_MissingNewLine();
         }
 
         [Fact]
@@ -395,19 +171,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_Heredoc_MissingNewLineMultipleLines()
         {
-            using (var hostContext = Setup())
-            {
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                string multilineFragment = @"line one
-                                             line two
-                                             line three";
-
-                // Note that the final EOF does not appear on it's own line.
-                string content = $"MY_OUTPUT<<EOF {multilineFragment} EOF";
-                TestUtil.WriteContent(stateFile, content);
-                var ex = Assert.Throws<Exception>(() => _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null));
-                Assert.Contains("EOF marker missing new line", ex.Message);
-            }
+            base.TestHeredoc_MissingNewLineMultipleLines();
         }
 
 #if OS_WINDOWS
@@ -416,81 +180,9 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void SetOutputFileCommand_Heredoc_PreservesNewline()
         {
-            using (var hostContext = Setup())
-            {
-                var newline = "\n";
-                var stateFile = Path.Combine(_rootDirectory, "heredoc");
-                var content = new List<string>
-                {
-                    "MY_OUTPUT<<EOF",
-                    "hello",
-                    "world",
-                    "EOF",
-                };
-                TestUtil.WriteContent(stateFile, content, LineEndingType.Linux);
-                _setOutputFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
-                Assert.Equal(0, _issues.Count);
-                Assert.Equal(1, _outputs.Count);
-                Assert.Equal($"hello{newline}world", _outputs["MY_OUTPUT"]);
-            }
+            base.TestHeredoc_PreservesNewline();
         }
 #endif
 
-        private TestHostContext Setup([CallerMemberName] string name = "")
-        {
-            _issues = new List<Tuple<DTWebApi.Issue, string>>();
-            _outputs = new Dictionary<string, string>();
-
-            var hostContext = new TestHostContext(this, name);
-
-            // Trace
-            _trace = hostContext.GetTrace();
-
-            // Directory for test data
-            var workDirectory = hostContext.GetDirectory(WellKnownDirectory.Work);
-            ArgUtil.NotNullOrEmpty(workDirectory, nameof(workDirectory));
-            Directory.CreateDirectory(workDirectory);
-            _rootDirectory = Path.Combine(workDirectory, nameof(SetOutputFileCommandL0));
-            Directory.CreateDirectory(_rootDirectory);
-
-            // Execution context
-            _executionContext = new Mock<IExecutionContext>();
-            _executionContext.Setup(x => x.Global)
-                .Returns(new GlobalContext
-                {
-                    EnvironmentVariables = new Dictionary<string, string>(VarUtil.EnvironmentVariableKeyComparer),
-                    WriteDebug = true,
-                });
-            _executionContext.Setup(x => x.AddIssue(It.IsAny<DTWebApi.Issue>(), It.IsAny<ExecutionContextLogOptions>()))
-                .Callback((DTWebApi.Issue issue, ExecutionContextLogOptions logOptions) =>
-                {
-                    var resolvedMessage = issue.Message;
-                    if (logOptions.WriteToLog && !string.IsNullOrEmpty(logOptions.LogMessageOverride))
-                    {
-                        resolvedMessage = logOptions.LogMessageOverride;
-                    }
-                    _issues.Add(new(issue, resolvedMessage));
-                    _trace.Info($"Issue '{issue.Type}': {resolvedMessage}");
-                });
-            _executionContext.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>()))
-                .Callback((string tag, string message) =>
-                {
-                    _trace.Info($"{tag}{message}");
-                });
-
-            var reference = string.Empty;
-            _executionContext.Setup(x => x.SetOutput(It.IsAny<string>(), It.IsAny<string>(), out reference))
-              .Callback((string name, string value, out string reference) =>
-              {
-                  reference = value;
-                  _outputs[name] = value;
-              });
-
-            // SetOutputFileCommand
-            _setOutputFileCommand = new SetOutputFileCommand();
-            _setOutputFileCommand.Initialize(hostContext);
-
-            return hostContext;
-        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/github/c2c-actions/issues/6910

GitHub Docs for context:  https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings