### PR TITLE
run.sh should only copy the run-helper.sh.template if it does not exist.

### DIFF
--- a/src/Misc/layoutroot/run.sh
+++ b/src/Misc/layoutroot/run.sh
@@ -14,7 +14,7 @@ run() {
     # run the helper process which keep the listener alive
     while :;
     do
-        cp -f "$DIR"/run-helper.sh.template "$DIR"/run-helper.sh
+        test -f "$DIR/run-helper.sh.template || cp -f "$DIR"/run-helper.sh.template "$DIR"/run-helper.sh
         "$DIR"/run-helper.sh $*
         returnCode=$?
         if [[ $returnCode -eq 2 ]]; then
@@ -35,7 +35,7 @@ runWithManualTrap() {
     # run the helper process which keep the listener alive
     while :;
     do
-        cp -f "$DIR"/run-helper.sh.template "$DIR"/run-helper.sh
+        test -f "$DIR"/run-helper.sh || cp -f "$DIR"/run-helper.sh.template "$DIR"/run-helper.sh
         "$DIR"/run-helper.sh $* &
         PID=$!
         wait -f $PID


### PR DESCRIPTION
I am not familiar with the reason for these two scripts (run-helper.sh.template and run-helper.cmd.template) being added as "template" files, for then to be copied. So it could be possible that they instead should be renamed to run-helper.{sh,cmd} as not templating is actually done?

While running this image in kubernetes with actions-runner-controller in the documented manner (https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller#updating-the-pod-specification-for-the-runner-pod)
with 

```yaml
      securityContext:
        readOnlyRootFilesystem: true
```
we get the following error message:
```
cp: cannot create regular file '/home/runner/run-helper.sh': Read-only file system 
/home/runner/run.sh: line 39: /home/runner/run-helper.sh: No such file or directory
```

The intent of this PR is to make it possible to create a new image based on this runner image without breaking the current configuration. In a new Dockerfile this can be used with:
```
RUN cp /home/runner/run-helper.sh.template /home/runner/run-helper.sh
```