### PR TITLE
Allow spaces in path for shell scripts

### DIFF
--- a/src/Runner.Worker/Handlers/ScriptHandlerHelpers.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandlerHelpers.cs
@@ -15,8 +15,8 @@ namespace GitHub.Runner.Worker.Handlers
             ["cmd"] = "/D /E:ON /V:OFF /S /C \"CALL \"{0}\"\"",
             ["pwsh"] = "-command \". '{0}'\"",
             ["powershell"] = "-command \". '{0}'\"",
-            ["bash"] = "--noprofile --norc -e -o pipefail {0}",
-            ["sh"] = "-e {0}",
+            ["bash"] = "--noprofile --norc -e -o pipefail \"{0}\"",
+            ["sh"] = "-e \"{0}\"",
             ["python"] = "{0}"
         };
 


### PR DESCRIPTION
If the runner is in located at path that has spaces in then every `run:` in a Job will fail as it tries to run the path up to the space.

The problem is this conflicts with this change here: https://github.com/actions/runner/pull/1932

I'm not sure what the answer is, but just wanted to bring it to attention. I guess it's quite niche that a self hosted runner will be located in a path that has spaces but I ran into this here: https://github.com/cirruslabs/tart/pull/620#issuecomment-1747237822.

I guess the fix could be to add quotes or escape the spaces at a higher level when it's known that the argument is a path and not a command, but I'd need help to implement that.