### PR TITLE
Install `gpg-agent` during actions/runner container image build

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -39,8 +39,9 @@ ENV RUNNER_MANUALLY_TRAP_SIG=1
 ENV ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1
 ENV ImageOS=ubuntu22
 
+# 'gpg-agent' and 'software-properties-common' are needed for the 'add-apt-repository' command that follows
 RUN apt update -y \
-    && apt install -y --no-install-recommends sudo lsb-release software-properties-common \
+    && apt install -y --no-install-recommends sudo lsb-release gpg-agent software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure git-core/ppa based on guidance here:  https://git-scm.com/download/linux


### PR DESCRIPTION
`add-apt-repository` depends on `gpg-agent`