### PR TITLE
Make sure to drain the upload queue before clean temp directory

### DIFF
--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -298,6 +298,8 @@ namespace GitHub.Runner.Worker
                 jobContext.Warning(string.Format(Constants.Runner.EnforcedNode12DetectedAfterEndOfLife, actions));
             }
 
+            await ShutdownQueue(throwOnFailure: false);
+
             // Make sure to clean temp after file upload since they may be pending fileupload still use the TEMP dir.
             _tempDirectoryManager?.CleanupTempDirectory();
 


### PR DESCRIPTION
In the run server flow, we are cleaning the temp directory without draining the file upload queue.

This PR drains the queue as the original flow does.