### PR TITLE
Add mask bug

### DIFF
--- a/src/Runner.Common/ActionCommand.cs
+++ b/src/Runner.Common/ActionCommand.cs
@@ -16,17 +16,10 @@ namespace GitHub.Runner.Common
             new StringEscapingUtil.EscapeMapping(token: "%", replacement: "%25"),
         };
 
-        private static readonly StringEscapingUtil.EscapeMapping[] _commandDataEscapeMappings = new[]
- {
-            new StringEscapingUtil.EscapeMapping(token: "\r", replacement: "%0D"),
-            new StringEscapingUtil.EscapeMapping(token: "\n", replacement: "%0A"),
-        };
-
         private static readonly StringEscapingUtil.EscapeMapping[] _escapeDataMappings = new[]
         {
             new StringEscapingUtil.EscapeMapping(token: "\r", replacement: "%0D"),
             new StringEscapingUtil.EscapeMapping(token: "\n", replacement: "%0A"),
-            // new StringEscapingUtil.EscapeMapping(token: "%", replacement: "%25"),
         };
 
         private static readonly StringEscapingUtil.EscapeMapping[] _escapePropertyMappings = new[]
@@ -115,7 +108,7 @@ namespace GitHub.Runner.Common
                     }
                 }
 
-                command.Data = StringEscapingUtil.UnescapeString(message.Substring(endIndex + _commandKey.Length), _commandDataEscapeMappings);
+                command.Data = StringEscapingUtil.UnescapeString(message.Substring(endIndex + _commandKey.Length), _escapeDataMappings);
                 return true;
             }
             catch

--- a/src/Runner.Common/ActionCommand.cs
+++ b/src/Runner.Common/ActionCommand.cs
@@ -16,11 +16,17 @@ namespace GitHub.Runner.Common
             new StringEscapingUtil.EscapeMapping(token: "%", replacement: "%25"),
         };
 
+        private static readonly StringEscapingUtil.EscapeMapping[] _commandDataEscapeMappings = new[]
+ {
+            new StringEscapingUtil.EscapeMapping(token: "\r", replacement: "%0D"),
+            new StringEscapingUtil.EscapeMapping(token: "\n", replacement: "%0A"),
+        };
+
         private static readonly StringEscapingUtil.EscapeMapping[] _escapeDataMappings = new[]
         {
             new StringEscapingUtil.EscapeMapping(token: "\r", replacement: "%0D"),
             new StringEscapingUtil.EscapeMapping(token: "\n", replacement: "%0A"),
-            new StringEscapingUtil.EscapeMapping(token: "%", replacement: "%25"),
+            // new StringEscapingUtil.EscapeMapping(token: "%", replacement: "%25"),
         };
 
         private static readonly StringEscapingUtil.EscapeMapping[] _escapePropertyMappings = new[]
@@ -109,7 +115,7 @@ namespace GitHub.Runner.Common
                     }
                 }
 
-                command.Data = StringEscapingUtil.UnescapeString(message.Substring(endIndex + _commandKey.Length), _escapeDataMappings);
+                command.Data = StringEscapingUtil.UnescapeString(message.Substring(endIndex + _commandKey.Length), _commandDataEscapeMappings);
                 return true;
             }
             catch

--- a/src/Runner.Common/Util/StringEscapingUtil.cs
+++ b/src/Runner.Common/Util/StringEscapingUtil.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GitHub.Runner.Sdk;
+using GitHub.Runner.Common;
+
+namespace GitHub.Runner.Common.Util
+{
+    public static class StrigEscapingUtil
+    {
+
+        private static readonly EscapeMapping[] _escapeDataMappings = new[]
+        {
+            new EscapeMapping(token: "\r", replacement: "%0D"),
+            new EscapeMapping(token: "\n", replacement: "%0A"),
+            new EscapeMapping(token: "%", replacement: "%25"),
+        };
+        public static string UnescapeData(string escaped)
+        {
+            if (string.IsNullOrEmpty(escaped))
+            {
+                return string.Empty;
+            }
+
+            string unescaped = escaped;
+            foreach (EscapeMapping mapping in _escapeDataMappings)
+            {
+                unescaped = unescaped.Replace(mapping.Replacement, mapping.Token);
+            }
+
+            return unescaped;
+        }
+        private sealed class EscapeMapping
+        {
+            public string Replacement { get; }
+            public string Token { get; }
+
+            public EscapeMapping(string token, string replacement)
+            {
+                ArgUtil.NotNullOrEmpty(token, nameof(token));
+                ArgUtil.NotNullOrEmpty(replacement, nameof(replacement));
+                Token = token;
+                Replacement = replacement;
+            }
+        }
+    }
+}

