### PR TITLE
Bump node 20 to v20.12.2

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -6,7 +6,7 @@ NODE_URL=https://nodejs.org/dist
 UNOFFICIAL_NODE_URL=https://unofficial-builds.nodejs.org/download/release
 NODE_ALPINE_URL=https://github.com/actions/alpine_nodejs/releases/download
 NODE16_VERSION="16.20.2"
-NODE20_VERSION="20.8.1"
+NODE20_VERSION="20.12.2"
 # used only for win-arm64, remove node16 unofficial version when official version is available
 NODE16_UNOFFICIAL_VERSION="16.20.0"
 


### PR DESCRIPTION
Node v20.8.1 has a number of security vulnerabilities. Bumping node 20 to the latest release to address all fixes.

https://nodejs.org/en/blog/release/v20.12.2