### PR TITLE
backoff if we retried polling for more than 50 times in less than 30m…

### DIFF
--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -361,15 +361,6 @@ namespace GitHub.Runner.Listener
                 if (message == null)
                 {
                     continuousEmptyMessage++;
-                    if (continuousEmptyMessage > 50)
-                    {
-                        // retried more than 50 times in less than 30mins and still getting empty message
-                        // something is not right on the service side, backoff for 15-30s before retry
-                        _getNextMessageRetryInterval = BackoffTimerHelper.GetRandomBackoff(TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(30), _getNextMessageRetryInterval);
-                        Trace.Info("Sleeping for {0} seconds before retrying.", _getNextMessageRetryInterval.TotalSeconds);
-                        await HostContext.Delay(_getNextMessageRetryInterval, token);
-                    }
-
                     if (heartbeat.Elapsed > TimeSpan.FromMinutes(30))
                     {
                         Trace.Info($"No message retrieved from session '{_session.SessionId}' within last 30 minutes.");
@@ -379,6 +370,15 @@ namespace GitHub.Runner.Listener
                     else
                     {
                         Trace.Verbose($"No message retrieved from session '{_session.SessionId}'.");
+                    }
+                    
+                    if (continuousEmptyMessage > 50)
+                    {
+                        // retried more than 50 times in less than 30mins and still getting empty message
+                        // something is not right on the service side, backoff for 15-30s before retry
+                        _getNextMessageRetryInterval = BackoffTimerHelper.GetRandomBackoff(TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(30), _getNextMessageRetryInterval);
+                        Trace.Info("Sleeping for {0} seconds before retrying.", _getNextMessageRetryInterval.TotalSeconds);
+                        await HostContext.Delay(_getNextMessageRetryInterval, token);
                     }
 
                     continue;

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -371,7 +371,7 @@ namespace GitHub.Runner.Listener
                     {
                         Trace.Verbose($"No message retrieved from session '{_session.SessionId}'.");
                     }
-                    
+
                     if (continuousEmptyMessage > 50)
                     {
                         // retried more than 50 times in less than 30mins and still getting empty message


### PR DESCRIPTION
…inutes

We should not really be making more than 40 long polls in 30mins so backoff if we tried more than 50 times. This is a temporary fix until we figure out why message queue cancellation doesn't always work.