### PR TITLE
Log template errors as debug message

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -155,7 +155,7 @@ namespace GitHub.Runner.Common
             {
                 public static readonly string DiskSpaceWarning = "runner.diskspace.warning";
                 public static readonly string Node12Warning = "DistributedTask.AddWarningToNode12Action";
-                public static readonly string LogTemplateErrorsAsDebugMessages = "DistributedTask.LogTemplateErrorAsDebugMessages";
+                public static readonly string LogTemplateErrorsAsDebugMessages = "DistributedTask.LogTemplateErrorsAsDebugMessages";
                 public static readonly string UseContainerPathForTemplate = "DistributedTask.UseContainerPathForTemplate";
                 public static readonly string AllowRunnerContainerHooks = "DistributedTask.AllowRunnerContainerHooks";
             }

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -155,7 +155,7 @@ namespace GitHub.Runner.Common
             {
                 public static readonly string DiskSpaceWarning = "runner.diskspace.warning";
                 public static readonly string Node12Warning = "DistributedTask.AddWarningToNode12Action";
-                public static readonly string LogTemplateErrorsAsDebugMessages = "DistributedTask.LogTemplateErrorAsDebugMessage";
+                public static readonly string LogTemplateErrorsAsDebugMessages = "DistributedTask.LogTemplateErrorAsDebugMessages";
                 public static readonly string UseContainerPathForTemplate = "DistributedTask.UseContainerPathForTemplate";
                 public static readonly string AllowRunnerContainerHooks = "DistributedTask.AllowRunnerContainerHooks";
             }

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -155,6 +155,7 @@ namespace GitHub.Runner.Common
             {
                 public static readonly string DiskSpaceWarning = "runner.diskspace.warning";
                 public static readonly string Node12Warning = "DistributedTask.AddWarningToNode12Action";
+                public static readonly string LogTemplateErrorsAsDebugMessage = "DistributedTask.LogTemplateErrorsAsDebugMessage";
                 public static readonly string UseContainerPathForTemplate = "DistributedTask.UseContainerPathForTemplate";
                 public static readonly string AllowRunnerContainerHooks = "DistributedTask.AllowRunnerContainerHooks";
             }

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -155,7 +155,7 @@ namespace GitHub.Runner.Common
             {
                 public static readonly string DiskSpaceWarning = "runner.diskspace.warning";
                 public static readonly string Node12Warning = "DistributedTask.AddWarningToNode12Action";
-                public static readonly string LogTemplateErrorsAsDebugMessage = "DistributedTask.LogTemplateErrorsAsDebugMessage";
+                public static readonly string LogTemplateErrorsAsDebugMessages = "DistributedTask.LogTemplateErrorAsDebugMessage";
                 public static readonly string UseContainerPathForTemplate = "DistributedTask.UseContainerPathForTemplate";
                 public static readonly string AllowRunnerContainerHooks = "DistributedTask.AllowRunnerContainerHooks";
             }

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -155,7 +155,7 @@ namespace GitHub.Runner.Common
             {
                 public static readonly string DiskSpaceWarning = "runner.diskspace.warning";
                 public static readonly string Node12Warning = "DistributedTask.AddWarningToNode12Action";
-                public static readonly string LogTemplateErrorsAsDebugMessages = "DistributedTask.LogTemplateErrorsAsDebugMessages";
+                public static readonly string LogTemplateErrorsToTraceWriter = "DistributedTask.LogTemplateErrorsToTraceWriter";
                 public static readonly string UseContainerPathForTemplate = "DistributedTask.UseContainerPathForTemplate";
                 public static readonly string AllowRunnerContainerHooks = "DistributedTask.AllowRunnerContainerHooks";
             }

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1402,14 +1402,13 @@ namespace GitHub.Runner.Worker
 
         public void Error(string format, params Object[] args)
         {
-            _executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.Features.LogTemplateErrorsAsDebugMessage, out var logErrorsAsDebug);
-            if (StringUtil.ConvertToBoolean(logErrorsAsDebug, defaultValue: false))
+
+            if (logTemplateErrorsAsDebugMessage())
             {
                 _executionContext.Debug(string.Format(CultureInfo.CurrentCulture, format, args));
             }
             else _executionContext.Error(string.Format(CultureInfo.CurrentCulture, format, args));
         }
