### PR TITLE
Fix ArgumentOutOfRangeException in PowerShellPostAmpersandEscape.

### DIFF
--- a/src/Sdk/DTLogging/Logging/ValueEncoders.cs
+++ b/src/Sdk/DTLogging/Logging/ValueEncoders.cs
@@ -123,8 +123,11 @@ namespace GitHub.DistributedTask.Logging
                 var secretSection = string.Empty;
                 if (value.Contains("&+"))
                 {
-                    // +1 to skip the letter that got colored
-                    secretSection = value.Substring(value.IndexOf("&+") + "&+".Length + 1);
+                    if (value.Length > value.IndexOf("&+") + "&+".Length + 1)
+                    {
+                        // +1 to skip the letter that got colored
+                        secretSection = value.Substring(value.IndexOf("&+") + "&+".Length + 1);
+                    }
                 }
                 else
                 {

--- a/src/Test/L0/HostContextL0.cs
+++ b/src/Test/L0/HostContextL0.cs
@@ -120,6 +120,7 @@ namespace GitHub.Runner.Common.Tests
         [InlineData("secret&+secret&secret", "secret&+\x0033[96ms\x0033[0mecret&secret", "***\x0033[96ms\x0033[0m***")]
         [InlineData("secret&+secret&+secret", "secret&+\x0033[96ms\x0033[0mecret&+secret", "***\x0033[96ms\x0033[0m***")]
         [InlineData("secret&+secret&secret&+secret", "secret&+\x0033[96ms\x0033[0mecret&secret&+secret", "***\x0033[96ms\x0033[0m***")]
+        [InlineData("secret&secret&+", "secret&secret&+\x0033[96m\x0033[0m", "***\x0033[96m\x0033[0m")]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
         public void SecretSectionMasking(string secret, string rawOutput, string maskedOutput)


### PR DESCRIPTION
```
GitHub actions runner worker process crashed with error: System.ArgumentOutOfRangeException: startIndex cannot be larger than length of string. (Parameter 'startIndex')
   at System.String.Substring(Int32 startIndex, Int32 length)
   at System.String.Substring(Int32 startIndex)
   at GitHub.DistributedTask.Logging.ValueEncoders.PowerShellPostAmpersandEscape(String value)
   at GitHub.DistributedTask.Logging.SecretMasker.AddValue(String value)
   at GitHub.Runner.Worker.Worker.InitializeSecretMasker(AgentJobRequestMessage message)
   at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
   at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
```