### PR TITLE
Update safe_sleep.sh for bug when scheduler is paused for more than 1 second

### DIFF
--- a/src/Misc/layoutroot/safe_sleep.sh
+++ b/src/Misc/layoutroot/safe_sleep.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 SECONDS=0
-while [[ $SECONDS != $1 ]]; do
+while [[ $SECONDS -lt $1 ]]; do
     :
 done


### PR DESCRIPTION
fixed a rare condition where the comparison may not be made within the second and then this will loop forever (or at least until a rollover of SECONDS)  ;-)

sleep was replaced in https://github.com/actions/runner/pull/1707

But if safe_sleep.sh is running when a vm is suspended it will not do the comparison within the second and therefore loops forever when the vm is resumed.