-
 
         public void Info(string format, params Object[] args)
         {
@@ -1421,6 +1420,13 @@ namespace GitHub.Runner.Worker
             // todo: switch to verbose?
             _executionContext.Debug(string.Format(CultureInfo.CurrentCulture, $"{format}", args));
         }
+
+        private bool logTemplateErrorsAsDebugMessage()
+        {
+            _executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.Features.LogTemplateErrorsAsDebugMessage, out var logErrorsAsDebug);
+            return StringUtil.ConvertToBoolean(logErrorsAsDebug, defaultValue: false);
+        }
+
     }
 
     public static class WellKnownTags
@@ -1432,4 +1438,5 @@ namespace GitHub.Runner.Worker
         public static readonly string Notice = "##[notice]";
         public static readonly string Debug = "##[debug]";
     }
+
 }

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1423,7 +1423,7 @@ namespace GitHub.Runner.Worker
 
         private bool logTemplateErrorsAsDebugMessage()
         {
-            _executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.Features.LogTemplateErrorsAsDebugMessage, out var logErrorsAsDebug);
+            _executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.Features.LogTemplateErrorsAsDebugMessages, out var logErrorsAsDebug);
             return StringUtil.ConvertToBoolean(logErrorsAsDebug, defaultValue: false);
         }
 

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -21,6 +21,7 @@ using Newtonsoft.Json;
 using Sdk.RSWebApi.Contracts;
 using ObjectTemplating = GitHub.DistributedTask.ObjectTemplating;
 using Pipelines = GitHub.DistributedTask.Pipelines;
+using constants = GitHub.Runner.Common.Constants;
 
 namespace GitHub.Runner.Worker
 {
@@ -1401,8 +1402,14 @@ namespace GitHub.Runner.Worker
 
         public void Error(string format, params Object[] args)
         {
-            _executionContext.Error(string.Format(CultureInfo.CurrentCulture, format, args));
+            _executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.Features.LogTemplateErrorsAsDebugMessage, out var logErrorsAsDebug);
+            if (StringUtil.ConvertToBoolean(logErrorsAsDebug, defaultValue: false))
+            {
+                _executionContext.Debug(string.Format(CultureInfo.CurrentCulture, format, args));
+            }
+            else _executionContext.Error(string.Format(CultureInfo.CurrentCulture, format, args));
         }
+
 
         public void Info(string format, params Object[] args)
         {

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1403,7 +1403,7 @@ namespace GitHub.Runner.Worker
         public void Error(string format, params Object[] args)
         {
 
-            if (logTemplateErrorsAsDebugMessage())
+            if (logTemplateErrorsAsDebugMessages())
             {
                 _executionContext.Debug(string.Format(CultureInfo.CurrentCulture, format, args));
             }
@@ -1421,7 +1421,7 @@ namespace GitHub.Runner.Worker
             _executionContext.Debug(string.Format(CultureInfo.CurrentCulture, $"{format}", args));
         }
 
-        private bool logTemplateErrorsAsDebugMessage()
+        private bool logTemplateErrorsAsDebugMessages()
         {
             _executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.Features.LogTemplateErrorsAsDebugMessages, out var logErrorsAsDebug);
             return StringUtil.ConvertToBoolean(logErrorsAsDebug, defaultValue: false);

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1402,12 +1402,7 @@ namespace GitHub.Runner.Worker
 
         public void Error(string format, params Object[] args)
         {
-
-            if (logTemplateErrorsAsDebugMessages())
-            {
-                _executionContext.Debug(string.Format(CultureInfo.CurrentCulture, format, args));
-            }
-            else _executionContext.Error(string.Format(CultureInfo.CurrentCulture, format, args));
+            _executionContext.Error(string.Format(CultureInfo.CurrentCulture, format, args));
         }
 
         public void Info(string format, params Object[] args)
@@ -1420,13 +1415,6 @@ namespace GitHub.Runner.Worker
             // todo: switch to verbose?
             _executionContext.Debug(string.Format(CultureInfo.CurrentCulture, $"{format}", args));
         }
