### PR TITLE
use a glibc 2.17 compatible node20 build on x86_64 (better idea inside!)

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -176,7 +176,7 @@ fi
 if [[ "$PACKAGERUNTIME" == "linux-x64" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/node-v${NODE16_VERSION}-linux-x64.tar.gz" node16 fix_nested_dir
     acquireExternalTool "$NODE_ALPINE_URL/v${NODE16_VERSION}/node-v${NODE16_VERSION}-alpine-x64.tar.gz" node16_alpine
-    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-x64.tar.gz" node20 fix_nested_dir
+    acquireExternalTool "$UNOFFICIAL_NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-x64-glibc-217.tar.gz" node20 fix_nested_dir
     acquireExternalTool "$NODE_ALPINE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-alpine-x64.tar.gz" node20_alpine
 fi
 


### PR DESCRIPTION
GitHub uses official nodejs.org builds in most cases, but also uses the "unofficial node" builds (which are also supplied by node.js) for win-arm64. This PR uses the unofficial node.js build for 20.x that links against glibc 2.17. This restores compatibility with older Linux distributions (CentOS7) that are still commonly in use.

While this "fixes" the problem for x86_64, the issue also exists for AArch64, and the correct solution is actually for GH to produce its own node builds using the `--fully-static` flag. GitHub could produce `--fully-static` builds for Linux x86_64 and AArch64 and then they would no longer need to worry about this problem (both old distributions and alpine).

Considering you're already building musl node builds via https://github.com/actions/alpine_nodejs please consider just altering this to use `--fully-static`, adding AArch64, and then using those binaries in all cases. To demonstrate this I've forked that repo and built a [fully static node.js](https://github.com/reaperhulk/static_nodejs/releases/tag/v20.8.1) which runs on all glibc distributions as well.

refs: https://github.com/actions/runner/issues/2906