### PR TITLE
Add new SessionConflict return code

### DIFF
--- a/src/Misc/layoutbin/RunnerService.js
+++ b/src/Misc/layoutbin/RunnerService.js
@@ -114,6 +114,11 @@ var runService = function () {
             );
             stopping = true;
           }
+        } else if (code === 5) {
+          console.log(
+            "Runner listener exit with Session Conflict error, stop the service, no retry needed."
+          );
+          stopping = true;
         } else {
           var messagePrefix = "Runner listener exit with undefined return code";
           unknownFailureRetryCount++;

--- a/src/Misc/layoutroot/run-helper.cmd.template
+++ b/src/Misc/layoutroot/run-helper.cmd.template
@@ -49,5 +49,10 @@ if %ERRORLEVEL% EQU 4 (
   exit /b 1
 )
 
+if %ERRORLEVEL% EQU 5 (
+  echo "Runner listener exit with Session Conflict error, stop the service, no retry needed."
+  exit /b 0
+)
+
 echo "Exiting after unknown error code: %ERRORLEVEL%"
 exit /b 0

--- a/src/Misc/layoutroot/run-helper.sh.template
+++ b/src/Misc/layoutroot/run-helper.sh.template
@@ -70,6 +70,9 @@ elif [[ $returnCode == 4 ]]; then
         "$DIR"/safe_sleep.sh 1
     done
     exit 2
+elif [[ $returnCode == 5 ]]; then
+    echo "Runner listener exit with Session Conflict error, stop the service, no retry needed."
+    exit 0
 else
     echo "Exiting with unknown error code: ${returnCode}"
     exit 0

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -146,6 +146,13 @@ namespace GitHub.Runner.Common
                 }
             }
 
+            public enum CreateSessionResult
+            {
+                Success,
+                Failure,
+                SessionConflict
+            }
+
             public static class ReturnCode
             {
                 public const int Success = 0;

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -153,6 +153,7 @@ namespace GitHub.Runner.Common
                 public const int RetryableError = 2;
                 public const int RunnerUpdating = 3;
                 public const int RunOnceRunnerUpdating = 4;
+                public const int SessionConflict = 5;
             }
 
             public static class Features

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -146,13 +146,6 @@ namespace GitHub.Runner.Common
                 }
             }
 
-            public enum CreateSessionResult
-            {
-                Success,
-                Failure,
-                SessionConflict
-            }
-
             public static class ReturnCode
             {
                 public const int Success = 0;

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -42,7 +42,7 @@ namespace GitHub.Runner.Listener
             _brokerServer = HostContext.GetService<IBrokerServer>();
         }
 
-        public async Task<int> CreateSessionAsync(CancellationToken token)
+        public async Task<Constants.Runner.CreateSessionResult> CreateSessionAsync(CancellationToken token)
         {
             Trace.Entering();
 
@@ -99,7 +99,7 @@ namespace GitHub.Runner.Listener
                         encounteringError = false;
                     }
 
-                    return Constants.Runner.ReturnCode.Success;
+                    return Constants.Runner.CreateSessionResult.Success;
                 }
                 catch (OperationCanceledException) when (token.IsCancellationRequested)
                 {
@@ -123,7 +123,7 @@ namespace GitHub.Runner.Listener
                         if (string.Equals(vssOAuthEx.Error, "invalid_client", StringComparison.OrdinalIgnoreCase))
                         {
                             _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
-                            return Constants.Runner.ReturnCode.TerminatedError;
+                            return Constants.Runner.CreateSessionResult.Failure;
                         }
 
                         // Check whether we get 401 because the runner registration already removed by the service.
@@ -134,7 +134,7 @@ namespace GitHub.Runner.Listener
                         if (string.Equals(authError, "invalid_client", StringComparison.OrdinalIgnoreCase))
                         {
                             _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
-                            return Constants.Runner.ReturnCode.TerminatedError;
+                            return Constants.Runner.CreateSessionResult.Failure;
                         }
                     }
 
@@ -143,9 +143,9 @@ namespace GitHub.Runner.Listener
                         _term.WriteError($"Failed to create session. {ex.Message}");
                         if (ex is TaskAgentSessionConflictException)
                         {
-                            return Constants.Runner.ReturnCode.SessionConflict;
+                            return Constants.Runner.CreateSessionResult.SessionConflict;
                         }
