### PR TITLE
Remove USE_BROKER_FLOW usage

### DIFF
--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -183,18 +183,15 @@ namespace GitHub.Runner.Listener
 
         public void OnJobStatus(object sender, JobStatusEventArgs e)
         {
-            if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("USE_BROKER_FLOW")))
+            Trace.Info("Received job status event. JobState: {0}", e.Status);
+            runnerStatus = e.Status;
+            try
             {
-                Trace.Info("Received job status event. JobState: {0}", e.Status);
-                runnerStatus = e.Status;
-                try
-                {
-                    _getMessagesTokenSource?.Cancel();
-                }
-                catch (ObjectDisposedException)
-                {
-                    Trace.Info("_getMessagesTokenSource is already disposed.");
-                }
+                _getMessagesTokenSource?.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                Trace.Info("_getMessagesTokenSource is already disposed.");
             }
         }
 

--- a/src/Runner.Sdk/Util/VssUtil.cs
+++ b/src/Runner.Sdk/Util/VssUtil.cs
@@ -62,11 +62,6 @@ namespace GitHub.Runner.Sdk
                 settings.SendTimeout = TimeSpan.FromSeconds(Math.Min(Math.Max(httpRequestTimeoutSeconds, 100), 1200));
             }
 
-            if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("USE_BROKER_FLOW")))
-            {
-                settings.AllowAutoRedirectForBroker = true;
-            }
-
             // Remove Invariant from the list of accepted languages.
             //
             // The constructor of VssHttpRequestSettings (base class of VssClientHttpRequestSettings) adds the current

--- a/src/Sdk/Common/Common/VssHttpMessageHandler.cs
+++ b/src/Sdk/Common/Common/VssHttpMessageHandler.cs
@@ -215,7 +215,7 @@ namespace GitHub.Services.Common
                     // SyncronizationContext (such as ASP.NET's) which keeps things from deadlocking...
 
                     var tmpResponse = await m_messageInvoker.SendAsync(request, tokenSource.Token).ConfigureAwait(false);
-                    if (Settings.AllowAutoRedirectForBroker && tmpResponse.StatusCode == HttpStatusCode.Redirect)
+                    if (tmpResponse.StatusCode == HttpStatusCode.Redirect)
                     {
                         //Dispose of the previous response
                         tmpResponse?.Dispose();

--- a/src/Sdk/Common/Common/VssHttpRequestSettings.cs
+++ b/src/Sdk/Common/Common/VssHttpRequestSettings.cs
@@ -111,16 +111,6 @@ namespace GitHub.Services.Common
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not HttpClientHandler should follow redirect on outgoing broker requests
-        /// This is special since this also sends token in the request, where as default AllowAutoRedirect does not
-        /// </summary>
-        public Boolean AllowAutoRedirectForBroker
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
         /// Gets or sets a value indicating whether or not compression should be used on outgoing requests.
         /// The default value is true.
         /// </summary>


### PR DESCRIPTION
This `USE_BROKER_FLOW ` flag allowed client-side redirects. It should not be needed anymore so removing for now. 