### PR TITLE
Bump node 20 to v20.8.1

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -6,7 +6,7 @@ NODE_URL=https://nodejs.org/dist
 UNOFFICIAL_NODE_URL=https://unofficial-builds.nodejs.org/download/release
 NODE_ALPINE_URL=https://github.com/actions/alpine_nodejs/releases/download
 NODE16_VERSION="16.20.2"
-NODE20_VERSION="20.5.0"
+NODE20_VERSION="20.8.1"
 # used only for win-arm64, remove node16 unofficial version when official version is available
 NODE16_UNOFFICIAL_VERSION="16.20.0"
 


### PR DESCRIPTION
Bumping node 20, as there was 2 security releases since the v20.5.0:

- https://nodejs.org/en/blog/release/v20.5.1
- https://nodejs.org/en/blog/release/v20.8.1