### PR TITLE
Publish multi-architecture container image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -63,3 +63,6 @@ jobs:
             org.opencontainers.image.source=${{github.server_url}}/${{github.repository}}
             org.opencontainers.image.description=https://github.com/actions/runner/releases/tag/v${{ steps.image.outputs.version }}
             org.opencontainers.image.licenses=MIT
+          platforms: |
+            linux/amd64
+            linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -709,3 +709,6 @@ jobs:
             org.opencontainers.image.source=${{github.server_url}}/${{github.repository}}
             org.opencontainers.image.description=https://github.com/actions/runner/releases/tag/v${{ steps.image.outputs.version }}
             org.opencontainers.image.licenses=MIT
+          platforms: |
+            linux/amd64
+            linux/arm64

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,14 +1,16 @@
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0 as build
 
+ARG TARGETARCH
 ARG RUNNER_VERSION
-ARG RUNNER_ARCH="x64"
 ARG RUNNER_CONTAINER_HOOKS_VERSION=0.3.2
 ARG DOCKER_VERSION=20.10.23
 
 RUN apt update -y && apt install curl unzip -y
 
 WORKDIR /actions-runner
-RUN curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz \
+RUN export RUNNER_ARCH="x64" \
+    && if [ "$TARGETARCH" = "arm64" ]; then export RUNNER_ARCH=arm64 ; fi \
+    && curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz \
     && tar xzf ./runner.tar.gz \
     && rm runner.tar.gz
 
@@ -17,7 +19,7 @@ RUN curl -f -L -o runner-container-hooks.zip https://github.com/actions/runner-c
     && rm runner-container-hooks.zip
 
 RUN export DOCKER_ARCH=x86_64 \
-    && if [ "$RUNNER_ARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
+    && if [ "$TARGETARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
     && curl -fLo docker.tgz https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
     && rm -rf docker.tgz


### PR DESCRIPTION
## Feature request
We uses the self-hosted runners on both x86 (amd64) and arm64.
It would be nice if the official image supports multi-architectures.
https://github.com/orgs/community/discussions/56720

## Changes
This will change Dockerfile and workflows to build a multi-architectures image.

I have tested this change as follows:
- Build an image
  - I ran the workflow in my fork as https://github.com/int128/actions-runner/actions/runs/5116816696
  - The image is available at [`ghcr.io/int128/actions-runner:2.304.0`](https://github.com/int128/actions-runner/pkgs/container/actions-runner/97118291?tag=2.304.0)
- Test the image
  - I tested the image with RunnerScaleSets and kind cluster: https://github.com/int128/actions-runner-controller-in-actions/pull/7
  - I tested the image with RunnerScaleSets in our Kubernetes cluster including arm64 nodes.

I think this change does not break the existing workflows.
Please let me know if you have any feedback.