### PR TITLE
Add a lock timeout for apt-get installs

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -53,7 +53,7 @@ then
         command -v apt-get
         if [ $? -eq 0 ]
         then
-            apt_get=apt-get
+            apt_get="apt-get -o DPkg::Lock::Timeout=300"
         else
             command -v apt
             if [ $? -eq 0 ]


### PR DESCRIPTION
apt-get often gets in a race condition with self-hosted runners that results in it being unable to obtain the lock for install/upgrades (as seen below).  This fix adds a 5 minute timeout which retries apt-get install/upgrades, making the installation process more robust.

See
https://help.ubuntu.com/community/AutomaticSecurityUpdates
https://blog.sinjakli.co.uk/2021/10/25/waiting-for-apt-locks-without-the-hacky-bash-scripts/

Example error message:

```

+ os_id='ubuntu
debian'
+ [[ ubuntu
debian =~ ^ubuntu.* ]]
+ echo 'Installing dependencies'
Installing dependencies
+ ./bin/installdependencies.sh
--------OS Information--------
NAME="Ubuntu"
VERSION="20.04.6 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.6 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
------------------------------
The current OS is Debian based
--------Debian Version--------
bullseye/sid
------------------------------
/usr/bin/apt-get
Hit:1 http://us-west-2.ec2.archive.ubuntu.com/ubuntu focal InRelease
Hit:2 http://us-west-2.ec2.archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:3 http://us-west-2.ec2.archive.ubuntu.com/ubuntu focal-backports InRelease
Hit:4 https://download.docker.com/linux/ubuntu focal InRelease
Hit:5 https://nvidia.github.io/libnvidia-container/stable/deb/amd64  InRelease
Hit:6 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease
Hit:7 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:8 https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu focal InRelease
Reading package lists...
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 33029 (unattended-upgr)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
'apt-get' failed with exit code '0'
Can't install dotnet core dependencies.
You can manually install all required dependencies based on following documentation
https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x

```