-                        return Constants.Runner.ReturnCode.TerminatedError;
+                        return Constants.Runner.CreateSessionResult.Failure;
                     }
 
                     if (!encounteringError) //print the message only on the first error

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -141,7 +141,8 @@ namespace GitHub.Runner.Listener
                     if (!IsSessionCreationExceptionRetriable(ex))
                     {
                         _term.WriteError($"Failed to create session. {ex.Message}");
-                        if (ex is TaskAgentSessionConflictException) {
+                        if (ex is TaskAgentSessionConflictException)
+                        {
                             return Constants.Runner.ReturnCode.SessionConflict;
                         }
                         return Constants.Runner.ReturnCode.TerminatedError;

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -42,7 +42,7 @@ namespace GitHub.Runner.Listener
             _brokerServer = HostContext.GetService<IBrokerServer>();
         }
 
-        public async Task<Constants.Runner.CreateSessionResult> CreateSessionAsync(CancellationToken token)
+        public async Task<CreateSessionResult> CreateSessionAsync(CancellationToken token)
         {
             Trace.Entering();
 
@@ -99,7 +99,7 @@ namespace GitHub.Runner.Listener
                         encounteringError = false;
                     }
 
-                    return Constants.Runner.CreateSessionResult.Success;
+                    return CreateSessionResult.Success;
                 }
                 catch (OperationCanceledException) when (token.IsCancellationRequested)
                 {
@@ -123,7 +123,7 @@ namespace GitHub.Runner.Listener
                         if (string.Equals(vssOAuthEx.Error, "invalid_client", StringComparison.OrdinalIgnoreCase))
                         {
                             _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
-                            return Constants.Runner.CreateSessionResult.Failure;
+                            return CreateSessionResult.Failure;
                         }
 
                         // Check whether we get 401 because the runner registration already removed by the service.
@@ -134,7 +134,7 @@ namespace GitHub.Runner.Listener
                         if (string.Equals(authError, "invalid_client", StringComparison.OrdinalIgnoreCase))
                         {
                             _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
-                            return Constants.Runner.CreateSessionResult.Failure;
+                            return CreateSessionResult.Failure;
                         }
                     }
 
@@ -143,9 +143,9 @@ namespace GitHub.Runner.Listener
                         _term.WriteError($"Failed to create session. {ex.Message}");
                         if (ex is TaskAgentSessionConflictException)
                         {
-                            return Constants.Runner.CreateSessionResult.SessionConflict;
+                            return CreateSessionResult.SessionConflict;
                         }
-                        return Constants.Runner.CreateSessionResult.Failure;
+                        return CreateSessionResult.Failure;
                     }
 
                     if (!encounteringError) //print the message only on the first error

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -18,10 +18,17 @@ using GitHub.Services.WebApi;
 
 namespace GitHub.Runner.Listener
 {
+    public enum CreateSessionResult
+    {
+        Success,
+        Failure,
+        SessionConflict
+    }
+
     [ServiceLocator(Default = typeof(MessageListener))]
     public interface IMessageListener : IRunnerService
     {
-        Task<Constants.Runner.CreateSessionResult> CreateSessionAsync(CancellationToken token);
+        Task<CreateSessionResult> CreateSessionAsync(CancellationToken token);
         Task DeleteSessionAsync();
         Task<TaskAgentMessage> GetNextMessageAsync(CancellationToken token);
         Task DeleteMessageAsync(TaskAgentMessage message);
@@ -59,7 +66,7 @@ namespace GitHub.Runner.Listener
             _brokerServer = hostContext.GetService<IBrokerServer>();
         }
 
-        public async Task<Constants.Runner.CreateSessionResult> CreateSessionAsync(CancellationToken token)
+        public async Task<CreateSessionResult> CreateSessionAsync(CancellationToken token)
         {
             Trace.Entering();
 
@@ -123,7 +130,7 @@ namespace GitHub.Runner.Listener
                         encounteringError = false;
                     }
 
-                    return Constants.Runner.CreateSessionResult.Success;
+                    return CreateSessionResult.Success;
                 }
                 catch (OperationCanceledException) when (token.IsCancellationRequested)
                 {
@@ -147,7 +154,7 @@ namespace GitHub.Runner.Listener
                         if (string.Equals(vssOAuthEx.Error, "invalid_client", StringComparison.OrdinalIgnoreCase))
                         {
                             _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
-                            return Constants.Runner.CreateSessionResult.Failure;
+                            return CreateSessionResult.Failure;
                         }
 
                         // Check whether we get 401 because the runner registration already removed by the service.
@@ -158,7 +165,7 @@ namespace GitHub.Runner.Listener
                         if (string.Equals(authError, "invalid_client", StringComparison.OrdinalIgnoreCase))
                         {
                             _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
-                            return Constants.Runner.CreateSessionResult.Failure;
+                            return CreateSessionResult.Failure;
                         }
                     }
 
