### PR TITLE
Update HTTPEventSourceListener to trace the right events.

### DIFF
--- a/src/Runner.Listener/Checks/CheckUtil.cs
+++ b/src/Runner.Listener/Checks/CheckUtil.cs
@@ -351,21 +351,39 @@ namespace GitHub.Runner.Listener.Check
         private readonly Dictionary<string, HashSet<string>> _ignoredEvent = new()
         {
             {
-                "Microsoft-System-Net-Http",
+                "System.Net.Http",
                 new HashSet<string>
                 {
                     "Info",
                     "Associate",
-                    "Enter",
-                    "Exit"
                 }
             },
             {
-                "Microsoft-System-Net-Security",
+                "System.Net.Security",
                 new HashSet<string>
                 {
-                    "Enter",
-                    "Exit",
+                    "Info",
+                    "DumpBuffer",
+                    "SslStreamCtor",
+                    "SecureChannelCtor",
+                    "NoDelegateNoClientCert",
+                    "CertsAfterFiltering",
+                    "UsingCachedCredential",
+                    "SspiSelectedCipherSuite"
+                }
+            },
+            {
+                "Private.InternalDiagnostics.System.Net.Http",
+                new HashSet<string>
+                {
+                    "Info",
+                    "Associate",
+                }
+            },
+            {
+                "Private.InternalDiagnostics.System.Net.Security",
+                new HashSet<string>
+                {
                     "Info",
                     "DumpBuffer",
                     "SslStreamCtor",
@@ -391,8 +409,8 @@ namespace GitHub.Runner.Listener.Check
         {
             base.OnEventSourceCreated(eventSource);
 
-            if (eventSource.Name == "Microsoft-System-Net-Http" ||
-                eventSource.Name == "Microsoft-System-Net-Security")
+            if (eventSource.Name.Contains("System.Net.Http") ||
+                eventSource.Name.Contains("System.Net.Security"))
             {
                 EnableEvents(eventSource, EventLevel.Verbose, EventKeywords.All);
             }


### PR DESCRIPTION
Dotnet core changed their network tracing event source name as part of dotnet core 5.0

https://github.com/dotnet/runtime/issues/37428

We need to react these changes otherwise we are not going to get any trace from the network layer from dotnet core.

TLDR:

`Microsoft-System-Net-Http` -> `System.Net.Http` and `Private.InternalDiagnostics.System.Net.Http`
`Microsoft-System-Net-Security` -> `System.Net.Security` and `Private.InternalDiagnostics.System.Net.Security`

I noticed this when check support issue https://github.com/github/c2c-actions-support/issues/2691