### PR TITLE
Expose results service endpoint as environment variable

### DIFF
--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -228,6 +228,10 @@ namespace GitHub.Runner.Worker.Handlers
                 Environment["ACTIONS_ID_TOKEN_REQUEST_URL"] = generateIdTokenUrl;
                 Environment["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = systemConnection.Authorization.Parameters[EndpointAuthorizationParameters.AccessToken];
             }
+            if (systemConnection.Data.TryGetValue("ResultsServiceUrl", out var resultsUrl) && !string.IsNullOrEmpty(resultsUrl))
+            {
+                Environment["ACTIONS_RESULTS_URL"] = resultsUrl;
+            }
 
             foreach (var variable in this.Environment)
             {

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -63,6 +63,10 @@ namespace GitHub.Runner.Worker.Handlers
                 Environment["ACTIONS_ID_TOKEN_REQUEST_URL"] = generateIdTokenUrl;
                 Environment["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = systemConnection.Authorization.Parameters[EndpointAuthorizationParameters.AccessToken];
             }
+            if (systemConnection.Data.TryGetValue("ResultsServiceUrl", out var resultsUrl) && !string.IsNullOrEmpty(resultsUrl))
+            {
+                Environment["ACTIONS_RESULTS_URL"] = resultsUrl;
+            }
 
             // Resolve the target script.
             string target = null;


### PR DESCRIPTION
We'll need to expose the results service public endpoint for upcoming work with toolkit and eventually the upload/download artifact actions.