### PR TITLE
Add codeload to the list of service we check during '--check'.

### DIFF
--- a/docs/checks/actions.md
+++ b/docs/checks/actions.md
@@ -7,6 +7,7 @@ Make sure the runner has access to actions service for GitHub.com or GitHub Ente
 
 - For GitHub.com
   - The runner needs to access `https://api.github.com` for downloading actions.
+  - The runner needs to access `https://codeload.github.com` for downloading actions tar.gz/zip.
   - The runner needs to access `https://vstoken.actions.githubusercontent.com/_apis/.../` for requesting an access token.
   - The runner needs to access `https://pipelines.actions.githubusercontent.com/_apis/.../` for receiving workflow jobs.
   ---
@@ -16,12 +17,14 @@ Make sure the runner has access to actions service for GitHub.com or GitHub Ente
 
     ```
     curl -v https://api.github.com/zen
+    curl -v https://codeload.github.com/_ping
     curl -v https://vstoken.actions.githubusercontent.com/_apis/health
     curl -v https://pipelines.actions.githubusercontent.com/_apis/health
     ```
 
 - For GitHub Enterprise Server
   - The runner needs to access `https://[hostname]/api/v3` for downloading actions.
+  - The runner needs to access `https://codeload.[hostname]/_ping` for downloading actions tar.gz/zip.
   - The runner needs to access `https://[hostname]/_services/vstoken/_apis/.../` for requesting an access token.
   - The runner needs to access `https://[hostname]/_services/pipelines/_apis/.../` for receiving workflow jobs.
   
@@ -29,6 +32,7 @@ Make sure the runner has access to actions service for GitHub.com or GitHub Ente
 
     ```
     curl -v https://[hostname]/api/v3/zen
+    curl -v https://codeload.[hostname]/_ping
     curl -v https://[hostname]/_services/vstoken/_apis/health
     curl -v https://[hostname]/_services/pipelines/_apis/health
     ```
@@ -43,6 +47,10 @@ Make sure the runner has access to actions service for GitHub.com or GitHub Ente
 - DNS lookup for api.github.com or myGHES.com using dotnet
 - Ping api.github.com or myGHES.com using dotnet
 - Make HTTP GET to https://api.github.com or https://myGHES.com/api/v3 using dotnet, check response headers contains `X-GitHub-Request-Id`
+---
+- DNS lookup for codeload.github.com or codeload.myGHES.com using dotnet
+- Ping codeload.github.com or codeload.myGHES.com using dotnet
+- Make HTTP GET to https://codeload.github.com/_ping or https://codeload.myGHES.com/_ping using dotnet, check response headers contains `X-GitHub-Request-Id`
 ---
 - DNS lookup for vstoken.actions.githubusercontent.com using dotnet
 - Ping vstoken.actions.githubusercontent.com using dotnet

--- a/src/Runner.Listener/Checks/ActionsCheck.cs
+++ b/src/Runner.Listener/Checks/ActionsCheck.cs
@@ -58,10 +58,19 @@ namespace GitHub.Runner.Listener.Check
                 actionsPipelinesServiceUrl = urlBuilder.Uri.AbsoluteUri;
             }
 
+            var codeLoadUrlBuilder = new UriBuilder(url);
+            codeLoadUrlBuilder.Host = $"codeload.{codeLoadUrlBuilder.Host}";
+            codeLoadUrlBuilder.Path = "_ping";
+
             // check github api
             checkTasks.Add(CheckUtil.CheckDns(githubApiUrl));
             checkTasks.Add(CheckUtil.CheckPing(githubApiUrl));
             checkTasks.Add(HostContext.CheckHttpsGetRequests(githubApiUrl, pat, expectedHeader: "X-GitHub-Request-Id"));
+
+            // check github codeload
+            checkTasks.Add(CheckUtil.CheckDns(codeLoadUrlBuilder.Uri.AbsoluteUri));
+            checkTasks.Add(CheckUtil.CheckPing(codeLoadUrlBuilder.Uri.AbsoluteUri));
+            checkTasks.Add(HostContext.CheckHttpsGetRequests(codeLoadUrlBuilder.Uri.AbsoluteUri, pat, expectedHeader: "X-GitHub-Request-Id"));
 
             // check actions token service
             checkTasks.Add(CheckUtil.CheckDns(actionsTokenServiceUrl));


### PR DESCRIPTION
This pull request includes changes to ensure the runner can access the GitHub codeload service and updates the documentation to reflect this requirement. The most important changes include adding a code block to check the accessibility of the codeload service in the `ActionsCheck.RunCheck` method and updating the `actions.md` documentation file with instructions for testing the accessibility of the codeload service.

Main code changes:

* <a href="diffhunk://#diff-5404ecadd753720cc50d319be290f2e66258ab229886a0e48ba612985c96af5cR61-R74">`src/Runner.Listener/Checks/ActionsCheck.cs`</a>: Added a code block to check the accessibility of the GitHub codeload service in the `ActionsCheck.RunCheck` method.

Documentation updates:

* <a href="diffhunk://#diff-9d68451ba3986e9c3d1cc3b296a605826cefc3dcf0086faaa61378b51632ee1fR10">`docs/checks/actions.md`</a>: Updated the `actions.md` documentation file with instructions for testing the accessibility of the codeload service and mentioning the requirement for the runner to access `https://codeload.github.com` for downloading actions tar.gz/zip. <a href="diffhunk://#diff-9d68451ba3986e9c3d1cc3b296a605826cefc3dcf0086faaa61378b51632ee1fR10">[1]</a> <a href="diffhunk://#diff-9d68451ba3986e9c3d1cc3b296a605826cefc3dcf0086faaa61378b51632ee1fR51-R54">[2]</a>
* <a href="diffhunk://#diff-9d68451ba3986e9c3d1cc3b296a605826cefc3dcf0086faaa61378b51632ee1fR20-R35">`docs/checks/actions.md`</a>: Added a new bullet point for GitHub Enterprise Server, mentioning the requirement for the runner to access `https://codeload.[hostname]/_ping`.