### PR TITLE
Fix typo

### DIFF
--- a/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateReader.cs
+++ b/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateReader.cs
@@ -586,7 +586,7 @@ namespace GitHub.DistributedTask.ObjectTemplating
                 return new StringToken(m_fileId, token.Line, token.Column, str);
             }
 
-            // Check if only ony segment
+            // Check if only one segment
             if (segments.Count == 1)
             {
                 return segments[0];


### PR DESCRIPTION
Maybe typo in comment. `only ony segment` → `only one segment `