### PR TITLE
Instruct docker build to load the image.

### DIFF
--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -104,7 +104,7 @@ namespace GitHub.Runner.Worker.Container
 
         public async Task<int> DockerBuild(IExecutionContext context, string workingDirectory, string dockerFile, string dockerContext, string tag)
         {
-            return await ExecuteDockerCommandAsync(context, "build", $"-t {tag} -f \"{dockerFile}\" \"{dockerContext}\"", workingDirectory, context.CancellationToken);
+            return await ExecuteDockerCommandAsync(context, "build", $"--load -t {tag} -f \"{dockerFile}\" \"{dockerContext}\"", workingDirectory, context.CancellationToken);
         }
 
         public async Task<string> DockerCreate(IExecutionContext context, ContainerInfo container)


### PR DESCRIPTION
Docker buildx loads the image by default for local build drivers but not for remote build drivers.

This change enables the seamless usage of remote buildx drivers for GitHub runners.
For local build drivers, this change is a noop.