### PR TITLE
In config.sh, change directory before running `ldd ./bin/libcoreclr.so`.

### DIFF
--- a/src/Misc/layoutroot/config.sh
+++ b/src/Misc/layoutroot/config.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Change directory to the script root directory
+# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+cd "$DIR"
+
 user_id=`id -u`
 
 # we want to snapshot the environment of the config user
@@ -59,17 +70,6 @@ then
         exit 1
     fi
 fi
-
-# Change directory to the script root directory
-# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
-SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
-  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-  SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-done
-DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-cd "$DIR"
 
 source ./env.sh
 


### PR DESCRIPTION
I'm doing a crazy thing with the runner. I'm adding it as a composer bin script, which symlinks it to vendor/bin dir.

The config.sh script can be run this way, except for the "Check dotnet Core 6.0 dependencies for Linux". 

This is because it calls `ldd ./bin/x` using relative paths when `pwd` might be different.

Moving the `cd` code to run before the `ldd` checks fixes it.