### PR TITLE
Add ability to enforce actions to run on node20

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -180,6 +180,9 @@ namespace GitHub.Runner.Common
             public static readonly string DeprecatedNodeVersion = "node16";
             public static readonly string EnforcedNode12DetectedAfterEndOfLife = "The following actions uses node12 which is deprecated and will be forced to run on node16: {0}. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/";
             public static readonly string EnforcedNode12DetectedAfterEndOfLifeEnvVariable = "Node16ForceActionsWarnings";
+            public static readonly string EnforcedNode16DetectedAfterEndOfLife = "The following actions uses Node.js version which is deprecated and will be forced to run on node20: {0}. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/";
+            public static readonly string EnforcedNode16DetectedAfterEndOfLifeEnvVariable = "Node20ForceActionsWarnings";
+
         }
 
         public static class RunnerEvent
@@ -262,6 +265,7 @@ namespace GitHub.Runner.Common
                 public static readonly string ForcedActionsNodeVersion = "ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION";
                 public static readonly string PrintLogToStdout = "ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT";
                 public static readonly string ActionArchiveCacheDirectory = "ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE";
+                public static readonly string ManualForceActionsToNode20 = "FORCE_JAVASCRIPT_ACTIONS_TO_NODE20";
             }
 
             public static class System

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -254,6 +254,7 @@ namespace GitHub.Runner.Common
                 public static readonly string RunnerDebug = "ACTIONS_RUNNER_DEBUG";
                 public static readonly string StepDebug = "ACTIONS_STEP_DEBUG";
                 public static readonly string AllowActionsUseUnsecureNodeVersion = "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION";
+                public static readonly string ManualForceActionsToNode20 = "FORCE_JAVASCRIPT_ACTIONS_TO_NODE20";
             }
 
             public static class Agent

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -813,12 +813,6 @@ namespace GitHub.Runner.Worker
                 Environment.SetEnvironmentVariable(Constants.Variables.Agent.ForcedInternalNodeVersion, "node16");
             }
 
-            var forceActionsToNode20 = StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable(Constants.Variables.Agent.ManualForceActionsToNode20));
-            if ((Global.Variables.GetBoolean("DistributedTask.ForceGithubJavascriptActionsToNode20") ?? false) || forceActionsToNode20)
-            {
-                Environment.SetEnvironmentVariable(Constants.Variables.Agent.ForcedActionsNodeVersion, "node20");
-            }
-
             // Environment variables shared across all actions
             Global.EnvironmentVariables = new Dictionary<string, string>(VarUtil.EnvironmentVariableKeyComparer);
 

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -813,6 +813,12 @@ namespace GitHub.Runner.Worker
                 Environment.SetEnvironmentVariable(Constants.Variables.Agent.ForcedInternalNodeVersion, "node16");
             }
 
+            var forceActionsToNode20 = StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable(Constants.Variables.Agent.ManualForceActionsToNode20));
+            if ((Global.Variables.GetBoolean("DistributedTask.ForceGithubJavascriptActionsToNode20") ?? false) || forceActionsToNode20)
+            {
+                Environment.SetEnvironmentVariable(Constants.Variables.Agent.ForcedActionsNodeVersion, "node20");
+            }
+
             // Environment variables shared across all actions
             Global.EnvironmentVariables = new Dictionary<string, string>(VarUtil.EnvironmentVariableKeyComparer);
 

--- a/src/Runner.Worker/Handlers/HandlerFactory.cs
+++ b/src/Runner.Worker/Handlers/HandlerFactory.cs
@@ -116,7 +116,7 @@ namespace GitHub.Runner.Worker.Handlers
                             }
 
                             warningActions.Add(repoActionFullName);
-                            executionContext.Global.Variables.Set("Node16ForceActionsWarnings", StringUtil.ConvertToJson(warningActions));
+                            executionContext.Global.Variables.Set("Node20ForceActionsWarnings", StringUtil.ConvertToJson(warningActions));
                         }
                         nodeData.NodeVersion = "node20";
                     }

--- a/src/Runner.Worker/Handlers/HandlerFactory.cs
+++ b/src/Runner.Worker/Handlers/HandlerFactory.cs
@@ -85,9 +85,11 @@ namespace GitHub.Runner.Worker.Handlers
                     nodeData.NodeVersion = "node16";
                 }
 
