### PR TITLE
Forego implicit and explicit `apt update` during `add-apt-repository`invocation.

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -45,8 +45,7 @@ RUN apt update -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure git-core/ppa based on guidance here:  https://git-scm.com/download/linux
-RUN add-apt-repository ppa:git-core/ppa \
-    && apt update -y
+RUN add-apt-repository -y --no-update ppa:git-core/ppa
 
 RUN adduser --disabled-password --gecos "" --uid 1001 runner \
     && groupadd docker --gid 123 \


### PR DESCRIPTION

This will save a significant amount of space in the generated image.

Users should run `apt update` if needed prior to any `apt install`