### PR TITLE
check for your own process pid instead

### DIFF
--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -527,7 +527,7 @@ namespace GitHub.Runner.Worker
             }
 #pragma warning restore CA1416
 #else
-            var initProcessCgroup = File.ReadLines("/proc/1/cgroup");
+            var initProcessCgroup = File.ReadLines("/proc/thread-self/cgroup");
             if (initProcessCgroup.Any(x => x.IndexOf(":/docker/", StringComparison.OrdinalIgnoreCase) >= 0))
             {
                 throw new NotSupportedException("Container feature is not supported when runner is already running inside container.");


### PR DESCRIPTION
fix issue where you get
```
Error: Could not find a part of the path '/proc/1/cgroup'.
```
when trying to use service and the with a less privileged runner