### PR TITLE
fix summaries for actions results

### DIFF
--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -244,7 +244,7 @@ namespace GitHub.Runner.Worker
                 if (resultsReceiverEndpoint != null)
                 {
                     Trace.Info($"Queueing results file ({filePath}) for attachment upload ({attachmentName})");
-                    var stepId = context.Id;
+                    var stepId = !context.IsEmbedded ? context.Id : context.EmbeddedId; 
                     // Attachments must be added to the parent context (job), not the current context (step)
                     context.Root.QueueSummaryFile(attachmentName, scrubbedFilePath, stepId);
                 }

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -244,7 +244,7 @@ namespace GitHub.Runner.Worker
                 if (resultsReceiverEndpoint != null)
                 {
                     Trace.Info($"Queueing results file ({filePath}) for attachment upload ({attachmentName})");
-                    var stepId = !context.IsEmbedded ? context.Id : context.EmbeddedId; 
+                    var stepId = context.IsEmbedded ? context.EmbeddedId : context.Id;
                     // Attachments must be added to the parent context (job), not the current context (step)
                     context.Root.QueueSummaryFile(attachmentName, scrubbedFilePath, stepId);
                 }


### PR DESCRIPTION
Addresses a bug that was reported around summaries where we don't respect the embedded Id on uploads. This can cause conflicts during the upload due to how the IDs are utilized by GitHub Actions. 