### PR TITLE
Correcting `zen` address

### DIFF
--- a/docs/checks/actions.md
+++ b/docs/checks/actions.md
@@ -15,7 +15,7 @@ Make sure the runner has access to actions service for GitHub.com or GitHub Ente
   These can by tested by running the following `curl` commands from your self-hosted runner machine:
 
     ```
-    curl -v https://api.github.com/api/v3/zen
+    curl -v https://api.github.com/zen
     curl -v https://vstoken.actions.githubusercontent.com/_apis/health
     curl -v https://pipelines.actions.githubusercontent.com/_apis/health
     ```


### PR DESCRIPTION
`https://api.github.com/api/v3/zen` should be `https://api.github.com/zen` for `github.com`