### PR TITLE
chore(Dockerfile): update Dockerfile to support multiple architectures

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,15 +1,18 @@
 # Source: https://github.com/dotnet/dotnet-docker
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy as build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy as build
 
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 ARG RUNNER_VERSION
-ARG RUNNER_ARCH="x64"
+ARG RUNNER_ARCH=
 ARG RUNNER_CONTAINER_HOOKS_VERSION=0.3.2
 ARG DOCKER_VERSION=20.10.23
 
 RUN apt update -y && apt install curl unzip -y
 
 WORKDIR /actions-runner
-RUN curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz \
+RUN RUNNER_ARCH=${RUNNER_ARCH:-$(case "$TARGETPLATFORM" in "linux/arm64") echo "arm64" ;; *) echo "x64" ;; esac)} \
+    && curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz \
     && tar xzf ./runner.tar.gz \
     && rm runner.tar.gz
 
@@ -17,13 +20,14 @@ RUN curl -f -L -o runner-container-hooks.zip https://github.com/actions/runner-c
     && unzip ./runner-container-hooks.zip -d ./k8s \
     && rm runner-container-hooks.zip
 
-RUN export DOCKER_ARCH=x86_64 \
+RUN RUNNER_ARCH=${RUNNER_ARCH:-$(case "$TARGETPLATFORM" in "linux/arm64") echo "arm64" ;; *) echo "x64" ;; esac)} \
+    && export DOCKER_ARCH=x86_64 \
     && if [ "$RUNNER_ARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
     && curl -fLo docker.tgz https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
     && rm -rf docker.tgz
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV RUNNER_MANUALLY_TRAP_SIG=1


### PR DESCRIPTION
Usage

```sh
docker buildx build --build-arg RUNNER_VERSION=2.304.0 --platform linux/amd64,linux/arm64 --output=type=image,push=true . -t quay.io/actions/actions-runner:latest
```

Build and push I would like to provide a multiple architecture supported image using buildx in Docker image.

The image I built is below.
If you want to try it out, please do so!

```
quay.io/kahirokunn/actions-runner-multi-arch-base:latest
```