### PR TITLE
Throw NonRetryableException on GetNextMessage from broker as needed.

### DIFF
--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -108,7 +108,7 @@ namespace GitHub.Runner.Listener
 
                     if (!IsGetNextMessageExceptionRetriable(ex))
                     {
-                        throw;
+                        throw new NonRetryableException("Get next message failed with non-retryable error.", ex);
                     }
                     else
                     {


### PR DESCRIPTION
The runner exit itself as expected instead of a infinite restart loop.
```
@TingluoHuang ➜ /workspaces/actions/runner/_layout $ ./run.sh 
Current runner version: '2.308.0'
2023-09-05 18:10:10Z: Listening for Jobs
2023-09-05 18:10:56Z: Runner connect error: Failed to get job message: Error: Not Found. Retrying until reconnected.
An error occurred: Get next message failed with non-retryable error.
Runner listener exit with terminated error, stop the service, no retry needed.
Exiting runner...
```