### PR TITLE
Load '_runnerSettings' in the early point of JobRunner.cs

### DIFF
--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -42,6 +42,7 @@ namespace GitHub.Runner.Worker
             Trace.Info("Job ID {0}", message.JobId);
 
             DateTime jobStartTimeUtc = DateTime.UtcNow;
+            _runnerSettings = HostContext.GetService<IConfigurationStore>().GetSettings();
             IRunnerService server = null;
 
             // add orchestration id to useragent for better correlation.
@@ -164,8 +165,6 @@ namespace GitHub.Runner.Worker
 
                 jobContext.SetRunnerContext("os", VarUtil.OS);
                 jobContext.SetRunnerContext("arch", VarUtil.OSArchitecture);
-
-                _runnerSettings = HostContext.GetService<IConfigurationStore>().GetSettings();
                 jobContext.SetRunnerContext("name", _runnerSettings.AgentName);
 
                 if (jobContext.Global.Variables.TryGetValue(WellKnownDistributedTaskVariables.RunnerEnvironment, out var runnerEnvironment))


### PR DESCRIPTION
```
[2024-03-23 15:40:39Z ERR  Worker] System.NullReferenceException: Object reference not set to an instance of an object.
   at GitHub.Runner.Worker.JobRunner.CompleteJobAsync(IJobServer jobServer, IExecutionContext jobContext, AgentJobRequestMessage message, Nullable`1 taskResult) in /Users/tingluohuang/repo/runner/src/Runner.Worker/JobRunner.cs:line 359
   at GitHub.Runner.Worker.JobRunner.CompleteJobAsync(IRunnerService server, IExecutionContext jobContext, AgentJobRequestMessage message, Nullable`1 taskResult) in /Users/tingluohuang/repo/runner/src/Runner.Worker/JobRunner.cs:line 281
   at GitHub.Runner.Worker.JobRunner.RunAsync(AgentJobRequestMessage message, CancellationToken jobRequestCancellationToken) in /Users/tingluohuang/repo/runner/src/Runner.Worker/JobRunner.cs:line 161
   at GitHub.Runner.Worker.JobRunner.RunAsync(AgentJobRequestMessage message, CancellationToken jobRequestCancellationToken) in /Users/tingluohuang/repo/runner/src/Runner.Worker/JobRunner.cs:line 270
   at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut) in /Users/tingluohuang/repo/runner/src/Runner.Worker/Worker.cs:line 108
   at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args) in /Users/tingluohuang/repo/runner/src/Runner.Worker/Program.cs:line 50

```