### PR TITLE
Security bump dependency System.IdentityModel.Tokens.Jwt to version 7.2.0

### DIFF
--- a/src/Sdk/Sdk.csproj
+++ b/src/Sdk/Sdk.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.1" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
         <PackageReference Include="System.Security.Cryptography.Cng" Version="4.4.0" />
         <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0" />
         <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />


### PR DESCRIPTION
Fixes build error:

Warning As Error: Package 'System.IdentityModel.Tokens.Jwt' 5.2.1 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-59j7-ghrg-fj52