### PR TITLE
Use ENV to set LogLevel / TraceLevel in Listener and Worker log files and stdout when allowed.

### DIFF
--- a/src/Runner.Common/TraceSetting.cs
+++ b/src/Runner.Common/TraceSetting.cs
@@ -24,7 +24,7 @@ namespace GitHub.Runner.Common
                 // force user's TraceLevel to comply with runner TraceLevel enums
                 traceLevel = Math.Clamp(traceLevel, 0, 5);
 
-                DefaultTraceLevel = (TraceLevel) traceLevel;
+                DefaultTraceLevel = (TraceLevel)traceLevel;
             }
         }
 

--- a/src/Runner.Common/TraceSetting.cs
+++ b/src/Runner.Common/TraceSetting.cs
@@ -19,6 +19,13 @@ namespace GitHub.Runner.Common
             {
                 DefaultTraceLevel = TraceLevel.Verbose;
             }
+            else if (int.TryParse(Environment.GetEnvironmentVariable("ACTIONS_RUNNER_TRACE_LEVEL"), out var traceLevel))
+            {
+                // force user's TraceLevel to comply with runner TraceLevel enums
+                traceLevel = Math.Clamp(traceLevel, 0, 5);
+
+                DefaultTraceLevel = (TraceLevel) traceLevel;
+            }
         }
 
         [DataMember(EmitDefaultValue = false)]


### PR DESCRIPTION
Legacy GITHUB_ACTIONS_RUNNER_TRACE still takes precedence for back compat.