### PR TITLE
Expose job name as env var

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -868,11 +868,16 @@ namespace GitHub.Runner.Worker
             var base64EncodedToken = Convert.ToBase64String(Encoding.UTF8.GetBytes($"x-access-token:{githubAccessToken}"));
             HostContext.SecretMasker.AddValue(base64EncodedToken);
             var githubJob = Global.Variables.Get("system.github.job");
+            var githubJobName = Global.Variables.Get("system.jobDisplayName");
             var githubContext = new GitHubContext();
             githubContext["token"] = githubAccessToken;
             if (!string.IsNullOrEmpty(githubJob))
             {
                 githubContext["job"] = new StringContextData(githubJob);
+            }
+            if (!string.IsNullOrEmpty(githubJobName))
+            {
+                githubContext["job_name"] = new StringContextData(githubJobName);
             }
             var githubDictionary = ExpressionValues["github"].AssertDictionary("github");
             foreach (var pair in githubDictionary)

--- a/src/Runner.Worker/GitHubContext.cs
+++ b/src/Runner.Worker/GitHubContext.cs
@@ -22,6 +22,7 @@ namespace GitHub.Runner.Worker
             "graphql_url",
             "head_ref",
             "job",
+            "job_name",
             "output",
             "path",
             "ref_name",


### PR DESCRIPTION
This PR exposes the job display name as an environment variable. The job display name is exposed in webhooks as `name`([docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_job)) so having it as an environment variable allows correlating data between the webhooks and processes that run in the runner.

This change would be specifically useful to improve Datadog's CI Visibility integration with GitHub Actions, where we currently require users to manually expose the job name as a variable for the integration to fully work ([docs](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_measures/?tab=linux#add-tags-and-measures-to-github-jobs)).

If this change is acceptable for the runner team, I am also happy to open a PR to update the documentation around default environment variables ([docs](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)).