### PR TITLE
Update heredoc detection to add additional edge cases

### DIFF
--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -396,7 +396,7 @@ namespace GitHub.Runner.Worker
         }
 
         // accepts a string, two indexes, and returns true if only whitespace chars exist between those two indexes (non-inclusive)
-        private static bool CheckIfOnlyWhitespaceBetweenPositions(string str, int pos1, int pos2)
+        private static bool OnlyContainsWhiteSpaceBetweenPositions(string str, int pos1, int pos2)
         {
             // Check if the provided positions are valid
             if (pos1 < 0 || pos2 < 0 || pos1 >= str.Length || pos2 >= str.Length)

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -329,11 +329,11 @@ namespace GitHub.Runner.Worker
                     var isHeredoc = heredocIndex >= 0 &&
                     (
                         equalsIndex < 0 ||
-                        
+                        heredocIndex < equalsIndex ||
                         (
                             heredocIndex > equalsIndex &&
                             OnlyContainsWhiteSpaceBetweenPositions(line, equalsIndex, heredocIndex)
-                        ) || heredocIndex < equalsIndex
+                        ) 
                     );
                     
                     if (isHeredoc)

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -396,7 +396,7 @@ namespace GitHub.Runner.Worker
         }
 
         // accepts a string, two indexes, and returns true if only whitespace chars exist between those two indexes (non-inclusive)
-        private static bool CheckIfOnlyWhitespaceBetweenSymbols(string str, int pos1, int pos2)
+        private static bool CheckIfOnlyWhitespaceBetweenPositions(string str, int pos1, int pos2)
         {
             // Check if the provided positions are valid
             if (pos1 < 0 || pos2 < 0 || pos1 >= str.Length || pos2 >= str.Length)

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -343,7 +343,7 @@ namespace GitHub.Runner.Worker
                         {
                             throw new Exception($"Invalid format '{line}'. Name must not be empty and delimiter must not be empty");
                         }
-                        key = split[0];
+                        key = split[0].Trim().TrimEnd('=');
                         var delimiter = split[1];
                         var startIndex = index; // Start index of the value (inclusive)
                         var endIndex = index;   // End index of the value (exclusive)

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -329,11 +329,11 @@ namespace GitHub.Runner.Worker
                     var isHeredoc = heredocIndex >= 0 &&
                     (
                         equalsIndex < 0 ||
-                        heredocIndex < equalsIndex ||
+                        
                         (
                             heredocIndex > equalsIndex &&
                             OnlyContainsWhiteSpaceBetweenPositions(line, equalsIndex, heredocIndex)
-                        )
+                        ) || heredocIndex < equalsIndex
                     );
                     
                     if (isHeredoc)
@@ -401,15 +401,13 @@ namespace GitHub.Runner.Worker
             // Check if the provided positions are valid
             if (pos1 < 0 || pos2 < 0 || pos1 >= str.Length || pos2 >= str.Length)
             {
-                throw new ArgumentOutOfRangeException("Whitespace check: Positions should be within the string length.");
+                throw new ArgumentOutOfRangeException("OnlyContainsWhiteSpaceBetweenPositions: Positions should be within the string length.");
             }
 
             // Ensure pos1 is always the smaller position
             if (pos2 < pos1)
             {
-                int temp = pos2;
-                pos2 = pos1;
-                pos1 = temp;
+                throw new ArgumentException("OnlyContainsWhiteSpaceBetweenPositions: pos1 must be less than or equal to pos2.")
             }
 
             for (int i = pos1 + 1; i < pos2; i++)

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -407,7 +407,7 @@ namespace GitHub.Runner.Worker
             // Ensure pos1 is always the smaller position
             if (pos2 < pos1)
             {
-                throw new ArgumentException("OnlyContainsWhiteSpaceBetweenPositions: pos1 must be less than or equal to pos2.")
+                throw new ArgumentException("OnlyContainsWhiteSpaceBetweenPositions: pos1 must be less than or equal to pos2.");
             }
 
             for (int i = pos1 + 1; i < pos2; i++)

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -364,8 +364,8 @@ namespace GitHub.Runner.Worker
 
                         output = endIndex > startIndex ? text.Substring(startIndex, endIndex - startIndex) : string.Empty;
                     }
-                    // Normal style NAME=VALUE
-                    else if (equalsIndex >= 0 && heredocIndex < 0)
+                    // Normal style NAME=VALUE, can have << in the value.
+                    else if (equalsIndex >= 0)
                     {
                         var split = line.Split(new[] { '=' }, 2, StringSplitOptions.None);
                         if (string.IsNullOrEmpty(line))

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -329,11 +329,11 @@ namespace GitHub.Runner.Worker
                     var isHeredoc = heredocIndex >= 0 &&
                     (
                         equalsIndex < 0 ||
+                        heredocIndex < equalsIndex ||
                         (
                             heredocIndex > equalsIndex &&
                             OnlyContainsWhiteSpaceBetweenPositions(line, equalsIndex, heredocIndex)
-                        ) ||
-                        heredocIndex < equalsIndex
+                        )
                     );
                     
                     if (isHeredoc)

