### PR TITLE
Mark action download failures as infra failures

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -921,7 +921,7 @@ namespace GitHub.Runner.Worker
                 }
                 catch (InvalidDataException e)
                 {
-                    throw new InvalidActionArchiveException($"Can't un-zip archive file: {archiveFile}. action being checked out: {downloadInfo.NameWithOwner}. error: {e}.");
+                    throw new InvalidActionArchiveException($"Can't un-zip archive file: {archiveFile}. action being checked out: {downloadInfo.NameWithOwner}@{downloadInfo.Ref}. error: {e}.");
                 }
 #else
                 string tar = WhichUtil.Which("tar", require: true, trace: Trace);
@@ -948,7 +948,7 @@ namespace GitHub.Runner.Worker
                     int exitCode = await processInvoker.ExecuteAsync(stagingDirectory, tar, $"-xzf \"{archiveFile}\"", null, executionContext.CancellationToken);
                     if (exitCode != 0)
                     {
-                        throw new InvalidActionArchiveException($"Can't use 'tar -xzf' extract archive file: {archiveFile}. Action being checked out: {downloadInfo.NameWithOwner}. return code: {exitCode}.");
+                        throw new InvalidActionArchiveException($"Can't use 'tar -xzf' extract archive file: {archiveFile}. Action being checked out: {downloadInfo.NameWithOwner}@{downloadInfo.Ref}. return code: {exitCode}.");
                     }
                 }
 #endif

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -948,7 +948,7 @@ namespace GitHub.Runner.Worker
                     int exitCode = await processInvoker.ExecuteAsync(stagingDirectory, tar, $"-xzf \"{archiveFile}\"", null, executionContext.CancellationToken);
                     if (exitCode != 0)
                     {
-                        throw new InvalidActionArchiveException($"Can't use 'tar -xzf' extract archive file: {archiveFile}. action being checked out: {downloadInfo.NameWithOwner}. return code: {exitCode}.");
+                        throw new InvalidActionArchiveException($"Can't use 'tar -xzf' extract archive file: {archiveFile}. Action being checked out: {downloadInfo.NameWithOwner}. return code: {exitCode}.");
                     }
                 }
 #endif

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -921,7 +921,7 @@ namespace GitHub.Runner.Worker
                 }
                 catch (InvalidDataException e)
                 {
-                    throw new InvalidActionArchiveException($"Can't un-zip archive file: {archiveFile}. action being checked out: {downloadInfo.NameWithOwner}. error: {ex}.");
+                    throw new InvalidActionArchiveException($"Can't un-zip archive file: {archiveFile}. action being checked out: {downloadInfo.NameWithOwner}. error: {e}.");
                 }
 #else
                 string tar = WhichUtil.Which("tar", require: true, trace: Trace);

--- a/src/Sdk/DTWebApi/WebApi/Exceptions.cs
+++ b/src/Sdk/DTWebApi/WebApi/Exceptions.cs
@@ -2516,4 +2516,23 @@ namespace GitHub.DistributedTask.WebApi
         {
         }
     }
+
+    [Serializable]
+    public sealed class InvalidActionArchiveException : DistributedTaskException
+    {
+        public InvalidActionArchiveException(String message)
+            : base(message)
+        {
+        }
+
+        public InvalidActionArchiveException(String message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        private InvalidActionArchiveException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
 }


### PR DESCRIPTION
When the tar/zip is corrupted, it is most likely due to an infrastructure failures on the GitHub side. We will mark these failures so that it shows up as such in internal metrics.