### PR TITLE
Parse os-release to identify OS by ID_LIKE field (i.e. make `install-dependencies.sh` work on Amazon Linux 2023)

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -36,13 +36,19 @@ function print_rhel6errormessage()
     echo "https://github.com/dotnet/core/blob/master/Documentation/build-and-install-rhel6-prerequisites.md"
 }
 
-if [ -e /etc/os-release ]
+# As per https://www.freedesktop.org/software/systemd/man/latest/os-release.html
+# Snippet licensed under:
+# # SPDX-License-Identifier: MIT-0
+test -e /etc/os-release && os_release='/etc/os-release' || os_release='/usr/lib/os-release'
+. "${os_release}"
+
+if [ -e ${os_release} ]
 then
     echo "--------OS Information--------"
-    cat /etc/os-release
+    cat ${os_release}
     echo "------------------------------"
 
-    if [ -e /etc/debian_version ]
+    if [ "${ID:-linux}" = "debian" ] || [ "${ID_LIKE#*debian*}" != "${ID_LIKE}" ];
     then
         echo "The current OS is Debian based"
         echo "--------Debian Version--------"
@@ -117,16 +123,14 @@ then
             print_errormessage
             exit 1
         fi
-    elif [ -e /etc/redhat-release ]
+    elif [ "${ID:-linux}" = "fedora" ] || [ "${ID_LIKE#*fedora*}" != "${ID_LIKE}" ];
     then
-        echo "The current OS is Fedora based"
-        echo "--Fedora/RHEL/CentOS Version--"
-        cat /etc/redhat-release
-        echo "------------------------------"
+        echo "The current OS is: ${PRETTY_NAME}, which is like Fedora"
+        test -e /etc/redhat-release && (echo "------------------------------"; cat /etc/redhat-release; echo "------------------------------")
 
         # use dnf on fedora
         # use yum on centos and rhel
-        if [ -e /etc/fedora-release ]
+        if [ "${ID}" != "centos" ] && [ "${ID}" != "rhel" ];
         then
             command -v dnf
             if [ $? -eq 0 ]


### PR DESCRIPTION
The /etc/os-release file has evolved over the years, with current documentation being at
https://www.freedesktop.org/software/systemd/man/latest/os-release.html

Part of this spec is to also look at /usr/lib/os-release as image based Linux distributions that can exist without anything in /etc may put the os-release file there.

In the docs, Example 3 shows how to parse this file with shell. We can use that example and look at ID_LIKE to better determine if the OS is a Debian like system, or a Fedora like system, and differentiate between how RHEL / CentOS and friends are like Fedora and how non-RHEL, non-CentOS is also like Fedora.

The practical end-outcome of this is that it will now correctly detect Amazon Linux 2023, pick 'dnf' as the package manager, and install the dependencies.

Fixes: https://github.com/actions/runner/issues/2511