### PR TITLE
Fixes #759 - Include default port 80 in Git Proxy URI, add util GetAbsoluteUrlWithPort.

### DIFF
--- a/src/Runner.Listener/Checks/GitCheck.cs
+++ b/src/Runner.Listener/Checks/GitCheck.cs
@@ -101,7 +101,8 @@ namespace GitHub.Runner.Listener.Check
                     }
                     else
                     {
-                        gitProxy = $"-c http.proxy={proxy.AbsoluteUri}";
+                        string proxyUrlWithPort = UrlUtil.GetAbsoluteUrlWithPort(proxy);
+                        gitProxy = $"-c http.proxy={proxyUrlWithPort}";
                     }
                 }
 

--- a/src/Test/L0/Util/UrlUtilL0.cs
+++ b/src/Test/L0/Util/UrlUtilL0.cs
@@ -60,5 +60,61 @@ namespace GitHub.Runner.Common.Tests.Util
             // Actual
             Assert.Equal("https://user%20123:password%20123@github.com/actions/runner.git", result.AbsoluteUri);
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void GetAbsoluteUrlWithPort_WithUriPort80OutputContainsPort80()
+        {
+            UriBuilder uriBuilder = new UriBuilder
+            {
+                Port = 80,
+                Host = "my.proxy.com",
+                Scheme = "http"
+            };
+
+            string result = UrlUtil.GetAbsoluteUrlWithPort(uriBuilder.Uri);
+
+            Assert.Equal("http://my.proxy.com:80/", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void GetAbsoluteUrlWithPort_WithUriPort443OutputContainsPort443()
+        {
+            UriBuilder uriBuilder = new UriBuilder
+            {
+                Port = 443,
+                Host = "my.proxy.com",
+                Scheme = "https"
+            };
+
+            string result = UrlUtil.GetAbsoluteUrlWithPort(uriBuilder.Uri);
+
+            Assert.Equal("https://my.proxy.com:443/", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void GetAbsoluteUrlWithPort_WithCredentialsAndPort80OutputContainsPort80()
+        {
+            Uri result = new Uri("https://$user123:$pass123@my.proxy.com:80");
+            string resultWithPort = UrlUtil.GetAbsoluteUrlWithPort(result);
+
+            Assert.Equal("https://%24user123:%24pass123@my.proxy.com:80/", resultWithPort);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void GetAbsoluteUrlWithPort_WithCredentialsAndPort443OutputContainsPort443()
+        {
+            Uri result = new Uri("https://$user123:$pass123@my.proxy.com:443");
+            string resultWithPort = UrlUtil.GetAbsoluteUrlWithPort(result);
+
+            Assert.Equal("https://%24user123:%24pass123@my.proxy.com:443/", resultWithPort);
+        }
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/actions/runner/issues/759, Uri.AbsoluteUri strips default port 80, which causes the git runner to infer port 1080 as a SOCKS proxy, which is unexpected (see --check output below'.

```
2023-08-24T04:49:40.4791637Z Runner is behind http proxy 'http://myproxy/'
2023-08-24T04:49:40.4812906Z Run 'git -c http.proxy=http://myproxy/ ls-remote --exit-code https://...@github.com/actions/checkout HEAD'
2023-08-24T04:49:40.5141314Z trace: built-in: git 'ls-remote' '--exit-code' 'https://gh:.../actions/checkout' 'HEAD'
2023-08-24T04:49:40.5141355Z trace: run_command: 'git-remote-https' 'https://gh:...@github.com/actions/checkout' 'https://gh:...@github.com/actions/checkout'
2023-08-24T04:49:40.5154663Z * Couldn't find host github.com in the .netrc file; using defaults
2023-08-24T04:49:40.5198621Z * About to connect() to proxy myproxy on port 1080 (#0)
2023-08-24T04:49:40.5199057Z *   Trying X.X.X.X...
2023-08-24T04:51:47.6987648Z * Connection timed out
2023-08-24T04:51:47.6988288Z * Failed connect to myproxy:1080; Connection timed out
2023-08-24T04:51:47.6988328Z * Closing connection 0
2023-08-24T04:51:47.6988331Z fatal: unable to access 'https://gh:...@github.com/actions/checkout/': Failed connect to myproxy:1080; Connection timed out
2023-08-24T04:51:47.7023770Z ***************************************************************************************************************
2023-08-24T04:51:47.7023833Z ****                                                                                                       ****
2023-08-24T04:51:47.7023850Z ****     git ls-remote failed with error: GitHub.Runner.Sdk.ProcessExitCodeException: Exit code 128 returned from process: file name '/usr/bin/git', arguments '-c http.proxy=http://myproxy/ ls-remote --exit-code https://gh:...@github.com/actions/checkout HEAD'.
   at GitHub.Runner.Sdk.ProcessInvoker.ExecuteAsync(String workingDirectory, String fileName, String arguments, IDictionary`2 environment, Boolean requireExitCodeZero, Encoding outputEncoding, Boolean killProcessOnCancel, Channel`1 redirectStandardIn, Boolean inheritConsoleHandler, Boolean keepStandardInOpen, Boolean highPriorityProcess, CancellationToken cancellationToken)
   at GitHub.Runner.Common.ProcessInvokerWrapper.ExecuteAsync(String workingDirectory, String fileName, String arguments, IDictionary`2 environment, Boolean requireExitCodeZero, Encoding outputEncoding, Boolean killProcessOnCancel, Channel`1 redirectStandardIn, Boolean inheritConsoleHandler, Boolean keepStandardInOpen, Boolean highPriorityProcess, CancellationToken cancellationToken)
   at GitHub.Runner.Listener.Check.GitCheck.CheckGit(String url, String pat, Boolean extraCA)
2023-08-24T04:51:47.7125111Z ****    
```

The commit https://github.com/actions/runner/commit/0c8da9557eabad54c2c7fddc301f8920dedab3ff addressed the issue of the environment variable value being stripped of the default port, but not the actual variable passed to the github runner (https://github.com/actions/runner/blob/main/src/Runner.Listener/Checks/GitCheck.cs#L104).

I could have used uri.OriginalString, but then UserInfo user and passwords would not be escaped. I decided to write the util GetAbsoluteUrlWithPort also allow for usage with input of a URI containing unescaped credentials, returning the absoluteUrl with escaped credentials.