### PR TITLE
Fix `buildx` installation

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -54,6 +54,7 @@ RUN adduser --disabled-password --gecos "" --uid 1001 runner \
 WORKDIR /home/runner
 
 COPY --chown=runner:docker --from=build /actions-runner .
+COPY --from=build /usr/local/lib/docker/cli-plugins/docker-buildx /usr/local/lib/docker/cli-plugins/docker-buildx
 
 RUN install -o root -g root -m 755 docker/* /usr/bin/ && rm -rf docker
 


### PR DESCRIPTION
This PR is a continuation of #2901.

I hadn't tested that change locally and didn't realize the Dockerfile did a multi-stage build.

This PR fixes the `buildx` installation to ensure that the binary is copied to the final stage.

I tested these changes locally to confirm that it works as expected.