-                var manualForceActionsToNode20 = StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable(Constants.Variables.Agent.ManualForceActionsToNode20));
+                var localForceActionsToNode20 = StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable(Constants.Variables.Agent.ManualForceActionsToNode20));
+                executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Variables.Actions.ManualForceActionsToNode20, out var workflowForceActionsToNode20);
+                var isEnforceNode20Locally = !string.IsNullOrWhiteSpace(workflowForceActionsToNode20) ? StringUtil.ConvertToBoolean(workflowForceActionsToNode20) : localForceActionsToNode20;
                 if (string.Equals(nodeData.NodeVersion, "node16")
-                && ((executionContext.Global.Variables.GetBoolean("DistributedTask.ForceGithubJavascriptActionsToNode20") ?? false) || manualForceActionsToNode20))
+                && ((executionContext.Global.Variables.GetBoolean("DistributedTask.ForceGithubJavascriptActionsToNode20") ?? false) || isEnforceNode20Locally))
                 {
                     executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Variables.Actions.AllowActionsUseUnsecureNodeVersion, out var workflowOptOut);
                     var isWorkflowOptOutSet = !string.IsNullOrWhiteSpace(workflowOptOut);

--- a/src/Runner.Worker/Handlers/HandlerFactory.cs
+++ b/src/Runner.Worker/Handlers/HandlerFactory.cs
@@ -87,9 +87,9 @@ namespace GitHub.Runner.Worker.Handlers
 
                 var localForceActionsToNode20 = StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable(Constants.Variables.Agent.ManualForceActionsToNode20));
                 executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Variables.Actions.ManualForceActionsToNode20, out var workflowForceActionsToNode20);
-                var isEnforceNode20Locally = !string.IsNullOrWhiteSpace(workflowForceActionsToNode20) ? StringUtil.ConvertToBoolean(workflowForceActionsToNode20) : localForceActionsToNode20;
+                var enforceNode20Locally = !string.IsNullOrWhiteSpace(workflowForceActionsToNode20) ? StringUtil.ConvertToBoolean(workflowForceActionsToNode20) : localForceActionsToNode20;
                 if (string.Equals(nodeData.NodeVersion, "node16")
-                && ((executionContext.Global.Variables.GetBoolean("DistributedTask.ForceGithubJavascriptActionsToNode20") ?? false) || isEnforceNode20Locally))
+                && ((executionContext.Global.Variables.GetBoolean("DistributedTask.ForceGithubJavascriptActionsToNode20") ?? false) || enforceNode20Locally))
                 {
                     executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Variables.Actions.AllowActionsUseUnsecureNodeVersion, out var workflowOptOut);
                     var isWorkflowOptOutSet = !string.IsNullOrWhiteSpace(workflowOptOut);
@@ -118,7 +118,7 @@ namespace GitHub.Runner.Worker.Handlers
                             }
 
                             warningActions.Add(repoActionFullName);
-                            executionContext.Global.Variables.Set("Node20ForceActionsWarnings", StringUtil.ConvertToJson(warningActions));
+                            executionContext.Global.Variables.Set(Constants.Runner.EnforcedNode16DetectedAfterEndOfLifeEnvVariable, StringUtil.ConvertToJson(warningActions));
                         }
                         nodeData.NodeVersion = "node20";
                     }

--- a/src/Runner.Worker/Handlers/HandlerFactory.cs
+++ b/src/Runner.Worker/Handlers/HandlerFactory.cs
@@ -84,6 +84,43 @@ namespace GitHub.Runner.Worker.Handlers
                     }
                     nodeData.NodeVersion = "node16";
                 }
+
+                var manualForceActionsToNode20 = StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable(Constants.Variables.Agent.ManualForceActionsToNode20));
+                if (string.Equals(nodeData.NodeVersion, "node16")
+                && ((executionContext.Global.Variables.GetBoolean("DistributedTask.ForceGithubJavascriptActionsToNode20") ?? false) || manualForceActionsToNode20))
+                {
+                    executionContext.Global.EnvironmentVariables.TryGetValue(Constants.Variables.Actions.AllowActionsUseUnsecureNodeVersion, out var workflowOptOut);
+                    var isWorkflowOptOutSet = !string.IsNullOrWhiteSpace(workflowOptOut);
+                    var isLocalOptOut = StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable(Constants.Variables.Actions.AllowActionsUseUnsecureNodeVersion));
+                    bool isOptOut = isWorkflowOptOutSet ? StringUtil.ConvertToBoolean(workflowOptOut) : isLocalOptOut;
+
+                    if (!isOptOut)
+                    {
+                        var repoAction = action as Pipelines.RepositoryPathReference;
+                        if (repoAction != null)
+                        {
+                            var warningActions = new HashSet<string>();
+                            if (executionContext.Global.Variables.TryGetValue(Constants.Runner.EnforcedNode16DetectedAfterEndOfLifeEnvVariable, out var node20ForceWarnings))
+                            {
+                                warningActions = StringUtil.ConvertFromJson<HashSet<string>>(node20ForceWarnings);
+                            }
+
+                            string repoActionFullName;
+                            if (string.IsNullOrEmpty(repoAction.Name))
+                            {
+                                repoActionFullName = repoAction.Path; // local actions don't have a 'Name'
+                            }
+                            else
+                            {
+                                repoActionFullName = $"{repoAction.Name}/{repoAction.Path ?? string.Empty}".TrimEnd('/') + $"@{repoAction.Ref}";
+                            }
+
+                            warningActions.Add(repoActionFullName);
+                            executionContext.Global.Variables.Set("Node16ForceActionsWarnings", StringUtil.ConvertToJson(warningActions));
+                        }
+                        nodeData.NodeVersion = "node20";
+                    }
+                }
                 (handler as INodeScriptActionHandler).Data = nodeData;
             }
             else if (data.ExecutionType == ActionExecutionType.Script)

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -119,7 +119,7 @@ namespace GitHub.Runner.Worker.Handlers
                 Data.NodeVersion = "node16";
             }
 