@@ -167,9 +174,9 @@ namespace GitHub.Runner.Listener
                         _term.WriteError($"Failed to create session. {ex.Message}");
                         if (ex is TaskAgentSessionConflictException)
                         {
-                            return Constants.Runner.CreateSessionResult.SessionConflict;
+                            return CreateSessionResult.SessionConflict;
                         }
-                        return Constants.Runner.CreateSessionResult.Failure;
+                        return CreateSessionResult.Failure;
                     }
 
                     if (!encounteringError) //print the message only on the first error
@@ -307,7 +314,7 @@ namespace GitHub.Runner.Listener
                     Trace.Error(ex);
 
                     // don't retry if SkipSessionRecover = true, DT service will delete agent session to stop agent from taking more jobs.
-                    if (ex is TaskAgentSessionExpiredException && !_settings.SkipSessionRecover && (await CreateSessionAsync(token) == Constants.Runner.CreateSessionResult.Success))
+                    if (ex is TaskAgentSessionExpiredException && !_settings.SkipSessionRecover && (await CreateSessionAsync(token) == CreateSessionResult.Success))
                     {
                         Trace.Info($"{nameof(TaskAgentSessionExpiredException)} received, recovered by recreate session.");
                     }

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -165,7 +165,8 @@ namespace GitHub.Runner.Listener
                     if (!IsSessionCreationExceptionRetriable(ex))
                     {
                         _term.WriteError($"Failed to create session. {ex.Message}");
-                        if (ex is TaskAgentSessionConflictException) {
+                        if (ex is TaskAgentSessionConflictException)
+                        {
                             return Constants.Runner.ReturnCode.SessionConflict;
                         }
                         return Constants.Runner.ReturnCode.TerminatedError;

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -359,12 +359,12 @@ namespace GitHub.Runner.Listener
             {
                 Trace.Info(nameof(RunAsync));
                 _listener = GetMesageListener(settings);
-                Constants.Runner.CreateSessionResult createSessionResult = await _listener.CreateSessionAsync(HostContext.RunnerShutdownToken);
-                if (createSessionResult == Constants.Runner.CreateSessionResult.SessionConflict)
+                CreateSessionResult createSessionResult = await _listener.CreateSessionAsync(HostContext.RunnerShutdownToken);
+                if (createSessionResult == CreateSessionResult.SessionConflict)
                 {
                     return Constants.Runner.ReturnCode.SessionConflict;
                 }
-                else if (createSessionResult == Constants.Runner.CreateSessionResult.Failure)
+                else if (createSessionResult == CreateSessionResult.Failure)
                 {
                     return Constants.Runner.ReturnCode.TerminatedError;
                 }

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -359,9 +359,10 @@ namespace GitHub.Runner.Listener
             {
                 Trace.Info(nameof(RunAsync));
                 _listener = GetMesageListener(settings);
-                if (!await _listener.CreateSessionAsync(HostContext.RunnerShutdownToken))
+                int returnCode = await _listener.CreateSessionAsync(HostContext.RunnerShutdownToken);
+                if (returnCode != Constants.Runner.ReturnCode.Success)
                 {
-                    return Constants.Runner.ReturnCode.TerminatedError;
+                    return returnCode;
                 }
 
                 HostContext.WritePerfCounter("SessionCreated");

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -359,10 +359,14 @@ namespace GitHub.Runner.Listener
             {
                 Trace.Info(nameof(RunAsync));
                 _listener = GetMesageListener(settings);
-                int returnCode = await _listener.CreateSessionAsync(HostContext.RunnerShutdownToken);
-                if (returnCode != Constants.Runner.ReturnCode.Success)
+                Constants.Runner.CreateSessionResult createSessionResult = await _listener.CreateSessionAsync(HostContext.RunnerShutdownToken);
+                if (createSessionResult == Constants.Runner.CreateSessionResult.SessionConflict)
                 {
-                    return returnCode;
+                    return Constants.Runner.ReturnCode.SessionConflict;
+                }
+                else if (createSessionResult == Constants.Runner.CreateSessionResult.Failure)
+                {
+                    return Constants.Runner.ReturnCode.TerminatedError;
                 }
 
                 HostContext.WritePerfCounter("SessionCreated");

--- a/src/Test/L0/Listener/BrokerMessageListenerL0.cs
+++ b/src/Test/L0/Listener/BrokerMessageListenerL0.cs
@@ -56,11 +56,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 BrokerMessageListener listener = new();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.True(result);
+                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
                 _brokerServer
                    .Verify(x => x.CreateSessionAsync(
                        It.Is<TaskAgentSession>(y => y != null),

--- a/src/Test/L0/Listener/BrokerMessageListenerL0.cs
+++ b/src/Test/L0/Listener/BrokerMessageListenerL0.cs
@@ -56,11 +56,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 BrokerMessageListener listener = new();
                 listener.Initialize(tc);
 
-                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
+                Assert.Equal(CreateSessionResult.Success, result);
                 _brokerServer
                    .Verify(x => x.CreateSessionAsync(
                        It.Is<TaskAgentSession>(y => y != null),

--- a/src/Test/L0/Listener/BrokerMessageListenerL0.cs
+++ b/src/Test/L0/Listener/BrokerMessageListenerL0.cs
@@ -56,11 +56,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 BrokerMessageListener listener = new();
                 listener.Initialize(tc);
 
-                int result = await listener.CreateSessionAsync(tokenSource.Token);
+                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
+                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
                 _brokerServer
                    .Verify(x => x.CreateSessionAsync(
                        It.Is<TaskAgentSession>(y => y != null),

--- a/src/Test/L0/Listener/MessageListenerL0.cs
+++ b/src/Test/L0/Listener/MessageListenerL0.cs
@@ -75,11 +75,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.True(result);
+                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
                         _settings.PoolId,
@@ -135,11 +135,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.True(result);
+                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
 
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
@@ -185,8 +185,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.True(result);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
 
                 _runnerServer
                     .Setup(x => x.DeleteAgentSessionAsync(
@@ -245,10 +245,10 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
-                Assert.True(result);
+                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
 
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
@@ -309,8 +309,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.True(result);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
 
                 var arMessages = new TaskAgentMessage[]
                 {
@@ -390,8 +390,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.True(result);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
 
                 var brokerMigrationMesage = new BrokerMigrationMessage(new Uri("https://actions.broker.com"));
 
@@ -497,11 +497,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.True(result);
+                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
                         _settings.PoolId,
@@ -541,8 +541,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.True(result);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
 
                 _runnerServer
                     .Setup(x => x.GetAgentMessageAsync(

--- a/src/Test/L0/Listener/MessageListenerL0.cs
+++ b/src/Test/L0/Listener/MessageListenerL0.cs
@@ -75,11 +75,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
+                Assert.Equal(CreateSessionResult.Success, result);
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
                         _settings.PoolId,
@@ -135,11 +135,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
+                Assert.Equal(CreateSessionResult.Success, result);
 
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
@@ -185,8 +185,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(CreateSessionResult.Success, result);
 
                 _runnerServer
                     .Setup(x => x.DeleteAgentSessionAsync(
@@ -245,10 +245,10 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
-                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
+                Assert.Equal(CreateSessionResult.Success, result);
 
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
@@ -309,8 +309,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(CreateSessionResult.Success, result);
 
                 var arMessages = new TaskAgentMessage[]
                 {
@@ -390,8 +390,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(CreateSessionResult.Success, result);
 
                 var brokerMigrationMesage = new BrokerMigrationMessage(new Uri("https://actions.broker.com"));
 
@@ -497,11 +497,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
+                Assert.Equal(CreateSessionResult.Success, result);
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
                         _settings.PoolId,
@@ -541,8 +541,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(CreateSessionResult.Success, result);
 
                 _runnerServer
                     .Setup(x => x.GetAgentMessageAsync(

--- a/src/Test/L0/Listener/MessageListenerL0.cs
+++ b/src/Test/L0/Listener/MessageListenerL0.cs
@@ -75,11 +75,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                int result = await listener.CreateSessionAsync(tokenSource.Token);
+                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
+                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
                         _settings.PoolId,
@@ -135,11 +135,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                int result = await listener.CreateSessionAsync(tokenSource.Token);
+                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
+                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
 
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
@@ -185,8 +185,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                int result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
+                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
 
                 _runnerServer
                     .Setup(x => x.DeleteAgentSessionAsync(
@@ -245,10 +245,10 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                int result = await listener.CreateSessionAsync(tokenSource.Token);
+                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
-                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
+                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
 
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
@@ -309,8 +309,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                int result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
+                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
 
                 var arMessages = new TaskAgentMessage[]
                 {
@@ -390,8 +390,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                int result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
+                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
 
                 var brokerMigrationMesage = new BrokerMigrationMessage(new Uri("https://actions.broker.com"));
 
@@ -497,11 +497,11 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                int result = await listener.CreateSessionAsync(tokenSource.Token);
+                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
+                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
                 _runnerServer
                     .Verify(x => x.CreateAgentSessionAsync(
                         _settings.PoolId,
@@ -541,8 +541,8 @@ namespace GitHub.Runner.Common.Tests.Listener
                 MessageListener listener = new();
                 listener.Initialize(tc);
 
-                int result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.Equal(Constants.Runner.ReturnCode.Success, result);
+                Constants.Runner.CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(Constants.Runner.CreateSessionResult.Success, result);
 
                 _runnerServer
                     .Setup(x => x.GetAgentMessageAsync(

--- a/src/Test/L0/Listener/RunnerL0.cs
+++ b/src/Test/L0/Listener/RunnerL0.cs
@@ -88,7 +88,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.Success));
+                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -184,7 +184,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configStore.Setup(x => x.IsServiceConfigured()).Returns(configureAsService);
 
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.TerminatedError));
+                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Failure));
 
                 var runner = new Runner.Listener.Runner();
                 runner.Initialize(hc);
@@ -217,7 +217,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                     .Returns(false);
 
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.TerminatedError));
+                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Failure));
 
                 var runner = new Runner.Listener.Runner();
                 runner.Initialize(hc);
@@ -263,7 +263,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.Success));
+                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -363,7 +363,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.Success));
+                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -458,7 +458,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.Success));
+                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {

--- a/src/Test/L0/Listener/RunnerL0.cs
+++ b/src/Test/L0/Listener/RunnerL0.cs
@@ -88,7 +88,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<bool>(true));
+                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -184,7 +184,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configStore.Setup(x => x.IsServiceConfigured()).Returns(configureAsService);
 
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(false));
+                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.TerminatedError));
 
                 var runner = new Runner.Listener.Runner();
                 runner.Initialize(hc);
@@ -217,7 +217,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                     .Returns(false);
 
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(false));
+                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.TerminatedError));
 
                 var runner = new Runner.Listener.Runner();
                 runner.Initialize(hc);
@@ -263,7 +263,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<bool>(true));
+                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -363,7 +363,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<bool>(true));
+                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -458,7 +458,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<bool>(true));
+                    .Returns(Task.FromResult<int>(Constants.Runner.ReturnCode.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {

--- a/src/Test/L0/Listener/RunnerL0.cs
+++ b/src/Test/L0/Listener/RunnerL0.cs
@@ -88,7 +88,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Success));
+                    .Returns(Task.FromResult<CreateSessionResult>(CreateSessionResult.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -184,7 +184,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configStore.Setup(x => x.IsServiceConfigured()).Returns(configureAsService);
 
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Failure));
+                    .Returns(Task.FromResult<CreateSessionResult>(CreateSessionResult.Failure));
 
                 var runner = new Runner.Listener.Runner();
                 runner.Initialize(hc);
@@ -217,7 +217,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                     .Returns(false);
 
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Failure));
+                    .Returns(Task.FromResult<CreateSessionResult>(CreateSessionResult.Failure));
 
                 var runner = new Runner.Listener.Runner();
                 runner.Initialize(hc);
@@ -263,7 +263,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Success));
+                    .Returns(Task.FromResult<CreateSessionResult>(CreateSessionResult.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -363,7 +363,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Success));
+                    .Returns(Task.FromResult<CreateSessionResult>(CreateSessionResult.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -458,7 +458,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<Constants.Runner.CreateSessionResult>(Constants.Runner.CreateSessionResult.Success));
+                    .Returns(Task.FromResult<CreateSessionResult>(CreateSessionResult.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {


### PR DESCRIPTION
Bubbles up a new return code `SessionConflict` to allow hosted compute to handle this case differently than other failures.