### PR TITLE
Allow retry if Runner sees 404 when downloading actions

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -848,8 +848,15 @@ namespace GitHub.Runner.Worker
                                     }
                                     else if (response.StatusCode == HttpStatusCode.NotFound)
                                     {
-                                        // It doesn't make sense to retry in this case, so just stop
-                                        throw new ActionNotFoundException(new Uri(link));
+                                        if (retryCount == 2)
+                                        {
+                                            throw new ActionNotFoundException(new Uri(link));
+                                        }
+                                        else
+                                        {
+                                            Trace.Info($"Download action at '{link}' returned NotFound");
+                                            retryCount++;
+                                        }
                                     }
                                     else
                                     {

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -846,17 +846,9 @@ namespace GitHub.Runner.Worker
                                             break;
                                         }
                                     }
-                                    else if (response.StatusCode == HttpStatusCode.NotFound)
+                                    else if (response.StatusCode == HttpStatusCode.NotFound && retryCount >= 2)
                                     {
-                                        if (retryCount == 2)
-                                        {
-                                            throw new ActionNotFoundException(new Uri(link));
-                                        }
-                                        else
-                                        {
-                                            Trace.Info($"Download action at '{link}' returned NotFound");
-                                            retryCount++;
-                                        }
+                                        throw new ActionNotFoundException(new Uri(link));
                                     }
                                     else
                                     {

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -127,7 +127,10 @@ namespace GitHub.Runner.Common.Tests.Worker
                 string archiveFile = await CreateRepoArchive();
                 using var stream = File.OpenRead(archiveFile);
                 var mockClientHandler = new Mock<HttpClientHandler>();
-                mockClientHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                mockClientHandler.Protected()
+                    .SetupSequence<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound))
+                    .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound))
                     .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
 
                 var mockHandlerFactory = new Mock<IHttpClientHandlerFactory>();


### PR DESCRIPTION
Sometimes we get 404s when the token's permission is not yet replicated fully.  The 404 maybe temporary and we should retry in those cases.  