### PR TITLE
Better step timeout message.

### DIFF
--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -295,7 +295,7 @@ namespace GitHub.Runner.Worker
                     !jobCancellationToken.IsCancellationRequested)
                 {
                     Trace.Error($"Caught timeout exception from step: {ex.Message}");
-                    step.ExecutionContext.Error("The action has timed out.");
+                    step.ExecutionContext.Error($"The action '{step.DisplayName}' has timed out after {timeoutMinutes} minutes.");
                     step.ExecutionContext.Result = TaskResult.Failed;
                 }
                 else


### PR DESCRIPTION
Before:
![image](https://github.com/actions/runner/assets/1750815/7894ddc1-abab-4ec3-95cd-450c512b29dc)

After:
![image](https://github.com/actions/runner/assets/1750815/6c853617-49e9-4e29-971b-9d20ef060fad)
