### PR TITLE
Update default version to node20

### DIFF
--- a/docs/checks/nodejs.md
+++ b/docs/checks/nodejs.md
@@ -4,9 +4,9 @@
 
 Make sure the built-in node.js has access to GitHub.com or GitHub Enterprise Server.
 
-The runner carries its own copy of node.js executable under `<runner_root>/externals/node16/`.
+The runner carries its own copy of node.js executable under `<runner_root>/externals/node20/`.
 
-All javascript base Actions will get executed by the built-in `node` at `<runner_root>/externals/node16/`.
+All javascript base Actions will get executed by the built-in `node` at `<runner_root>/externals/node20/`.
 
 > Not the `node` from `$PATH`
 

--- a/src/Misc/layoutbin/runsvc.sh
+++ b/src/Misc/layoutbin/runsvc.sh
@@ -10,7 +10,7 @@ if [ -f ".path" ]; then
     echo ".path=${PATH}"
 fi
 
-nodever=${GITHUB_ACTIONS_RUNNER_FORCED_NODE_VERSION:-node16}
+nodever=${GITHUB_ACTIONS_RUNNER_FORCED_NODE_VERSION:-node20}
 
 # insert anything to setup env when running as a service
 # run the host process which keep the listener alive

--- a/src/Misc/layoutbin/update.sh.template
+++ b/src/Misc/layoutbin/update.sh.template
@@ -135,12 +135,17 @@ if [[ "$currentplatform" == 'darwin'  && restartinteractiverunner -eq 0 ]]; then
     then
         # inspect the open file handles to find the node process
         # we can't actually inspect the process using ps because it uses relative paths and doesn't follow symlinks
-        nodever="node16"
+        nodever="node20"
         path=$(lsof -a -g "$procgroup" -F n | grep $nodever/bin/node | grep externals | tail -1 | cut -c2-)
-        if [[ $? -ne 0 || -z "$path" ]] # Fallback if RunnerService.js was started with node12
+        if [[ $? -ne 0 || -z "$path" ]] # Fallback if RunnerService.js was started with node16
         then
-            nodever="node12"
+            nodever="node16"
             path=$(lsof -a -g "$procgroup" -F n | grep $nodever/bin/node | grep externals | tail -1 | cut -c2-)
+            if [[ $? -ne 0 || -z "$path" ]] # Fallback if RunnerService.js was started with node12
+            then
+                nodever="node12"
+                path=$(lsof -a -g "$procgroup" -F n | grep $nodever/bin/node | grep externals | tail -1 | cut -c2-)
+            fi
         fi
         if [[ $? -eq 0 && -n "$path" ]]
         then

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -257,7 +257,7 @@ namespace GitHub.Runner.Common
             {
                 public static readonly string ToolsDirectory = "agent.ToolsDirectory";
 
-                // Set this env var to "node12" to downgrade the node version for internal functions (e.g hashfiles). This does NOT affect the version of node actions.
+                // Set this env var to "node16" to downgrade the node version for internal functions (e.g hashfiles). This does NOT affect the version of node actions.
                 public static readonly string ForcedInternalNodeVersion = "ACTIONS_RUNNER_FORCED_INTERNAL_NODE_VERSION";
                 public static readonly string ForcedActionsNodeVersion = "ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION";
                 public static readonly string PrintLogToStdout = "ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT";

--- a/src/Runner.Common/Util/NodeUtil.cs
+++ b/src/Runner.Common/Util/NodeUtil.cs
@@ -5,7 +5,7 @@ namespace GitHub.Runner.Common.Util
 {
     public static class NodeUtil
     {
-        private const string _defaultNodeVersion = "node16";
+        private const string _defaultNodeVersion = "node20";
         public static readonly ReadOnlyCollection<string> BuiltInNodeVersions = new(new[] { "node16", "node20" });
         public static string GetInternalNodeVersion()
         {

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -836,7 +836,6 @@ namespace GitHub.Runner.Worker
             // Actions environment
             ActionsEnvironment = message.ActionsEnvironment;
 
-
             // Service container info
             Global.ServiceContainers = new List<ContainerInfo>();
 


### PR DESCRIPTION
Make node20 default node version for runner internal operations. This can be opted-out by starting Runner with `ACTIONS_RUNNER_FORCED_INTERNAL_NODE_VERSION=node16` or if `DistributedTask.ForceInternalNodeVersionOnRunnerTo16` FF set to `true` (PR: https://github.com/github/actions-dotnet/pull/16155).