### PR TITLE
Add sshd to .devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,9 @@
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "16"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {
+        "version": "latest"
     }
   },
   "customizations": {


### PR DESCRIPTION
This is required in order to ssh into a codespace for the repo: 


> error getting ssh server details: failed to start SSH server:
Please check if an SSH server is installed in the container. If the docker image being used for the codespace does not have an SSH server, install it in your Dockerfile or, for codespaces that use Debian-based images, you can add the following to your devcontainer.json:
> 
> "features": {
>     "ghcr.io/devcontainers/features/sshd:1": {
>         "version": "latest"
>     }
> }