### PR TITLE
Propagate runner listener exitcode

### DIFF
--- a/src/Misc/layoutbin/RunnerService.js
+++ b/src/Misc/layoutbin/RunnerService.js
@@ -133,6 +133,8 @@ var runService = function () {
 
         if (!stopping) {
           setTimeout(runService, 5000);
+        } else {
+          process.exitCode = code;
         }
       });
     } catch (ex) {


### PR DESCRIPTION
This change ensures that the exit code from the `Runner.Listener` process is propagate when the service is stopping.
This allows any system managing the service unit, such as systemd, to further propagate this to any `ExecStopPost` scripts.

For our use case, the `ExecStopPost` call will ensure the instance running the self-hosted runner service is marked unhealthy as required, or users alerted to investigate when the GitHub Actions process exits non-zero.