### PR TITLE
Pass runner version as environment variable in workflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -25,10 +25,12 @@ jobs:
       - name: Compute image version
         id: image
         uses: actions/github-script@v6
+        env:
+          RUNNER_VERSION: ${{ github.event.inputs.runnerVersion }}
         with:
           script: |
             const fs = require('fs');
-            const inputRunnerVersion = "${{ github.event.inputs.runnerVersion }}"
+            const inputRunnerVersion = process.env.RUNNER_VERSION;
             if (inputRunnerVersion) {
               console.log(`Using input runner version ${inputRunnerVersion}`)
               core.setOutput('version', inputRunnerVersion);


### PR DESCRIPTION
It's recommended to pass expressions into `actions/github-script` via `env` - this avoids issues with special characters or other syntax that could be interpreted as JavaScript.

https://github.com/actions/github-script#use-env-as-input

This also serves to avoid any potential script injections - https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable