### PR TITLE
Run actions runner on FreeBSD Linux compatibility layer

### DIFF
--- a/src/Runner.Sdk/Util/WhichUtil.cs
+++ b/src/Runner.Sdk/Util/WhichUtil.cs
@@ -36,8 +36,8 @@ namespace GitHub.Runner.Sdk
             {
                 if (!string.IsNullOrEmpty(pathSegment) && Directory.Exists(pathSegment))
                 {
-                    string[] matches = null;
 #if OS_WINDOWS
+                    string[] matches = null;
                     string pathExt = Environment.GetEnvironmentVariable("PATHEXT");
                     if (string.IsNullOrEmpty(pathExt))
                     {
@@ -95,20 +95,11 @@ namespace GitHub.Runner.Sdk
                         }
                     }
 #else
-                    try
+                    string commandPath = Path.Join(pathSegment, command);
+                    if (File.Exists(commandPath) && IsPathValid(commandPath, trace))
                     {
-                        matches = Directory.GetFiles(pathSegment, command);
-                    }
-                    catch (UnauthorizedAccessException ex)
-                    {
-                        trace?.Info("Ignore UnauthorizedAccess exception during Which.");
-                        trace?.Verbose(ex.ToString());
-                    }
-
-                    if (matches != null && matches.Length > 0 && IsPathValid(matches.First(), trace))
-                    {
-                        trace?.Info($"Location: '{matches.First()}'");
-                        return matches.First();
+                        trace?.Info($"Location: '{commandPath}'");
+                        return commandPath;
                     }
 #endif
                 }


### PR DESCRIPTION
I tried to run a self-hosted runner on the FreeBSD Linux compatibility layer. When I attempted to run it, I encountered an error stating that the 'tar' command does not exist.
After investigating the cause, I discovered that Directory.GetFiles was not functioning as expected in WhichUtil.Which. On FreeBSD's Linux compatibility layer, Directory.GetFiles does not work properly and consistently returns an empty array. Therefore, I implemented the equivalent functionality using File.Exists.

After overcoming this issue, the runner functions more or less as expected on FreeBSD Linux compatibility layer.
