### PR TITLE
Throw TimeoutException instead of OperationCanceledException on the final retry in DownloadRepositoryAction

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -854,6 +854,11 @@ namespace GitHub.Runner.Worker
                             Trace.Info("Action download has been cancelled.");
                             throw;
                         }
+                        catch (OperationCanceledException ex) when (!executionContext.CancellationToken.IsCancellationRequested && retryCount >= 2)
+                        {
+                            Trace.Info($"Action download final retry timeout after {timeoutSeconds} seconds.");
+                            throw new TimeoutException($"Action '{link}' download has timed out. Error: {ex.Message}");
+                        }
                         catch (ActionNotFoundException)
                         {
                             Trace.Info($"The action at '{link}' does not exist");


### PR DESCRIPTION
This will make sure the composite action get marked as failed and stop running following steps.
Before the change:
![image](https://github.com/actions/runner/assets/1750815/6984992f-bc82-4f8c-a34a-063998ae904a)

After the change:
![image](https://github.com/actions/runner/assets/1750815/614a4ebe-8e9e-4858-a182-0edaebb7ac7f)
