### PR TITLE
Refresh Token for BrokerServer

### DIFF
--- a/src/Runner.Common/BrokerServer.cs
+++ b/src/Runner.Common/BrokerServer.cs
@@ -23,6 +23,8 @@ namespace GitHub.Runner.Common
         Task<TaskAgentMessage> GetRunnerMessageAsync(Guid? sessionId, TaskAgentStatus status, string version, string os, string architecture, bool disableUpdate, CancellationToken token);
 
         Task UpdateConnectionIfNeeded(Uri serverUri, VssCredentials credentials);
+
+        Task ForceRefreshConnection(VssCredentials credentials);
     }
 
     public sealed class BrokerServer : RunnerService, IBrokerServer
@@ -80,6 +82,11 @@ namespace GitHub.Runner.Common
             }
 
             return Task.CompletedTask;
+        }
+
+        public Task ForceRefreshConnection(VssCredentials credentials)
+        {
+            return ConnectAsync(_brokerUri, credentials);
         }
 
         public bool ShouldRetryException(Exception ex)

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -385,6 +385,7 @@ namespace GitHub.Runner.Listener
         public async Task RefreshListenerTokenAsync(CancellationToken cancellationToken)
         {
             await _runnerServer.RefreshConnectionAsync(RunnerConnectionType.MessageQueue, TimeSpan.FromSeconds(60));
+            await _brokerServer.ForceRefreshConnection(_creds);
         }
 
         private TaskAgentMessage DecryptMessage(TaskAgentMessage message)

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -598,6 +598,7 @@ namespace GitHub.Runner.Listener
                             }
                             else if (string.Equals(message.MessageType, TaskAgentMessageTypes.ForceTokenRefresh))
                             {
+                                Trace.Info("Received ForceTokenRefreshMessage");
                                 await _listener.RefreshListenerTokenAsync(messageQueueLoopTokenSource.Token);
                             }
                             else


### PR DESCRIPTION
The token was refreshed for the runnerServer, but not the BrokerServer. It was still using the cached token. 