--- a/src/Test/L0/Worker/FileCommandTestBase.cs
+++ b/src/Test/L0/Worker/FileCommandTestBase.cs
@@ -242,9 +242,10 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "MY_KEY_6=    <<EOF",
                     "white space test",
                     "EOF",
-                    "MY_KEY_7 << =EOF=",
+                    "MY_KEY_7 <<=EOF=",
                     "abc",
-                    "=EOF="
+                    "=EOF=",
+                    string.Empty
                 };
                 TestUtil.WriteContent(stateFile, content);
                 _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);

--- a/src/Test/L0/Worker/FileCommandTestBase.cs
+++ b/src/Test/L0/Worker/FileCommandTestBase.cs
@@ -250,13 +250,13 @@ namespace GitHub.Runner.Common.Tests.Worker
                 TestUtil.WriteContent(stateFile, content);
                 _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
                 Assert.Equal(0, _issues.Count);
-                Assert.Equal(4, _store.Count);
+                Assert.Equal(7, _store.Count);
                 Assert.Equal($"hello{BREAK}{BREAK}three{BREAK}", _store["MY_KEY_1"]);
                 Assert.Equal($"hello=two", _store["MY_KEY_2"]);
                 Assert.Equal($" EOF", _store["MY_KEY_3"]);
                 Assert.Equal($"EOF EOF", _store["MY_KEY_4"]);
                 Assert.Equal($"abc << def", _store["MY_KEY_5"]);
-                Assert.Equal($"white space test", _store["MY_KEY_6="]);
+                Assert.Equal($"white space test", _store["MY_KEY_6"]);
                 Assert.Equal($"abc", _store["MY_KEY_7"]);
             }
         }

--- a/src/Test/L0/Worker/FileCommandTestBase.cs
+++ b/src/Test/L0/Worker/FileCommandTestBase.cs
@@ -238,6 +238,10 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "MY_KEY_4<<EOF",
                     "EOF EOF",
                     "EOF",
+                    "MY_KEY_5=abc << def",
+                    "MY_KEY_6=    <<EOF",
+                    "white space test",
+                    "EOF"
                 };
                 TestUtil.WriteContent(stateFile, content);
                 _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);
@@ -247,6 +251,8 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal($"hello=two", _store["MY_KEY_2"]);
                 Assert.Equal($" EOF", _store["MY_KEY_3"]);
                 Assert.Equal($"EOF EOF", _store["MY_KEY_4"]);
+                Assert.Equal($"abc << def", _store["MY_KEY_5"]);
+                Assert.Equal($"white space test", _store["MY_KEY_6="]);
             }
         }
 

--- a/src/Test/L0/Worker/FileCommandTestBase.cs
+++ b/src/Test/L0/Worker/FileCommandTestBase.cs
@@ -256,6 +256,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal($"EOF EOF", _store["MY_KEY_4"]);
                 Assert.Equal($"abc << def", _store["MY_KEY_5"]);
                 Assert.Equal($"white space test", _store["MY_KEY_6="]);
+                Assert.Equal($"abc", _store["MY_KEY_7"]);
             }
         }
 

--- a/src/Test/L0/Worker/FileCommandTestBase.cs
+++ b/src/Test/L0/Worker/FileCommandTestBase.cs
@@ -241,9 +241,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "MY_KEY_5=abc << def",
                     "MY_KEY_6=    <<EOF",
                     "white space test",
-                    "EOF"
-                    "MY_KEY_7 << =EOF="
-                    "abc"
+                    "EOF",
+                    "MY_KEY_7 << =EOF=",
+                    "abc",
                     "=EOF="
                 };
                 TestUtil.WriteContent(stateFile, content);

--- a/src/Test/L0/Worker/FileCommandTestBase.cs
+++ b/src/Test/L0/Worker/FileCommandTestBase.cs
@@ -242,6 +242,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                     "MY_KEY_6=    <<EOF",
                     "white space test",
                     "EOF"
+                    "MY_KEY_7 << =EOF="
+                    "abc"
+                    "=EOF="
                 };
                 TestUtil.WriteContent(stateFile, content);
                 _fileCmdExtension.ProcessCommand(_executionContext.Object, stateFile, null);


### PR DESCRIPTION
The following examples should all detected as heredoc

1. "=" at the end of the key

```
test=<<EOF
hello world
EOF
```
2. any number of spaces between the equals-containing key and <<

```
test=      <<EOF
hello world
EOF
```

3. case where there the delimeter itself has an equals (think base64 encoded random string)

```
MY_KEY<<sdfsdf=
hellow world
sdfsdf=
```

We also want to correctly detect "normal" single line key/value style where "<<" is in the value. 

`stdout=hi there << hello world`
