### PR TITLE
Redirect supported OS doc section to the public docs

### DIFF
--- a/docs/start/envlinux.md
+++ b/docs/start/envlinux.md
@@ -4,16 +4,7 @@
 
 ## Supported Distributions and Versions
 
-x64
-  - Red Hat Enterprise Linux 8+
-  - CentOS 8+
-  - Oracle Linux 8+
-  - Fedora 29+
-  - Debian 10+
-  - Ubuntu 20.04+
-  - Linux Mint 20+
-  - openSUSE 15.2+
-  - SUSE Enterprise Linux (SLES) 15 SP2+
+Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#supported-architectures-and-operating-systems-for-self-hosted-runners)."
 
 ## Install .Net Core 3.x Linux Dependencies
 

--- a/docs/start/envlinux.md
+++ b/docs/start/envlinux.md
@@ -4,7 +4,7 @@
 
 ## Supported Distributions and Versions
 
-Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#supported-architectures-and-operating-systems-for-self-hosted-runners)."
+Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#linux)."
 
 ## Install .Net Core 3.x Linux Dependencies
 

--- a/docs/start/envosx.md
+++ b/docs/start/envosx.md
@@ -4,6 +4,6 @@
 
 ## Supported Versions
 
-Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#supported-architectures-and-operating-systems-for-self-hosted-runners)."
+Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#macos)."
 
 ## [More .Net Core Prerequisites Information](https://docs.microsoft.com/en-us/dotnet/core/macos-prerequisites?tabs=netcore30)

--- a/docs/start/envosx.md
+++ b/docs/start/envosx.md
@@ -4,7 +4,6 @@
 
 ## Supported Versions
 
-  - macOS High Sierra (10.13) and later versions
-  - x64 and arm64 (Apple Silicon)
+Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#supported-architectures-and-operating-systems-for-self-hosted-runners)."
 
 ## [More .Net Core Prerequisites Information](https://docs.microsoft.com/en-us/dotnet/core/macos-prerequisites?tabs=netcore30)

--- a/docs/start/envwin.md
+++ b/docs/start/envwin.md
@@ -2,11 +2,6 @@
 
 ## Supported Versions
 
- - Windows 7 64-bit
- - Windows 8.1 64-bit
- - Windows 10 64-bit
- - Windows Server 2012 R2 64-bit
- - Windows Server 2016 64-bit
- - Windows Server 2019 64-bit
+Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#supported-architectures-and-operating-systems-for-self-hosted-runners)."
 
 ## [More .NET Core Prerequisites Information](https://docs.microsoft.com/en-us/dotnet/core/windows-prerequisites?tabs=netcore30)

--- a/docs/start/envwin.md
+++ b/docs/start/envwin.md
@@ -2,6 +2,6 @@
 
 ## Supported Versions
 
-Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#supported-architectures-and-operating-systems-for-self-hosted-runners)."
+Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#windows)."
 
 ## [More .NET Core Prerequisites Information](https://docs.microsoft.com/en-us/dotnet/core/windows-prerequisites?tabs=netcore30)


### PR DESCRIPTION
This change is to use the public docs as a single source of truth for supported runner OS versions. This avoids the duplication of work when this information is already present and more frequently updated in the public documentation. 