### PR TITLE
Add references to the firewall requirements docs

### DIFF
--- a/docs/checks/actions.md
+++ b/docs/checks/actions.md
@@ -9,6 +9,8 @@ Make sure the runner has access to actions service for GitHub.com or GitHub Ente
   - The runner needs to access `https://api.github.com` for downloading actions.
   - The runner needs to access `https://vstoken.actions.githubusercontent.com/_apis/.../` for requesting an access token.
   - The runner needs to access `https://pipelines.actions.githubusercontent.com/_apis/.../` for receiving workflow jobs.
+  ---
+  **NOTE:** for the full list of domains that are required to be in the firewall allow list refer to the [GitHub self-hosted runners requirements documentation](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#communication-between-self-hosted-runners-and-github).
 
   These can by tested by running the following `curl` commands from your self-hosted runner machine:
 

--- a/docs/checks/network.md
+++ b/docs/checks/network.md
@@ -14,7 +14,7 @@
 
 - A Proxy may try to modify the HTTPS request (like add or change some http headers) and causes the request become incompatible with the Actions Service (ASP.NetCore), Ex: [Nginx](https://github.com/dotnet/aspnetcore/issues/17081)
 
-- Firewall rules that block action runner from accessing certain hosts, ex: `*.github.com`, `*.actions.githubusercontent.com`, etc
+- Firewall rules that block action runner from accessing [certain hosts](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#communication-between-self-hosted-runners-and-github), ex: `*.github.com`, `*.actions.githubusercontent.com`, etc
 
 
 ### Identify and solve these problems


### PR DESCRIPTION
Docs in this repo that cover network troubleshooting do not mention the full list of domains that have to be in the firewall allow list. And that could result in misconfigured network settings on a customer's side.

This PR adds references to the public Actions docs that are the source of truth for the network requirements.