### PR TITLE
Receive error body from Run Service

### DIFF
--- a/src/Sdk/DTWebApi/WebApi/Exceptions.cs
+++ b/src/Sdk/DTWebApi/WebApi/Exceptions.cs
@@ -1540,6 +1540,26 @@ namespace GitHub.DistributedTask.WebApi
     }
 
     [Serializable]
+    [ExceptionMapping("0.0", "3.0", "TaskOrchestrationJobUnprocessableException", "GitHub.DistributedTask.WebApi.TaskOrchestrationJobUnprocessableException, GitHub.DistributedTask.WebApi, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+    public sealed class TaskOrchestrationJobUnprocessableException : DistributedTaskException
+    {
+        public TaskOrchestrationJobUnprocessableException(String message)
+            : base(message)
+        {
+        }
+
+        public TaskOrchestrationJobUnprocessableException(String message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        private TaskOrchestrationJobUnprocessableException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
     [ExceptionMapping("0.0", "3.0", "TaskOrchestrationPlanSecurityException", "GitHub.DistributedTask.WebApi.TaskOrchestrationPlanSecurityException, GitHub.DistributedTask.WebApi, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public sealed class TaskOrchestrationPlanSecurityException : DistributedTaskException
     {

--- a/src/Sdk/RSWebApi/Contracts/RunServiceError.cs
+++ b/src/Sdk/RSWebApi/Contracts/RunServiceError.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.Serialization;
+
+namespace GitHub.Actions.RunService.WebApi
+{
+    [DataContract]
+    public class RunServiceError
+    {
+        [DataMember(Name = "source", EmitDefaultValue = false)]
+        public string Source { get; set; }
+
+        [DataMember(Name = "statusCode", EmitDefaultValue = false)]
+        public int Code { get; set; }
+
+        [DataMember(Name = "errorMessage", EmitDefaultValue = false)]
+        public string Message { get; set; }
+    }
+}

--- a/src/Sdk/RSWebApi/RunServiceHttpClient.cs
+++ b/src/Sdk/RSWebApi/RunServiceHttpClient.cs
@@ -86,6 +86,7 @@ namespace GitHub.Actions.RunService.WebApi
                 httpMethod,
                 requestUri: requestUri,
                 content: requestContent,
+                readErrorBody: true,
                 cancellationToken: cancellationToken);
 
             if (result.IsSuccess)
@@ -93,14 +94,35 @@ namespace GitHub.Actions.RunService.WebApi
                 return result.Value;
             }
 
+            if (TryParseErrorBody(result.ErrorBody, out RunServiceError error))
+            {
+                switch ((HttpStatusCode)error.Code)
+                {
+                    case HttpStatusCode.NotFound:
+                        throw new TaskOrchestrationJobNotFoundException($"Job message not found '{messageId}'. {error.Message}");
+                    case HttpStatusCode.Conflict:
+                        throw new TaskOrchestrationJobAlreadyAcquiredException($"Job message already acquired '{messageId}'. {error.Message}");
+                    case HttpStatusCode.UnprocessableEntity:
+                        throw new TaskOrchestrationJobUnprocessableException($"Unprocessable job '{messageId}'. {error.Message}");
+                }
+            }
+
+            // Temporary back compat
             switch (result.StatusCode)
             {
                 case HttpStatusCode.NotFound:
                     throw new TaskOrchestrationJobNotFoundException($"Job message not found: {messageId}");
                 case HttpStatusCode.Conflict:
                     throw new TaskOrchestrationJobAlreadyAcquiredException($"Job message already acquired: {messageId}");
-                default:
-                    throw new Exception($"Failed to get job message: {result.Error}");
+            }
+
+            if (!string.IsNullOrEmpty(result.ErrorBody))
+            {
+                throw new Exception($"Failed to get job message: {result.Error}. {Truncate(result.ErrorBody)}");
+            }
+            else
+            {
+                throw new Exception($"Failed to get job message: {result.Error}");
             }
         }
 
@@ -108,7 +130,7 @@ namespace GitHub.Actions.RunService.WebApi
             Uri requestUri,
             Guid planId,
             Guid jobId,
-            TaskResult result,
+            TaskResult conclusion,
             Dictionary<String, VariableValue> outputs,
             IList<StepResult> stepResults,
             IList<Annotation> jobAnnotations,
@@ -120,7 +142,7 @@ namespace GitHub.Actions.RunService.WebApi
             {
                 PlanID = planId,
                 JobID = jobId,
-                Conclusion = result,
+                Conclusion = conclusion,
                 Outputs = outputs,
                 StepResults = stepResults,
                 Annotations = jobAnnotations,
@@ -130,22 +152,39 @@ namespace GitHub.Actions.RunService.WebApi
             requestUri = new Uri(requestUri, "completejob");
 
             var requestContent = new ObjectContent<CompleteJobRequest>(payload, new VssJsonMediaTypeFormatter(true));
-            var response = await SendAsync(
+            var result = await Send2Async(
                     httpMethod,
                     requestUri,
                     content: requestContent,
                     cancellationToken: cancellationToken);
-            if (response.IsSuccessStatusCode)
+            if (result.IsSuccess)
             {
                 return;
             }
 
-            switch (response.StatusCode)
+            if (TryParseErrorBody(result.ErrorBody, out RunServiceError error))
+            {
+                switch ((HttpStatusCode)error.Code)
+                {
+                    case HttpStatusCode.NotFound:
+                        throw new TaskOrchestrationJobNotFoundException($"Job not found: {jobId}. {error.Message}");
+                }
+            }
+
+            // Temporary back compat
+            switch (result.StatusCode)
             {
                 case HttpStatusCode.NotFound:
                     throw new TaskOrchestrationJobNotFoundException($"Job not found: {jobId}");
-                default:
-                    throw new Exception($"Failed to complete job: {response.ReasonPhrase}");
+            }
+
+            if (!string.IsNullOrEmpty(result.ErrorBody))
+            {
+                throw new Exception($"Failed to complete job: {result.Error}. {Truncate(result.ErrorBody)}");
+            }
+            else
+            {
+                throw new Exception($"Failed to complete job: {result.Error}");
             }
         }
 
@@ -169,6 +208,7 @@ namespace GitHub.Actions.RunService.WebApi
                 httpMethod,
                 requestUri,
                 content: requestContent,
+                readErrorBody: true,
                 cancellationToken: cancellationToken);
 
             if (result.IsSuccess)
@@ -176,12 +216,29 @@ namespace GitHub.Actions.RunService.WebApi
                 return result.Value;
             }
 
+            if (TryParseErrorBody(result.ErrorBody, out RunServiceError error))
+            {
+                switch ((HttpStatusCode)error.Code)
+                {
+                    case HttpStatusCode.NotFound:
+                        throw new TaskOrchestrationJobNotFoundException($"Job not found: {jobId}. {error.Message}");
+                }
+            }
+
+            // Temporary back compat
             switch (result.StatusCode)
             {
                 case HttpStatusCode.NotFound:
                     throw new TaskOrchestrationJobNotFoundException($"Job not found: {jobId}");
-                default:
-                    throw new Exception($"Failed to renew job: {result.Error}");
+            }
+
+            if (!string.IsNullOrEmpty(result.ErrorBody))
+            {
+                throw new Exception($"Failed to renew job: {result.Error}. {Truncate(result.ErrorBody)}");
+            }
+            else
+            {
+                throw new Exception($"Failed to renew job: {result.Error}");
             }
         }
 
@@ -189,6 +246,37 @@ namespace GitHub.Actions.RunService.WebApi
         {
             var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             return JsonConvert.DeserializeObject<T>(json, s_serializerSettings);
+        }
+
+        private static bool TryParseErrorBody(string errorBody, out RunServiceError error)
+        {
+            if (!string.IsNullOrEmpty(errorBody))
+            {
+                try
+                {
+                    error = JsonUtility.FromString<RunServiceError>(errorBody);
+                    if (error?.Source == "actions-run-service")
+                    {
+                        return true;
+                    }
+                }
+                catch (Exception)
+                {
+                }
+            }
+
+            error = null;
+            return false;
+        }
+
+        private static string Truncate(string errorBody)
+        {
+            if (errorBody.Length > 100)
+            {
+                return errorBody.Substring(0, 100) + "[truncated]";
+            }
+
+            return errorBody;
         }
     }
 }

