### PR TITLE
Fix JobDispatcher crash during force cancellation.

### DIFF
--- a/src/Runner.Listener/JobDispatcher.cs
+++ b/src/Runner.Listener/JobDispatcher.cs
@@ -629,6 +629,20 @@ namespace GitHub.Runner.Listener
                                     Trace.Info("worker process has been killed.");
                                 }
                             }
+                            catch (Exception ex)
+                            {
+                                // message send failed, this might indicate worker process is already exited or stuck.
+                                Trace.Info($"Job cancel message sending for job {message.JobId} failed, kill running worker. {ex}");
+                                workerProcessCancelTokenSource.Cancel();
+                                try
+                                {
+                                    await workerProcessTask;
+                                }
+                                catch (OperationCanceledException)
+                                {
+                                    Trace.Info("worker process has been killed.");
+                                }
+                            }
 
                             // wait worker to exit 
                             // if worker doesn't exit within timeout, then kill worker.


### PR DESCRIPTION
The JobDispatcher will crash in this scenario:
- Job A lands on runner
- Runner start worker process
- Job A finish on worker process, but somehow the worker process didn't exit fast enough
- Job B lands on the runner
- Runner noticed worker process for Job A is still running, so it try to cancel and gracefully shutdown the worker process by sending a cancellation message via `AnonymousPipe`
- Worker process exit right before runner try to cancel it.
- The message sending to `AnonymousPipe` failed since the worker exited, exception get thrown and crashed the `JobDispatcher`

The fix: add another `catch(Exception)` to make sure the failure on sending cancellation don't crash the JobDispatcher.

https://github.com/github/c2c-actions-support/issues/3423