### PR TITLE
Run script handlers with `ACTIONS_*` environment variables

### DIFF
--- a/src/Runner.Worker/Handlers/ScriptHandler.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandler.cs
@@ -311,11 +311,26 @@ namespace GitHub.Runner.Worker.Handlers
                 fileName = node;
             }
 #endif
+            // Add Actions Runtime server info
             var systemConnection = ExecutionContext.Global.Endpoints.Single(x => string.Equals(x.Name, WellKnownServiceEndpointNames.SystemVssConnection, StringComparison.OrdinalIgnoreCase));
+            Environment["ACTIONS_RUNTIME_URL"] = systemConnection.Url.AbsoluteUri;
+            Environment["ACTIONS_RUNTIME_TOKEN"] = systemConnection.Authorization.Parameters[EndpointAuthorizationParameters.AccessToken];
+            if (systemConnection.Data.TryGetValue("CacheServerUrl", out var cacheUrl) && !string.IsNullOrEmpty(cacheUrl))
+            {
+                Environment["ACTIONS_CACHE_URL"] = cacheUrl;
+            }
+            if (systemConnection.Data.TryGetValue("PipelinesServiceUrl", out var pipelinesServiceUrl) && !string.IsNullOrEmpty(pipelinesServiceUrl))
+            {
+                Environment["ACTIONS_RUNTIME_URL"] = pipelinesServiceUrl;
+            }
             if (systemConnection.Data.TryGetValue("GenerateIdTokenUrl", out var generateIdTokenUrl) && !string.IsNullOrEmpty(generateIdTokenUrl))
             {
                 Environment["ACTIONS_ID_TOKEN_REQUEST_URL"] = generateIdTokenUrl;
                 Environment["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = systemConnection.Authorization.Parameters[EndpointAuthorizationParameters.AccessToken];
+            }
+            if (systemConnection.Data.TryGetValue("ResultsServiceUrl", out var resultsUrl) && !string.IsNullOrEmpty(resultsUrl))
+            {
+                Environment["ACTIONS_RESULTS_URL"] = resultsUrl;
             }
 
             ExecutionContext.Debug($"{fileName} {arguments}");


### PR DESCRIPTION
Refs https://github.com/actions/runner/issues/3046.

This runs script steps with `ACTIONS_*` environment variables in exactly the same way they are passed to Docker and Node steps.

By doing so, this reduces the need for steps like [crazy-max/ghaction-github-runtime](https://github.com/crazy-max/ghaction-github-runtime) when programmatically consuming cache APIs (for example via [tonistiigi/go-actions-cache](https://pkg.go.dev/github.com/tonistiigi/go-actions-cache)).

Test workflow:
```yaml
on:
  workflow_dispatch:

jobs:
  main:
    runs-on: self-hosted
    steps:
      - run: env | grep ACTION
```

Before this change:
```
2024-07-15T16:22:56.0537770Z Complete job name: main
2024-07-15T16:22:56.0976680Z ##[group]Run env | grep ACTION
2024-07-15T16:22:56.0977140Z [36;1menv | grep ACTION[0m
2024-07-15T16:22:56.1109490Z shell: /opt/homebrew/bin/bash -e {0}
2024-07-15T16:22:56.1110200Z ##[endgroup]
2024-07-15T16:22:56.1625900Z GITHUB_ACTION=__run
2024-07-15T16:22:56.1626460Z GITHUB_ACTIONS=true
2024-07-15T16:22:56.1626900Z GITHUB_ACTION_REPOSITORY=
2024-07-15T16:22:56.1627290Z GITHUB_ACTION_REF=
2024-07-15T16:22:56.1692500Z Cleaning up orphan processes
```

After this change:
```
2024-07-15T16:19:49.4702740Z Complete job name: main
2024-07-15T16:19:49.5223750Z ##[group]Run env | grep ACTION
2024-07-15T16:19:49.5224190Z [36;1menv | grep ACTION[0m
2024-07-15T16:19:49.5284960Z shell: /opt/homebrew/bin/bash -e {0}
2024-07-15T16:19:49.5285720Z ##[endgroup]
2024-07-15T16:19:49.5671290Z GITHUB_ACTION=__run
2024-07-15T16:19:49.5672240Z ACTIONS_CACHE_URL=https://acghubeus1.actions.githubusercontent.com/***/
2024-07-15T16:19:49.5672970Z GITHUB_ACTIONS=true
2024-07-15T16:19:49.5673720Z ACTIONS_RUNTIME_URL=https://pipelinesghubeus8.actions.githubusercontent.com/***/
2024-07-15T16:19:49.5674680Z ACTIONS_RESULTS_URL=https://results-receiver.actions.githubusercontent.com/
2024-07-15T16:19:49.5699210Z ACTIONS_RUNTIME_TOKEN=***
2024-07-15T16:19:49.5699910Z GITHUB_ACTION_REPOSITORY=
2024-07-15T16:19:49.5700310Z GITHUB_ACTION_REF=
2024-07-15T16:19:49.5765400Z Cleaning up orphan processes
```