-            if(forcedNodeVersion == "node20" && Data.NodeVersion != "node20")
+            if (forcedNodeVersion == "node20" && Data.NodeVersion != "node20")
             {
                 Data.NodeVersion = "node20";
             }

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -118,6 +118,11 @@ namespace GitHub.Runner.Worker.Handlers
             {
                 Data.NodeVersion = "node16";
             }
+
+            if(forcedNodeVersion == "node20" && Data.NodeVersion != "node20")
+            {
+                Data.NodeVersion = "node20";
+            }
             var nodeRuntimeVersion = await StepHost.DetermineNodeRuntimeVersion(ExecutionContext, Data.NodeVersion);
             string file = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), nodeRuntimeVersion, "bin", $"node{IOUtil.ExeExtension}");
 

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -298,6 +298,12 @@ namespace GitHub.Runner.Worker
                 jobContext.Warning(string.Format(Constants.Runner.EnforcedNode12DetectedAfterEndOfLife, actions));
             }
 
+            if (jobContext.Global.Variables.TryGetValue(Constants.Runner.EnforcedNode16DetectedAfterEndOfLifeEnvVariable, out var node20ForceWarnings) && (jobContext.Global.Variables.GetBoolean("DistributedTask.ForceGithubJavascriptActionsToNode20") ?? false))
+            {
+                var actions = string.Join(", ", StringUtil.ConvertFromJson<HashSet<string>>(node20ForceWarnings));
+                jobContext.Warning(string.Format(Constants.Runner.EnforcedNode16DetectedAfterEndOfLife, actions));
+            }
+
             await ShutdownQueue(throwOnFailure: false);
 
             // Make sure to clean temp after file upload since they may be pending fileupload still use the TEMP dir.
@@ -403,6 +409,12 @@ namespace GitHub.Runner.Worker
             {
                 var actions = string.Join(", ", StringUtil.ConvertFromJson<HashSet<string>>(node16ForceWarnings));
                 jobContext.Warning(string.Format(Constants.Runner.EnforcedNode12DetectedAfterEndOfLife, actions));
+            }
+
+            if (jobContext.Global.Variables.TryGetValue(Constants.Runner.EnforcedNode16DetectedAfterEndOfLifeEnvVariable, out var node20ForceWarnings) && (jobContext.Global.Variables.GetBoolean("DistributedTask.ForceGithubJavascriptActionsToNode20") ?? false))
+            {
+                var actions = string.Join(", ", StringUtil.ConvertFromJson<HashSet<string>>(node20ForceWarnings));
+                jobContext.Warning(string.Format(Constants.Runner.EnforcedNode16DetectedAfterEndOfLife, actions));
             }
 
             try

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -411,7 +411,7 @@ namespace GitHub.Runner.Worker
                 jobContext.Warning(string.Format(Constants.Runner.EnforcedNode12DetectedAfterEndOfLife, actions));
             }
 
-            if (jobContext.Global.Variables.TryGetValue(Constants.Runner.EnforcedNode16DetectedAfterEndOfLifeEnvVariable, out var node20ForceWarnings) && (jobContext.Global.Variables.GetBoolean("DistributedTask.ForceGithubJavascriptActionsToNode20") ?? false))
+            if (jobContext.Global.Variables.TryGetValue(Constants.Runner.EnforcedNode16DetectedAfterEndOfLifeEnvVariable, out var node20ForceWarnings))
             {
                 var actions = string.Join(", ", StringUtil.ConvertFromJson<HashSet<string>>(node20ForceWarnings));
                 jobContext.Warning(string.Format(Constants.Runner.EnforcedNode16DetectedAfterEndOfLife, actions));


### PR DESCRIPTION
Add two ways to enforce actions execute on `node20`:
1. Add FF `DistributedTask.ForceGithubJavascriptActionsToNode20` for Actions Service side. When this FF will be turned on it will make all javascript actions run on `node20`. In this case we will show warning, that actions was enforced: 

<img width="1351" alt="image" src="https://github.com/actions/runner/assets/32135588/115c887b-7946-42de-9ef0-731330f3c771"> 
This enforcement can be opted-out by setting `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` env var to `true`

2. Add env variable `FORCE_JAVASCRIPT_ACTIONS_TO_NODE20` so customers can try to enforce actions execution on `node20`. They can try to set this var on workflow level or as local environment variable.