### PR TITLE
Add 'http://' to http(s)_proxy if there is no protocol

### DIFF
--- a/src/Runner.Sdk/RunnerWebProxy.cs
+++ b/src/Runner.Sdk/RunnerWebProxy.cs
@@ -69,6 +69,10 @@ namespace GitHub.Runner.Sdk
                 return;
             }
 
+            if (!string.IsNullOrEmpty(httpProxyAddress) && !Uri.TryCreate(httpProxyAddress, UriKind.Absolute, out var _))
+            {
+                httpProxyAddress = PrependHttpIfNoProtocol(httpProxyAddress);
+            }
             if (!string.IsNullOrEmpty(httpProxyAddress) && Uri.TryCreate(httpProxyAddress, UriKind.Absolute, out var proxyHttpUri))
             {
                 _httpProxyAddress = proxyHttpUri.OriginalString;
@@ -99,6 +103,10 @@ namespace GitHub.Runner.Sdk
                 }
             }
 
+            if (!string.IsNullOrEmpty(httpsProxyAddress) && !Uri.TryCreate(httpsProxyAddress, UriKind.Absolute, out var _))
+            {
+                httpsProxyAddress = PrependHttpIfNoProtocol(httpsProxyAddress);
+            }
             if (!string.IsNullOrEmpty(httpsProxyAddress) && Uri.TryCreate(httpsProxyAddress, UriKind.Absolute, out var proxyHttpsUri))
             {
                 _httpsProxyAddress = proxyHttpsUri.OriginalString;
@@ -239,6 +247,16 @@ namespace GitHub.Runner.Sdk
             }
 
             return false;
+        }
+
+        private string PrependHttpIfNoProtocol(string proxyAddress)
+        {
+            // much like in golang, see https://go.dev/src/vendor/golang.org/x/net/http/httpproxy/proxy.go?s=4905:4916
+            if (proxyAddress.IndexOf("://", StringComparison.Ordinal) == -1)
+            {
+                proxyAddress = "http://" + proxyAddress;
+            }
+            return proxyAddress;
         }
     }
 }

--- a/src/Test/L0/RunnerWebProxyL0.cs
+++ b/src/Test/L0/RunnerWebProxyL0.cs
@@ -186,8 +186,8 @@ namespace GitHub.Runner.Common.Tests
         {
             try
             {
-                Environment.SetEnvironmentVariable("http_proxy", "127.0.0.1:7777");
-                Environment.SetEnvironmentVariable("https_proxy", "127.0.0.1");
+                Environment.SetEnvironmentVariable("http_proxy", "#fragment");
+                Environment.SetEnvironmentVariable("https_proxy", "#fragment");
                 var proxy = new RunnerWebProxy();
 
                 Assert.Null(proxy.HttpProxyAddress);
@@ -197,6 +197,50 @@ namespace GitHub.Runner.Common.Tests
                 Assert.Null(proxy.HttpsProxyAddress);
                 Assert.Null(proxy.HttpsProxyUsername);
                 Assert.Null(proxy.HttpsProxyPassword);
+
+                Assert.Equal(0, proxy.NoProxyList.Count);
+            }
+            finally
+            {
+                CleanProxyEnv();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void WebProxyPrependsHTTPforHTTP_PROXY()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("http_proxy", "127.0.0.1:7777");
+                var proxy = new RunnerWebProxy();
+
+                Assert.Equal("http://127.0.0.1:7777", proxy.HttpProxyAddress);
+                Assert.Null(proxy.HttpProxyUsername);
+                Assert.Null(proxy.HttpProxyPassword);
+
+                Assert.Equal(0, proxy.NoProxyList.Count);
+            }
+            finally
+            {
+                CleanProxyEnv();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void WebProxyPrependsHTTPforHTTPS_PROXY()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("https_proxy", "127.0.0.1:7777");
+                var proxy = new RunnerWebProxy();
+
+                Assert.Equal("http://127.0.0.1:7777", proxy.HttpsProxyAddress);
+                Assert.Null(proxy.HttpProxyUsername);
+                Assert.Null(proxy.HttpProxyPassword);
 
                 Assert.Equal(0, proxy.NoProxyList.Count);
             }


### PR DESCRIPTION
Add 'http://' to http(s)_proxy if there is no protocol

Before this commit, these URIs used to be ignored (nullproxy).

The new behaviour aligns with go style http(s)_proxy