### PR TITLE
Dont log error twice in ExecutionContext on template error

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1401,7 +1401,7 @@ namespace GitHub.Runner.Worker
 
         public void Error(string format, params Object[] args)
         {
-            _executionContext.Error(string.Format(CultureInfo.CurrentCulture, format, args));
+            _executionContext.Debug(string.Format(CultureInfo.CurrentCulture, format, args));
         }
 
         public void Info(string format, params Object[] args)


### PR DESCRIPTION
In case of embedded actions if the referenced workflow contains errors, they are added to the ExecutionContext twice*:
- once in ActionManifestManager [link](https://github.com/actions/runner/blob/21b49c542cdb8caf3c6217db6286fdefecb5f025/src/Runner.Worker/ActionManifestManager.cs#L144)
- and second time by the TemplateTraceWriter

After merging this PR TemplateTraceWriter won't write errors to the EC but simple debug messages.

Closes https://github.com/github/c2c-actions-runtime/issues/2381
Co-authored by @fhammerl 

**Before**
![Screenshot 2023-05-31 at 16 01 33](https://github.com/actions/runner/assets/67866556/a0733cc3-609f-4fdc-89d5-8d01734ac207)
**After**
![Screenshot 2023-05-31 at 16 01 05](https://github.com/actions/runner/assets/67866556/d30d22f5-dd6c-4c57-be73-8636f4134ab5)

* `ExecutionContext` uses `TimelineRecord.Issue` to store all workflow issues and they're later displayed in GH UI.  