### PR TITLE
Update example command

### DIFF
--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -723,7 +723,7 @@ Config Options:
             _term.WriteLine($@"
 Examples:
  Check GitHub server network connectivity:
-  .{separator}run.{ext} --check --url <url> --pat <pat>
+  .{separator}config.{ext} --check --url <url> --pat <pat>
  Configure a runner non-interactively:
   .{separator}config.{ext} --unattended --url <url> --token <token>
  Configure a runner non-interactively, replacing any existing runner with the same name:


### PR DESCRIPTION
When running the check as per the example you get the following error in the output

```
[RUNNER 2024-05-29 07:46:16Z ERR  Terminal] WRITE ERROR: Unrecognized command-line input arguments for command run: 'url, pat'. For usage refer to: .\config.cmd --help or ./config.sh --help
Unrecognized command-line input arguments for command run: 'url, pat'. For usage refer to: .\config.cmd --help or ./config.sh --help
```

The command still works as expected but the error is confusing.