--- a/src/Sdk/WebApi/WebApi/RawHttpClientResult.cs
+++ b/src/Sdk/WebApi/WebApi/RawHttpClientResult.cs
@@ -5,15 +5,27 @@ namespace Sdk.WebApi.WebApi
     public class RawHttpClientResult
     {
         public bool IsSuccess { get; protected set; }
+
+        /// <summary>
+        /// A description of the HTTP status code, like "Error: Unprocessable Entity"
+        /// </summary>
         public string Error { get; protected set; }
+
+        /// <summary>
+        /// The HTTP response body for unsuccessful HTTP status codes, or an error message when reading the response body fails.
+        /// </summary>
+        public string ErrorBody { get; protected set; }
+
         public HttpStatusCode StatusCode { get; protected set; }
+
         public bool IsFailure => !IsSuccess;
 
-        protected RawHttpClientResult(bool isSuccess, string error, HttpStatusCode statusCode)
+        public RawHttpClientResult(bool isSuccess, string error, HttpStatusCode statusCode, string errorBody = null)
         {
             IsSuccess = isSuccess;
             Error = error;
             StatusCode = statusCode;
+            ErrorBody = errorBody;
         }
     }
 
@@ -21,13 +33,13 @@ namespace Sdk.WebApi.WebApi
     {
         public T Value { get; private set; }
 
-        protected internal RawHttpClientResult(T value, bool isSuccess, string error, HttpStatusCode statusCode)
-            : base(isSuccess, error, statusCode)
+        protected internal RawHttpClientResult(T value, bool isSuccess, string error, HttpStatusCode statusCode, string errorBody)
+            : base(isSuccess, error, statusCode, errorBody)
         {
             Value = value;
         }
 
-        public static RawHttpClientResult<T> Fail(string message, HttpStatusCode statusCode) => new RawHttpClientResult<T>(default(T), false, message, statusCode);
-        public static RawHttpClientResult<T> Ok(T value) => new RawHttpClientResult<T>(value, true, string.Empty, HttpStatusCode.OK);
+        public static RawHttpClientResult<T> Fail(string message, HttpStatusCode statusCode, string errorBody) => new RawHttpClientResult<T>(default(T), false, message, statusCode, errorBody);
+        public static RawHttpClientResult<T> Ok(T value) => new RawHttpClientResult<T>(value, true, string.Empty, HttpStatusCode.OK, null);
     }
 }


### PR DESCRIPTION
Receive error body from Run Service so we can distinguish responses from proxies/etc

On an E2E Codespace, I tested an error response from each affected REST API (acquire job, complete job, renew job)