### PR TITLE
Add user-agent to all http clients using RawClientHttpRequestSettings.

### DIFF
--- a/src/Runner.Sdk/Util/VssUtil.cs
+++ b/src/Runner.Sdk/Util/VssUtil.cs
@@ -23,7 +23,13 @@ namespace GitHub.Runner.Sdk
 
             if (VssClientHttpRequestSettings.Default.UserAgent != null && VssClientHttpRequestSettings.Default.UserAgent.Count > 0)
             {
-                headerValues.AddRange(VssClientHttpRequestSettings.Default.UserAgent);
+                foreach (var headerVal in VssClientHttpRequestSettings.Default.UserAgent)
+                {
+                    if (!headerValues.Contains(headerVal))
+                    {
+                        headerValues.Add(headerVal);
+                    }
+                }
             }
 
             VssClientHttpRequestSettings.Default.UserAgent = headerValues;
@@ -33,6 +39,23 @@ namespace GitHub.Runner.Sdk
             {
                 VssClientHttpRequestSettings.Default.ServerCertificateValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
             }
+
+            var rawHeaderValues = new List<ProductInfoHeaderValue>();
+            rawHeaderValues.AddRange(additionalUserAgents);
+            rawHeaderValues.Add(new ProductInfoHeaderValue($"({StringUtil.SanitizeUserAgentHeader(RuntimeInformation.OSDescription)})"));
+
+            if (RawClientHttpRequestSettings.Default.UserAgent != null && RawClientHttpRequestSettings.Default.UserAgent.Count > 0)
+            {
+                foreach (var headerVal in RawClientHttpRequestSettings.Default.UserAgent)
+                {
+                    if (!rawHeaderValues.Contains(headerVal))
+                    {
+                        rawHeaderValues.Add(headerVal);
+                    }
+                }
+            }
+
+            RawClientHttpRequestSettings.Default.UserAgent = rawHeaderValues;
         }
 
         public static VssConnection CreateConnection(

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -49,6 +49,9 @@ namespace GitHub.Runner.Worker
                 !string.IsNullOrEmpty(orchestrationId.Value))
             {
                 HostContext.UserAgents.Add(new ProductInfoHeaderValue("OrchestrationId", orchestrationId.Value));
+
+                // make sure orchestration id is in the user-agent header.
+                VssUtil.InitializeVssClientSettings(HostContext.UserAgents, HostContext.WebProxy);
             }
 
             var jobServerQueueTelemetry = false;

--- a/src/Sdk/Common/Common/RawHttpHeaders.cs
+++ b/src/Sdk/Common/Common/RawHttpHeaders.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 
 namespace GitHub.Services.Common.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class RawHttpHeaders
     {
-        public const String SessionHeader = "X-Runner-Session";
+        public const String SessionHeader = "X-Actions-Session";
     }
 }

--- a/src/Sdk/Common/Common/RawHttpMessageHandler.cs
+++ b/src/Sdk/Common/Common/RawHttpMessageHandler.cs
@@ -138,6 +138,8 @@ namespace GitHub.Services.Common
                         response.Dispose();
                     }
 
+                    this.Settings.ApplyTo(request);
+
                     // Let's start with sending a token
                     IssuedToken token = null;
                     if (m_tokenProvider != null)


### PR DESCRIPTION
Before:
```
User-Agent: VSServices/2.312.0.0
(NetStandard; Darwin 23.3.0 Darwin Kernel Version 23.3.0: Wed Dec 20 21:30:44 PST 2023; root:xnu-10002.81.5~7/RELEASE_ARM64_T6000)
```

After:
```
User-Agent: VSServices/2.312.0.0 (NetStandard; Darwin 23.3.0 Darwin Kernel Version 23.3.0: Wed Dec 20 21:30:44 PST 2023; root:xnu-10002.81.5~7/RELEASE_ARM64_T6000) 
GitHubActionsRunner-osx-arm64/2.312.0
HttpProxyConfigured/True
ClientId/1ef6c146-8b46-40ab-b57f-0871bfc614b5 
RunnerId/2 
GroupId/1 
CommitSHA/2e8e48f2a53cf8077b7d27d7064943622ad42786 
OrchestrationId/aee4139d-34c5-429f-8ab3-07c2b6058396.build_and_test.relwithdebinfo.main.main.__default
(Darwin 23.3.0 Darwin Kernel Version 23.3.0: Wed Dec 20 21:30:44 PST 2023; root:xnu-10002.81.5~7/RELEASE_ARM64_T6000)
```

So we can have better correlation better telemetry and the runner.

Fixing: https://github.com/github/actions-results-team/issues/2204