### PR TITLE
Use the correct unicode checkmark symbol in success messages

### DIFF
--- a/src/Runner.Common/Terminal.cs
+++ b/src/Runner.Common/Terminal.cs
@@ -178,7 +178,7 @@ namespace GitHub.Runner.Common
             if (!Silent)
             {
                 Console.ForegroundColor = ConsoleColor.Green;
-                Console.Write("√ ");
+                Console.Write("✓ ");
                 Console.ResetColor();
                 Console.WriteLine(message);
             }


### PR DESCRIPTION
✓ is U+2713, check mark.
√ is U+221A, square root (radical symbol).