### PR TITLE
Switch from Debian to Ubuntu 22.04

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0 as build
+# Source: https://github.com/dotnet/dotnet-docker
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy as build
 
 ARG RUNNER_VERSION
 ARG RUNNER_ARCH="x64"
@@ -22,7 +23,7 @@ RUN export DOCKER_ARCH=x86_64 \
     && tar zxvf docker.tgz \
     && rm -rf docker.tgz
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV RUNNER_MANUALLY_TRAP_SIG=1
@@ -31,6 +32,7 @@ ENV ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
     sudo \
+    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 RUN adduser --disabled-password --gecos "" --uid 1001 runner \


### PR DESCRIPTION
### Context

Fixes https://github.com/github/c2c-actions-runtime/issues/2460

This PR changes the base image to Ubuntu 22.04 instead of Debian. Numerous actions such as: [actions/setup-python](https://github.com/actions/setup-python) and [ruby/setup-ruby](https://github.com/ruby/setup-ruby) are only compatible with Ubuntu. 

This change also introduces `lsb_release` which is used by [actions/setup-python](https://github.com/actions/setup-python/blob/bd6b4b6205c4dbad673328db7b31b7fab9e241c0/src/utils.ts#L155) to identify the underlying distribution. The introduction of this dependency was unavoidable, `actions/setup-python` depends on this script to identify the distribution version that maps to the appropriate python binary. There is room for improvement but for now we want to move forward and unblock end users depending on this first party action.

#### Testing

This change was tested with actions/setup-python and ruby/setup-ruby. Any additional changes (missing permissions, directories, etc.) to the runner image will need to be made by the end users. (example: https://github.com/ruby/setup-ruby#using-self-hosted-runners)