### PR TITLE
handle secret ending with &+

### DIFF
--- a/src/Sdk/DTLogging/Logging/ValueEncoders.cs
+++ b/src/Sdk/DTLogging/Logging/ValueEncoders.cs
@@ -98,7 +98,17 @@ namespace GitHub.DistributedTask.Logging
                 var secretSection = string.Empty;
                 if (value.Contains("&+"))
                 {
-                    secretSection = value.Substring(0, value.IndexOf("&+") + "&+".Length);
+                    int endIndex = value.IndexOf("&+") + "&+".Length;
+                    
+                    // If string ends with "&+", grab the whole string
+                    if (endIndex == value.Length)
+                    {
+                        secretSection = value;
+                    }
+                    else
+                    {
+                        secretSection = value.Substring(0, endIndex);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Context

This pull request addresses an edge case in the `PowerShellPostAmpersandEscape` method within the `ValueEncoders` class. Previously, when a secret string ended with `&+`, an `ArgumentOutOfRangeException` was thrown. This PR ensures that the method handles this scenario gracefully.

Related to https://github.com/github/c2c-actions-support/issues/2857