### PR TITLE
Delegating handler for Http redirects

### DIFF
--- a/src/Runner.Common/RedirectMessageHandler.cs
+++ b/src/Runner.Common/RedirectMessageHandler.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.ComponentModel;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GitHub.Runner.Sdk;
+using GitHub.Services.Common;
+
+namespace GitHub.Runner.Common
+{
+    /// <summary>
+    /// Handles redirects for Http requests
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class RedirectMessageHandler : DelegatingHandler
+    {
+        public RedirectMessageHandler(ITraceWriter trace)
+        {
+            Trace = trace;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            HttpResponseMessage response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if (response != null &&
+                IsRedirect(response.StatusCode) &&
+                response.Headers.Location != null)
+            {
+                Trace.Info($"Redirecting to '{response.Headers.Location}'.");
+
+                request = await CloneAsync(request, response.Headers.Location).ConfigureAwait(false);
+
+                response.Dispose();
+
+                response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+
+            return response;
+        }
+
+        private static bool IsRedirect(HttpStatusCode statusCode)
+        {
+            return (int)statusCode >= 300 && (int)statusCode < 400;
+        }
+
+        private static async Task<HttpRequestMessage> CloneAsync(HttpRequestMessage request, Uri requestUri)
+        {
+            var clone = new HttpRequestMessage(request.Method, requestUri)
+            {
+                Version = request.Version
+            };
+
+            request.Headers.ForEach(header => clone.Headers.TryAddWithoutValidation(header.Key, header.Value));
+
+            request.Options.ForEach(option => clone.Options.Set(new HttpRequestOptionsKey<object>(option.Key), option.Value));
+
+            if (request.Content != null)
+            {
+                clone.Content = new ByteArrayContent(await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false));
+
+                request.Content.Headers.ForEach(header => clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value));
+            }
+
+            return clone;
+        }
+
+        private readonly ITraceWriter Trace;
+    }
+}

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -85,7 +85,7 @@ namespace GitHub.Runner.Worker
                 // jobServerQueue is the throttling reporter.
                 _jobServerQueue = HostContext.GetService<IJobServerQueue>();
                 var delegatingHandlers = new List<DelegatingHandler>() { new ThrottlingReportHandler(_jobServerQueue) };
-                message.Variables.TryGetValue("system.github.enable_http_redirects", out VariableValue enableHttpRedirects);
+                message.Variables.TryGetValue("Actions.EnableHttpRedirects", out VariableValue enableHttpRedirects);
                 if (StringUtil.ConvertToBoolean(enableHttpRedirects?.Value) &&
                     !StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_NO_HTTP_REDIRECTS")))
                 {


### PR DESCRIPTION
This PR adds a delegating handler that performs redirection of Http requests if Actions service responds with one of 30x codes.

There is a safety switch disabling redirection handlers (controlled by the `GITHUB_ACTIONS_RUNNER_NO_HTTP_REDIRECTS` environment variable). It does not however control server behavior and if this environment is set and server responds with a redirect then job most likely will fail. 