### PR TITLE
Add in dependabot security scanning/updates

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+- package-ecosystem: "docker"
+  directory: "/images"
+  schedule:
+    interval: "daily" 
+  target-branch: "main" 
+- package-ecosystem: "nuget"
+  directory: "/src"
+  schedule:
+    interval: "daily" 
+  target-branch: "main" 
+- package-ecosystem: "npm"
+  directory: "/src/Misc/expressionFunc/hashFiles"
+  schedule:
+    interval: "daily" 
+  target-branch: "main" 
+  allow:
+  - dependency-type: direct
+  - dependency-type: production # check only dependencies, which are going to the compiled app, not supporting tools like @vue-cli


### PR DESCRIPTION
# Description 
This PR adds in a configuration file for dependabot vulnerability scanning as well as automated PR updates for packages. 

This will check our docker packages, dotnet packages as well as npm packages that we use for the custom hashFiles function.