### PR TITLE
Configure dependabot to check github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: "daily" 
   target-branch: "main" 
 - package-ecosystem: "github-actions"
-  directory: ".github"
+  directory: "/.github"
   schedule:
     interval: "daily" 
   target-branch: "main" 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
   schedule:
     interval: "daily" 
   target-branch: "main" 
+- package-ecosystem: "github-actions"
+  directory: ".github"
+  schedule:
+    interval: "daily" 
+  target-branch: "main" 
 - package-ecosystem: "nuget"
   directory: "/src"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: "daily" 
   target-branch: "main" 
 - package-ecosystem: "github-actions"
-  directory: "/.github/workflows"
+  directory: "/"
   schedule:
     interval: "daily" 
   target-branch: "main" 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: "daily" 
   target-branch: "main" 
 - package-ecosystem: "github-actions"
-  directory: "/.github"
+  directory: "/.github/workflows"
   schedule:
     interval: "daily" 
   target-branch: "main" 


### PR DESCRIPTION
Some actions based on Node 16 are deprecated.

See 
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions