### PR TITLE
Make Settings.IsHostedServer value consistent with UrlUtil.IsHostedServer

### DIFF
--- a/src/Runner.Common/ConfigurationStore.cs
+++ b/src/Runner.Common/ConfigurationStore.cs
@@ -62,7 +62,16 @@ namespace GitHub.Runner.Common
             get
             {
                 // Old runners do not have this property. Hosted runners likely don't have this property either.
-                return _isHostedServer ?? true;
+                if (_isHostedServer != null) {
+                    return (bool)_isHostedServer;
+                }
+
+                // GHES JIT config API does not set this property either, so we need to auto-detect it.
+                if (GitHubUrl != null) {
+                    return UrlUtil.IsHostedServer(new UriBuilder(GitHubUrl));
+                }
+
+                return true;
             }
 
             set


### PR DESCRIPTION
When running GitHub Enterprise Server with a pool of JIT-configured runners (such as what [philips-labs/terraform-aws-github-runner](https://github.com/philips-labs/terraform-aws-github-runner/) provides), #1199 still occurs. The fix in #1291 uses the "IsHostedServer" property from the settings which is **not** set by the GHES endpoint for JIT configuration.

This change computes the default value of IsHostedServer from the GitHub server URL, as is already done in [lots of other parts of the code](https://github.com/search?q=repo%3Aactions%2Frunner%20IsHostedServer&type=code) to make it consistent.