-
-        private bool logTemplateErrorsAsDebugMessages()
-        {
-            _executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.Features.LogTemplateErrorsAsDebugMessages, out var logErrorsAsDebug);
-            return StringUtil.ConvertToBoolean(logErrorsAsDebug, defaultValue: false);
-        }
-
     }
 
     public static class WellKnownTags

--- a/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateContext.cs
+++ b/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateContext.cs
@@ -34,6 +34,11 @@ namespace GitHub.DistributedTask.ObjectTemplating
                 m_errors = value;
             }
         }
+        /// <summary>
+        /// Because TraceWriter has access to the ExecutionContext and is logging template errors, duplicated issues are reported.
+        /// By setting LogErrorsToTraceWriter = false TemplateContext will add errors only to TemplateValidationErrors 
+        /// </summary>
+        internal bool LogErrorsToTraceWriter = true;
 
         /// <summary>
         /// Available functions within expression contexts
@@ -135,7 +140,11 @@ namespace GitHub.DistributedTask.ObjectTemplating
         {
             var prefix = GetErrorPrefix(fileId, line, column);
             Errors.Add(prefix, ex);
-            TraceWriter.Error(prefix, ex);
+
+            if (LogErrorsToTraceWriter)
+            {
+                TraceWriter.Error(prefix, ex);
+            }
         }
 
         internal void Error(
@@ -155,7 +164,10 @@ namespace GitHub.DistributedTask.ObjectTemplating
             var fullMessage = !String.IsNullOrEmpty(prefix) ? $"{prefix} {message}" : message;
 
             Errors.Add(fullMessage);
-            TraceWriter.Error(fullMessage);
+            if (LogErrorsToTraceWriter)
+            {
+                TraceWriter.Error(fullMessage);
+            }
         }
 
         internal INamedValueInfo[] GetExpressionNamedValues()

--- a/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateContext.cs
+++ b/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -120,15 +120,9 @@ namespace GitHub.DistributedTask.ObjectTemplating
             }
         }
 
-        internal void Error(TemplateValidationError error)
-        {
-            Errors.Add(error);
-            TraceWriter.Error(error.Message);
-        }
-
         internal void Error(
-            TemplateToken value,
-            Exception ex)
+           TemplateToken value,
+           Exception ex)
         {
             Error(value?.FileId, value?.Line, value?.Column, ex);
         }

--- a/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateContext.cs
+++ b/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateContext.cs
@@ -152,13 +152,10 @@ namespace GitHub.DistributedTask.ObjectTemplating
             String message)
         {
             var prefix = GetErrorPrefix(fileId, line, column);
-            if (!String.IsNullOrEmpty(prefix))
-            {
-                message = $"{prefix} {message}";
-            }
+            var fullMessage = !String.IsNullOrEmpty(prefix) ? $"{prefix} {message}" : message;
 
-            Errors.Add(message);
-            TraceWriter.Error(message);
+            Errors.Add(fullMessage);
+            TraceWriter.Error(fullMessage);
         }
 
         internal INamedValueInfo[] GetExpressionNamedValues()

