### PR TITLE
Add `buildx` to images

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -6,6 +6,7 @@ ARG TARGETARCH
 ARG RUNNER_VERSION
 ARG RUNNER_CONTAINER_HOOKS_VERSION=0.4.0
 ARG DOCKER_VERSION=24.0.6
+ARG BUILDX_VERSION=0.11.2
 
 RUN apt update -y && apt install curl unzip -y
 
@@ -25,7 +26,11 @@ RUN export RUNNER_ARCH=${TARGETARCH} \
     && if [ "$RUNNER_ARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
     && curl -fLo docker.tgz https://download.docker.com/${TARGETOS}/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
-    && rm -rf docker.tgz
+    && rm -rf docker.tgz \
+    && mkdir -p /usr/local/lib/docker/cli-plugins \
+    && curl -Lo /usr/local/lib/docker/cli-plugins/docker-buildx \
+        "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TARGETARCH}" \
+    && chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -28,7 +28,7 @@ RUN export RUNNER_ARCH=${TARGETARCH} \
     && tar zxvf docker.tgz \
     && rm -rf docker.tgz \
     && mkdir -p /usr/local/lib/docker/cli-plugins \
-    && curl -Lo /usr/local/lib/docker/cli-plugins/docker-buildx \
+    && curl -fLo /usr/local/lib/docker/cli-plugins/docker-buildx \
         "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TARGETARCH}" \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 


### PR DESCRIPTION
In #2694, I updated Docker from `20.10` to `23.0`, which was released in [`2.309.0`](https://github.com/actions/runner/releases/tag/v2.309.0).

As mentioned at the top of the `23.0` release notes [here](https://docs.docker.com/engine/release-notes/23.0/), `buildx` was separated into a separate package in that release.

As a result of this change, we started experiencing the `docker build` issue below on our self-hosted runners after we updated them to `2.309.0`:

- https://github.com/rapidsai/cuspatial/actions/runs/6385035317/job/17328916617?pr=1275#step:8:61

After further investigation, I noticed that `Docker-Buildx` was explicitly listed on the `Installed Packages` section of GitHub's runners below, which is likely why they weren't affected by this change:

- https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#tools

This PR installs `buildx` into the `actions/runner` images so that self-hosted runners can continue to function correctly.

cc: @Link-, @TingluoHuang 