### PR TITLE
Always Delete Actions Service Session

### DIFF
--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -188,12 +188,12 @@ namespace GitHub.Runner.Listener
                 {
                     using (var ts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
                     {
+                        await _runnerServer.DeleteAgentSessionAsync(_settings.PoolId, _session.SessionId, ts.Token);
+
                         if (_isBrokerSession)
                         {
                             await _brokerServer.DeleteSessionAsync(ts.Token);
-                            return;
                         }
-                        await _runnerServer.DeleteAgentSessionAsync(_settings.PoolId, _session.SessionId, ts.Token);
                     }
                 }
                 else

--- a/src/Test/L0/Listener/MessageListenerL0.cs
+++ b/src/Test/L0/Listener/MessageListenerL0.cs
@@ -272,7 +272,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 //Assert
                 _runnerServer
                     .Verify(x => x.DeleteAgentSessionAsync(
-                        _settings.PoolId, expectedSession.SessionId, It.IsAny<CancellationToken>()), Times.Never());
+                        _settings.PoolId, expectedBrokerSession.SessionId, It.IsAny<CancellationToken>()), Times.Once());
                 _brokerServer
                     .Verify(x => x.DeleteSessionAsync(It.IsAny<CancellationToken>()), Times.Once());
             }


### PR DESCRIPTION
Since we create the session in Actions service, we need to always be sure to delete it there _before_ we try to delete it from the broker. 