### PR TITLE
Add new libicu versions for Ubuntu 24.04 (74) and debian experimental (73,75)

### DIFF
--- a/docs/start/envlinux.md
+++ b/docs/start/envlinux.md
@@ -15,16 +15,16 @@ x64
   - openSUSE 15+
   - SUSE Enterprise Linux (SLES) 12 SP2+
 
-## Install .Net Core 3.x Linux Dependencies
+## Install .NET 6.x Linux Dependencies
 
-The `./config.sh` will check .Net Core 3.x dependencies during runner configuration.  
+The `./config.sh` will check .NET 6.x dependencies during runner configuration.  
 You might see something like this which indicate a dependency's missing.
 ```bash
 ./config.sh
     libunwind.so.8 => not found
     libunwind-x86_64.so.8 => not found
-Dependencies is missing for Dotnet Core 6.0
-Execute ./bin/installdependencies.sh to install any missing Dotnet Core 6.0 dependencies.
+Dependencies are missing for .NET 6.0
+Execute ./bin/installdependencies.sh to install any missing .NET 6.0 dependencies.
 ```
 You can easily correct the problem by executing `./bin/installdependencies.sh`.  
 The `installdependencies.sh` script should install all required dependencies on all supported Linux versions  
@@ -38,7 +38,7 @@ Debian based OS (Debian, Ubuntu, Linux Mint)
 - libkrb5-3
 - zlib1g
 - libssl1.1, libssl1.0.2 or libssl1.0.0
-- libicu63, libicu60, libicu57 or libicu55
+- libicu75, libicu74, libicu73, libicu72, libicu71, libicu70, libicu69, libicu68, libicu67, libicu66, libicu65, libicu63, libicu60, libicu57, libicu55, libicu52
 
 Fedora based OS (Fedora, Red Hat Enterprise Linux, CentOS, Oracle Linux 7)
 

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -110,7 +110,7 @@ then
             exit 1
         fi
 
-        apt_get_with_fallbacks libicu72 libicu71 libicu70 libicu69 libicu68 libicu67 libicu66 libicu65 libicu63 libicu60 libicu57 libicu55 libicu52
+        apt_get_with_fallbacks libicu75 libicu74 libicu73 libicu72 libicu71 libicu70 libicu69 libicu68 libicu67 libicu66 libicu65 libicu63 libicu60 libicu57 libicu55 libicu52
         if [ $? -ne 0 ]
         then
             echo "'$apt_get' failed with exit code '$?'"

--- a/src/Misc/layoutroot/config.sh
+++ b/src/Misc/layoutroot/config.sh
@@ -8,7 +8,7 @@ if [ $user_id -eq 0 -a -z "$RUNNER_ALLOW_RUNASROOT" ]; then
     exit 1
 fi
 
-# Check dotnet Core 6.0 dependencies for Linux
+# Check .NET 6.0 dependencies for Linux
 if [[ (`uname` == "Linux") ]]
 then
     command -v ldd > /dev/null
@@ -18,25 +18,25 @@ then
         exit 1
     fi
 
-    message="Execute sudo ./bin/installdependencies.sh to install any missing Dotnet Core 6.0 dependencies."
+    message="Execute sudo ./bin/installdependencies.sh to install any missing .NET 6.0 dependencies."
 
     ldd ./bin/libcoreclr.so | grep 'not found'
     if [ $? -eq 0 ]; then
-        echo "Dependencies is missing for Dotnet Core 6.0"
+        echo "Dependencies are missing for .NET 6.0"
         echo $message
         exit 1
     fi
 
     ldd ./bin/libSystem.Security.Cryptography.Native.OpenSsl.so | grep 'not found'
     if [ $? -eq 0 ]; then
-        echo "Dependencies is missing for Dotnet Core 6.0"
+        echo "Dependencies are missing for .NET 6.0"
         echo $message
         exit 1
     fi
 
     ldd ./bin/libSystem.IO.Compression.Native.so | grep 'not found'
     if [ $? -eq 0 ]; then
-        echo "Dependencies is missing for Dotnet Core 6.0"
+        echo "Dependencies are missing for .NET 6.0"
         echo $message
         exit 1
     fi
@@ -54,7 +54,7 @@ then
     libpath=${LD_LIBRARY_PATH:-}
     $LDCONFIG_COMMAND -NXv ${libpath//:/ } 2>&1 | grep libicu >/dev/null 2>&1
     if [ $? -ne 0 ]; then
-        echo "Libicu's dependencies is missing for Dotnet Core 6.0"
+        echo "Libicu's dependencies are missing for .NET 6.0"
         echo $message
         exit 1
     fi


### PR DESCRIPTION
libicu74 is in fact supported for 24.04: https://github.com/dotnet/core/blob/main/release-notes/6.0/linux-packages.md#ubuntu-2404-noble

Also update some of the documentation to reflect these changes and the changes to the .NET name.

Arguably this should just use the official .deb packages from Microsoft for the SDK on any modern Ubuntu version and all others that they support native packing for.