--- a/src/Test/L0/Sdk/DTObjectTemplating/TemplateContextL0.cs
+++ b/src/Test/L0/Sdk/DTObjectTemplating/TemplateContextL0.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using GitHub.DistributedTask.ObjectTemplating.Tokens;
+using Xunit;
+
+namespace GitHub.DistributedTask.ObjectTemplating.Tests
+{
+    public sealed class TemplateContextL0
+    {
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void VerifyError()
+        {
+            TemplateContext context = buildContext();
+            TemplateToken value = new StringToken(1, 1, 1, "some-token");
+            System.Exception ex = new System.Exception();
+
+            List<TemplateValidationError> expectedErrors = new();
+            expectedErrors.Add(new TemplateValidationError("(Line: 1, Col: 1): Exception of type 'System.Exception' was thrown."));
+
+            context.Error(value, ex);
+
+ 
+            Assert.True(expectedErrors.SequenceEqual(toList(context.Errors.GetEnumerator())));
+
+
+            Assert.True(true);
+        }
+
+        private TemplateContext buildContext()
+        {
+            return new TemplateContext
+            {
+                // CancellationToken = CancellationToken.None,
+                Errors = new TemplateValidationErrors(10, int.MaxValue), // Don't truncate error messages otherwise we might not scrub secrets correctly
+                Memory = new TemplateMemory(
+                maxDepth: 100,
+                maxEvents: 1000000,
+                maxBytes: 10 * 1024 * 1024),
+                Schema = null,
+                TraceWriter = new EmptyTraceWriter(),
+            };
+        }
+
+        private List<TemplateValidationError> toList(IEnumerator<TemplateValidationError> enumerator)
+        {
+            List<TemplateValidationError> result = new();
+            while (enumerator.MoveNext())
+            {
+                TemplateValidationError err = enumerator.Current;
+                result.Add(err);
+            }
+            return result;
+        }
+    }
+}

--- a/src/Test/L0/Sdk/DTObjectTemplating/TemplateContextL0.cs
+++ b/src/Test/L0/Sdk/DTObjectTemplating/TemplateContextL0.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using GitHub.DistributedTask.ObjectTemplating.Tokens;
 using Xunit;
 
@@ -10,22 +11,198 @@ namespace GitHub.DistributedTask.ObjectTemplating.Tests
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public void VerifyError()
+        public void VerifyErrorWithTokenAndException()
         {
             TemplateContext context = buildContext();
-            TemplateToken value = new StringToken(1, 1, 1, "some-token");
-            System.Exception ex = new System.Exception();
 
-            List<TemplateValidationError> expectedErrors = new();
-            expectedErrors.Add(new TemplateValidationError("(Line: 1, Col: 1): Exception of type 'System.Exception' was thrown."));
+            List<TemplateValidationError> expectedErrors = new List<TemplateValidationError> { new TemplateValidationError("(Line: 1, Col: 1): Exception of type 'System.Exception' was thrown.") };
 
-            context.Error(value, ex);
+            context.Error(new StringToken(1, 1, 1, "some-token"), new System.Exception());
 
- 
-            Assert.True(expectedErrors.SequenceEqual(toList(context.Errors.GetEnumerator())));
+            List<TemplateValidationError> templateValidationErrors = toList(context.Errors.GetEnumerator());
 
+            Assert.Single(templateValidationErrors);
+            Assert.True(areEqual(expectedErrors, templateValidationErrors));
+        }
 
