### PR TITLE
Fix feature flag location

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1468,7 +1468,7 @@ namespace GitHub.Runner.Worker
 
         private bool logTemplateErrorsAsDebugMessages()
         {
-            if (_executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Runner.Features.LogTemplateErrorsAsDebugMessages, out var logErrorsAsDebug))
+            if (_executionContext.Global.Variables.TryGetValue(Constants.Runner.Features.LogTemplateErrorsAsDebugMessages, out var logErrorsAsDebug))
             {
                 return StringUtil.ConvertToBoolean(logErrorsAsDebug, defaultValue: false);
             }


### PR DESCRIPTION
`DistributedTask.LogTemplateErrorsAsDebugMessages` flag was passed as part of `_executionContext.Global.Variables` and not `_executionContext.Global.EnvironmentVariables`. This PR fixes the code fetching it.

After the fix:

<img width="1347" alt="Screenshot 2023-07-19 at 11 52 37" src="https://github.com/actions/runner/assets/67866556/8c566aa8-c234-4e74-b324-b26a545910ec">
<img width="1355" alt="Screenshot 2023-07-19 at 11 52 47" src="https://github.com/actions/runner/assets/67866556/bfabec63-62d4-4e06-85d7-3a61013fb2e1">