--- a/src/Runner.Common/Util/StringEscapingUtil.cs
+++ b/src/Runner.Common/Util/StringEscapingUtil.cs
@@ -6,16 +6,10 @@ using GitHub.Runner.Common;
 
 namespace GitHub.Runner.Common.Util
 {
-    public static class StrigEscapingUtil
+    public static class StringEscapingUtil
     {
 
-        private static readonly EscapeMapping[] _escapeDataMappings = new[]
-        {
-            new EscapeMapping(token: "\r", replacement: "%0D"),
-            new EscapeMapping(token: "\n", replacement: "%0A"),
-            new EscapeMapping(token: "%", replacement: "%25"),
-        };
-        public static string UnescapeData(string escaped)
+        public static string UnescapeString(string escaped, EscapeMapping[] _escapeDataMappings)
         {
             if (string.IsNullOrEmpty(escaped))
             {
@@ -30,7 +24,7 @@ namespace GitHub.Runner.Common.Util
 
             return unescaped;
         }
-        private sealed class EscapeMapping
+        public class EscapeMapping
         {
             public string Replacement { get; }
             public string Token { get; }

--- a/src/Test/L0/Worker/ActionCommandL0.cs
+++ b/src/Test/L0/Worker/ActionCommandL0.cs
@@ -139,7 +139,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 message = "::do-something k1=;=%252C=%250D=%250A=]=%253A,::;-%250D-%250A-]-:-,";
                 test = new ActionCommand("do-something")
                 {
-                    Data = ";-%0D-%0A-]-:-,",
+                    Data = ";-%250D-%250A-]-:-,",
                 };
                 test.Properties.Add("k1", ";=%2C=%0D=%0A=]=%3A");
                 Assert.True(ActionCommand.TryParseV2(message, commands, out verify));

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -454,7 +454,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 _commandManager.TryProcessCommand(_ec.Object, $"::add-mask::%252F%2F", null);
 
                 // Assert
-                Assert.Equal("***", hc.SecretMasker.MaskSecrets("%2F%2F"));
+                Assert.Equal("***", hc.SecretMasker.MaskSecrets("%252F%2F"));
             }
         }
 

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -443,6 +443,21 @@ namespace GitHub.Runner.Common.Tests.Worker
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void AddMaskWithPercentEncodedString()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // Act
+                _commandManager.TryProcessCommand(_ec.Object, $"::add-mask::%252F%2F", null);
+
+                // Assert
+                Assert.Equal("***", hc.SecretMasker.MaskSecrets("%2F%2F"));
+            }
+        }
+
         private TestHostContext CreateTestContext([CallerMemberName] string testName = "")
         {
             var hostContext = new TestHostContext(this, testName);


### PR DESCRIPTION
**Issue Description**
Secrets containing encoded `%` sign are not correctly masked. The reason is: secrets are escaped [here](https://github.com/actions/runner/blob/a4c57f27477077e57545af79851551ff7f5632bd/src/Runner.Common/ActionCommand.cs#L111) but then add-mask is called on unescaped string, which makes method to return original value. This pr implements first way of fixing this issue, that is not escaping `%35` at all. Another option would be to escape every input passed to [MaskSecrets](https://github.com/actions/runner/blob/a4c57f27477077e57545af79851551ff7f5632bd/src/Sdk/DTLogging/Logging/SecretMasker.cs#L209).
**Before**
![Screenshot 2023-10-31 at 14 34 07](https://github.com/actions/runner/assets/67866556/3471101b-1347-48a6-8f04-d239fe7b8bab)
**After**
![Screenshot 2023-10-31 at 14 36 35](https://github.com/actions/runner/assets/67866556/feb76b77-a473-453e-8ef2-24a021d62505)
I also extracted escaping code to StringEscapingUtil so we can reuse it if we'd like to escape every input to `MaskSecrets`.
**Todo**
- add feature flag and hide new code behind it