-            Assert.True(true);
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void VerifyErrorWithNullTokenAndException()
+        {
+            TemplateContext context = buildContext();
+
+            List<TemplateValidationError> expectedErrors = new List<TemplateValidationError> { new TemplateValidationError("System.Exception: Exception of type 'System.Exception' was thrown.") };
+
+            context.Error(null, new System.Exception());
+
+            List<TemplateValidationError> templateValidationErrors = toList(context.Errors.GetEnumerator());
+
+            Assert.Single(templateValidationErrors);
+            Assert.True(areEqual(expectedErrors, templateValidationErrors));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void VerifyErrorWithTokenAndMessage()
+        {
+            TemplateContext context = buildContext();
+
+            List<TemplateValidationError> expectedErrors = new List<TemplateValidationError> { new TemplateValidationError("(Line: 1, Col: 1): message") };
+
+            context.Error(new StringToken(1, 1, 1, "some-token"), "message");
+
+            List<TemplateValidationError> templateValidationErrors = toList(context.Errors.GetEnumerator());
+
+            Assert.Single(templateValidationErrors);
+            Assert.True(areEqual(expectedErrors, templateValidationErrors));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void VerifyErrorWithNullTokenAndMessage()
+        {
+            TemplateContext context = buildContext();
+
+            List<TemplateValidationError> expectedErrors = new List<TemplateValidationError> { new TemplateValidationError("message") };
+
+            context.Error(null, "message");
+
+            List<TemplateValidationError> templateValidationErrors = toList(context.Errors.GetEnumerator());
+
+            Assert.Single(templateValidationErrors);
+            Assert.True(areEqual(expectedErrors, templateValidationErrors));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void VerifyErrorWithException()
+        {
+            TemplateContext context = buildContext();
+
+            List<TemplateValidationError> expectedErrors = new List<TemplateValidationError> { new TemplateValidationError("(Line: 2, Col: 3): Fatal template exception") };
+            List<string> expectedTracewriterErrors = new List<string> { "(Line: 2, Col: 3):" };
+
+            context.Error(1, 2, 3, new Exception("Fatal template exception"));
+
+            List<TemplateValidationError> templateValidationErrors = toList(context.Errors.GetEnumerator());
+            ListTraceWriter listTraceWriter = (ListTraceWriter)context.TraceWriter;
+            List<string> tracewriterErrors = listTraceWriter.GetErrors();
+
+            Assert.Single(templateValidationErrors);
+            Assert.True(areEqual(expectedErrors, templateValidationErrors));
+            Assert.True(expectedTracewriterErrors.SequenceEqual(tracewriterErrors));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void VerifyErrorWithExceptionAndInnerException()
+        {
+            TemplateContext context = buildContext();
+
+            List<TemplateValidationError> expectedErrors = new List<TemplateValidationError> { new TemplateValidationError("(Line: 2, Col: 3): Fatal template exception"),
+            new TemplateValidationError("(Line: 2, Col: 3): Inner Exception") };
+            List<string> expectedTracewriterErrors = new List<string> { "(Line: 2, Col: 3):" };
+
+            Exception e = new Exception("Fatal template exception", new Exception("Inner Exception"));
+
+            context.Error(1, 2, 3, e);
+
+            List<TemplateValidationError> templateValidationErrors = toList(context.Errors.GetEnumerator());
+            ListTraceWriter listTraceWriter = (ListTraceWriter)context.TraceWriter;
+            List<string> tracewriterErrors = listTraceWriter.GetErrors();
+
+            Assert.Equal(2, templateValidationErrors.Count);
+            Assert.True(areEqual(expectedErrors, templateValidationErrors));
+            Assert.True(expectedTracewriterErrors.SequenceEqual(tracewriterErrors));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void VerifyErrorWithLineNumbersAndMessage()
+        {
+            TemplateContext context = buildContext();
+
+            List<TemplateValidationError> expectedErrors = new List<TemplateValidationError> { new TemplateValidationError("(Line: 2, Col: 3): Fatal template exception") };
+            List<string> expectedTracewriterErrors = new List<string> { "(Line: 2, Col: 3): Fatal template exception" };
+
+            context.Error(1, 2, 3, "Fatal template exception");
+
+            List<TemplateValidationError> templateValidationErrors = toList(context.Errors.GetEnumerator());
+            ListTraceWriter listTraceWriter = (ListTraceWriter)context.TraceWriter;
+            List<string> tracewriterErrors = listTraceWriter.GetErrors();
+
+            Assert.Single(templateValidationErrors);
+            Assert.True(areEqual(expectedErrors, templateValidationErrors));
+            Assert.True(expectedTracewriterErrors.SequenceEqual(tracewriterErrors));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void VerifyErrorWithNullLineNumbersAndMessage()
+        {
+            TemplateContext context = buildContext();
+
+            List<TemplateValidationError> expectedErrors = new List<TemplateValidationError> { new TemplateValidationError("Fatal template exception") };
+            List<string> expectedTracewriterErrors = new List<string> { "Fatal template exception" };
+
+            context.Error(null, null, null, "Fatal template exception");
+
+            List<TemplateValidationError> templateValidationErrors = toList(context.Errors.GetEnumerator());
+            ListTraceWriter listTraceWriter = (ListTraceWriter)context.TraceWriter;
+            List<string> tracewriterErrors = listTraceWriter.GetErrors();
+
+            Assert.Single(templateValidationErrors);
+            Assert.True(areEqual(expectedErrors, templateValidationErrors));
+            Assert.True(expectedTracewriterErrors.SequenceEqual(tracewriterErrors));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void VerifyErrorWithLineNumbersAndException()
+        {
+            TemplateContext context = buildContext();
+
+            List<TemplateValidationError> expectedErrors = new List<TemplateValidationError> { new TemplateValidationError("(Line: 2, Col: 3): Fatal template exception") };
+            List<string> expectedTracewriterErrors = new List<string> { "(Line: 2, Col: 3):" };
+
+            context.Error(1, 2, 3, new Exception("Fatal template exception"));
+
+            List<TemplateValidationError> templateValidationErrors = toList(context.Errors.GetEnumerator());
+            ListTraceWriter listTraceWriter = (ListTraceWriter)context.TraceWriter;
+            List<string> tracewriterErrors = listTraceWriter.GetErrors();
+
+            Assert.Single(templateValidationErrors);
+            Assert.True(areEqual(expectedErrors, templateValidationErrors));
+            Assert.True(expectedTracewriterErrors.SequenceEqual(tracewriterErrors));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void VerifyErrorWithNullLineNumbersAndException()
+        {
+            TemplateContext context = buildContext();
+
+            List<TemplateValidationError> expectedErrors = new List<TemplateValidationError> { new TemplateValidationError("System.Exception: Fatal template exception") };
+            List<string> expectedTracewriterErrors = new List<string> { "" };
+
+            context.Error(null, null, null, new Exception("Fatal template exception"));
+
+            List<TemplateValidationError> templateValidationErrors = toList(context.Errors.GetEnumerator());
+            ListTraceWriter listTraceWriter = (ListTraceWriter)context.TraceWriter;
+            List<string> tracewriterErrors = listTraceWriter.GetErrors();
+
+            Assert.Single(templateValidationErrors);
+            Assert.True(areEqual(expectedErrors, templateValidationErrors));
+            Assert.True(expectedTracewriterErrors.SequenceEqual(tracewriterErrors));
         }
 
         private TemplateContext buildContext()
@@ -39,7 +216,7 @@ namespace GitHub.DistributedTask.ObjectTemplating.Tests
                 maxEvents: 1000000,
                 maxBytes: 10 * 1024 * 1024),
                 Schema = null,
-                TraceWriter = new EmptyTraceWriter(),
+                TraceWriter = new ListTraceWriter(),
             };
         }
 
@@ -52,6 +229,47 @@ namespace GitHub.DistributedTask.ObjectTemplating.Tests
                 result.Add(err);
             }
             return result;
+        }
+
+        private bool areEqual(List<TemplateValidationError> l1, List<TemplateValidationError> l2)
+        {
+            if (l1.Count != l2.Count) return false;
+
+            var twoLists = l1.Zip(l2, (l1Error, l2Error) => new { Elem1 = l1Error, Elem2 = l2Error });
+
+            foreach (var elem in twoLists)
+            {
+                if (elem.Elem1.Message != elem.Elem2.Message) return false;
+                if (elem.Elem1.Code != elem.Elem2.Code) return false;
+            }
+            return true;
+        }
+
+        internal sealed class ListTraceWriter : ITraceWriter
+        {
+
+            private List<string> errors = new();
+            private List<string> infoMessages = new();
+            private List<string> verboseMessages = new();
+            public void Error(string format, params object[] args)
+            {
+                errors.Add(string.Format(System.Globalization.CultureInfo.CurrentCulture, $"{format}", args));
+            }
+
+            public void Info(string format, params object[] args)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Verbose(string format, params object[] args)
+            {
+                throw new NotImplementedException();
+            }
+
+            public List<string> GetErrors()
+            {
+                return errors;
+            }
         }
     }
 }


### PR DESCRIPTION
**Background**
When parsing a workflow template there are two objects at play: `ExecutionContext` and `TemplateContext`. `ExecutionContext` stores all errors (named issues) that are later sent as job results. `TemplateContext` on the other side is an object used, as the name suggests, during the template parsing. It also stores template errors together with field ids and names, to provide a meaningful message, which workflow line was invalid. 

The duplication comes from the fact that during the template reading:
1. first we’re loading the template using [TemplateReader.Read](https://github.com/actions/runner/blob/efffbaeabc6d53c4c1ec05b11cea58331ff38e3c/src/Runner.Worker/ActionManifestManager.cs#L87) and here template errors are being written to the `TemplateContext` for the first time
1. after we’re done with loading all tokens we go through all TemplateContext errors and add them to the ExecutionContext errors list [here](https://github.com/actions/runner/blob/efffbaeabc6d53c4c1ec05b11cea58331ff38e3c/src/Runner.Worker/ActionManifestManager.cs#L144) (screenshot with more logs is at the bottom in expandable section) 
	
All that would be fine if not the small fact, that in step **1** `TemplateContext` already added errors to the ExecutionContext: internally it is using `TraceWriter.Error` method that is…writing errors to the `ExecutionContext`:
```
internal void Error(TemplateValidationError error)
{
            Errors.Add(error); <——— add error to Template errors (we iterate over them in step 2) 
            TraceWriter.Error(error.Message); <—— TraceWriter writes errors to ExecutionContext directly causing duplication 
}
```
[link](https://github.com/actions/runner/blob/efffbaeabc6d53c4c1ec05b11cea58331ff38e3c/src/Runner.Worker/ExecutionContext.cs#LL1404C13-L1404C30)

We could deduplicate issues in ExecutionContext based on error position and message, but that would not fix the underlying issue of logging two times the same error or fix the real issue, that is writing the same errors in multiple places.
Since the workflow parser code is used in other classes and there's a risk of regression, I have added a feature flag `DistributedTask.LogTemplateErrorsToTraceWriter` that will be passed from actions service. This way only one method in `TemplateReader` will stop duplicating errors. With time we can expand this logic and disable TraceWriter error logging in other places.
Long term solution would be code a refactoring, since `TemplateContext` has access to the `TraceWriter`, it can manipulate the state of `ExecutionContext`. These two should either be separated or merged into one object.

Closes https://github.com/github/c2c-actions-runtime/issues/2381
Follow-up: https://github.com/github/actions-dotnet/pull/15290

**Before**
![Screenshot 2023-05-31 at 16 01 33](https://github.com/actions/runner/assets/67866556/a0733cc3-609f-4fdc-89d5-8d01734ac207)
**After**
![Screenshot 2023-05-31 at 16 01 05](https://github.com/actions/runner/assets/67866556/d30d22f5-dd6c-4c57-be73-8636f4134ab5)

<details>
<summary>Workflow run with more debug logs</summary>

[Branch](https://github.com/actions/runner/tree/DuplicatedErrorWithLogging)
  
![Screenshot 2023-06-13 at 09 03 12](https://github.com/actions/runner/assets/67866556/0a317749-b131-4431-982f-e485f5a724a0)

</details>