### PR TITLE
Fix error message reported on non-local action setup

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1136,7 +1136,7 @@ namespace GitHub.Runner.Worker
                 {
                     reference = $"{reference}@{repositoryReference.Ref}";
                 }
-                throw new InvalidOperationException($"Can't find 'action.yml', 'action.yaml' or 'Dockerfile' for action '{reference.ToString()}'.");
+                throw new InvalidOperationException($"Can't find 'action.yml', 'action.yaml' or 'Dockerfile' for action '{reference}'.");
             }
         }
 

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1127,8 +1127,16 @@ namespace GitHub.Runner.Worker
             }
             else
             {
-                var fullPath = IOUtil.ResolvePath(actionEntryDirectory, "."); // resolve full path without access filesystem.
-                throw new InvalidOperationException($"Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '{fullPath}'. Did you forget to run actions/checkout before running your local action?");
+                var reference = repositoryReference.Name;
+                if (!string.IsNullOrEmpty(repositoryReference.Path))
+                {
+                    reference = $"{reference}/{repositoryReference.Path}";
+                }
+                if (!string.IsNullOrEmpty(repositoryReference.Ref))
+                {
+                    reference = $"{reference}@{repositoryReference.Ref}";
+                }
+                throw new InvalidOperationException($"Can't find 'action.yml', 'action.yaml' or 'Dockerfile' for action '{reference.ToString()}'.");
             }
         }
 


### PR DESCRIPTION
Fixes #2513

The PrepareRepositoryActionAsync stops if the action is local (self alias).

So the error message was misleading that the checkout is needed even though the action is not related to this repository.

The result of this change would look something like this:
![image](https://github.com/actions/runner/assets/97525037/88f556d8-4145-4b29-861c-8e8d15661c42)
