### PR TITLE
Filter out empty arguments in container hooks

### DIFF
--- a/src/Runner.Worker/Container/ContainerHooks/HookInput.cs
+++ b/src/Runner.Worker/Container/ContainerHooks/HookInput.cs
@@ -83,7 +83,7 @@ namespace GitHub.Runner.Worker.Container.ContainerHooks
         public HookContainer(ContainerInfo container)
         {
             Image = container.ContainerImage;
-            EntryPointArgs = container.ContainerEntryPointArgs?.Split(' ').Select(arg => arg.Trim()) ?? new List<string>();
+            EntryPointArgs = container.ContainerEntryPointArgs?.Split(' ').Select(arg => arg.Trim()).Where(arg => !string.IsNullOrEmpty(arg)) ?? new List<string>();
             EntryPoint = container.ContainerEntryPoint;
             WorkingDirectory = container.ContainerWorkDirectory;
             CreateOptions = container.ContainerCreateOptions;


### PR DESCRIPTION
When parsing container arguments, we did not check for the empty string. That led to the args array having the first element as an empty string, causing the container hook's container step to fail if we remove entrypoint script as a way to invoke it.

This change does not affect the docker action, since it is created as a command. But if we use containerArgs as an array building container step's Job resource, the command can't be executed. It will be transformed into:
```yaml
args:
- ""
- "arg1"
- "arg2"
- ...
```
For more context, please see [this](https://github.com/actions/runner-container-hooks/issues/76#issuecomment-1568591171) comment. :relaxed: 