### PR TITLE
Include whether http proxy configured as part of UserAgent.

### DIFF
--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -200,6 +200,10 @@ namespace GitHub.Runner.Common
             {
                 _trace.Info($"No proxy settings were found based on environmental variables (http_proxy/https_proxy/HTTP_PROXY/HTTPS_PROXY)");
             }
+            else
+            {
+                _userAgents.Add(new ProductInfoHeaderValue("HttpProxyConfigured", bool.TrueString));
+            }
 
             if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY")))
             {


### PR DESCRIPTION
This pull request includes a single change to the `HostContext` class in the `Runner.Common` project. The change adds code to track whether the proxy is configured or not.

Main change:

* <a href="diffhunk://#diff-57f70bdbd04ccd047c4e4cd93a5e71c43abbac952f679b9dc8561b45ea5ab842R203-R206">`src/Runner.Common/HostContext.cs`</a>: Added code to track whether the proxy is configured or not in the `HostContext` class.

This change would make trouble shooting customer's issue a little bit easier since we can advice our customers to double check their proxy setting while our support team working on other possible causes.