### PR TITLE
Make it easy to install `git` on an Action Runner Image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -39,11 +39,13 @@ ENV RUNNER_MANUALLY_TRAP_SIG=1
 ENV ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1
 ENV ImageOS=ubuntu22
 
-RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends \
-    sudo \
-    lsb-release \
+RUN apt update -y \
+    && apt install -y --no-install-recommends sudo lsb-release software-properties-common \
     && rm -rf /var/lib/apt/lists/*
+
+# Configure git-core/ppa based on guidance here:  https://git-scm.com/download/linux
+RUN add-apt-repository ppa:git-core/ppa \
+    && apt update -y
 
 RUN adduser --disabled-password --gecos "" --uid 1001 runner \
     && groupadd docker --gid 123 \


### PR DESCRIPTION
The version of `git` (`v2.34.1`) associated with `ubuntu:jammy` is quite old at this point.  Calling `apt update` out-of-the-box won't cause any newer version to be discovered.

This change allows users of the actions/runner container image to easily install more modern versions of git (e.g. `v2.43.0`) should they desire.

Note that we don't actually install `git`.  We simply get the prerequisites out of the way.

## Related Issues
- https://github.com/actions/checkout/issues/1708