### PR TITLE
Retries to lock Services database on Windows

### DIFF
--- a/src/Runner.Listener/Configuration/NativeWindowsServiceHelper.cs
+++ b/src/Runner.Listener/Configuration/NativeWindowsServiceHelper.cs
@@ -514,9 +514,25 @@ namespace GitHub.Runner.Listener.Configuration
                 failureActions.Add(new FailureAction(RecoverAction.Restart, 60000));
 
                 // Lock the Service Database
-                svcLock = LockServiceDatabase(scmHndl);
-                if (svcLock.ToInt64() <= 0)
+                int svcLockRetries = 10;
+                int svcLockRetryTimeout = 5000;
+                while (true)
                 {
+                    svcLock = LockServiceDatabase(scmHndl);
+                    if (svcLock.ToInt64() > 0)
+                    {
+                        break;
+                    }
+
+                    _term.WriteLine("Retrying Lock Service Database...");
+
+                    svcLockRetries--;
+                    if (svcLockRetries > 0)
+                    {
+                        Thread.Sleep(svcLockRetryTimeout);
+                        continue;
+                    }
+
                     throw new Exception("Failed to Lock Service Database for Write");
                 }
 


### PR DESCRIPTION
Fix: #2479

I referred to: https://github.com/microsoft/azure-pipelines-agent/pull/4085

I ran into this problem while automatically setting up a cloud instance, so I would like to add a retry logic.