### PR TITLE
fix missing default user-agent for jitconfig runner.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
     # Upload runner package tar.gz/zip as artifact
     - name: Publish Artifact
       if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: runner-package-${{ matrix.runtime }}
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
     # Since each package name is unique, so we don't need to put ${{matrix}} info into artifact name
     - name: Publish Artifact
       if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: runner-packages
         path: |
@@ -135,7 +135,7 @@ jobs:
 
     # Download runner package tar.gz/zip produced by 'build' job
     - name: Download Artifact
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: runner-packages
         path: ./

--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -36,6 +36,7 @@ namespace GitHub.Runner.Common
         event EventHandler Unloading;
         void ShutdownRunner(ShutdownReason reason);
         void WritePerfCounter(string counter);
+        void LoadDefaultUserAgents();
     }
 
     public enum StartupType
@@ -67,6 +68,7 @@ namespace GitHub.Runner.Common
         private StartupType _startupType;
         private string _perfFile;
         private RunnerWebProxy _webProxy = new();
+        private string _hostType = string.Empty;
 
         public event EventHandler Unloading;
         public CancellationToken RunnerShutdownToken => _runnerShutdownTokenSource.Token;
@@ -78,6 +80,7 @@ namespace GitHub.Runner.Common
         {
             // Validate args.
             ArgUtil.NotNullOrEmpty(hostType, nameof(hostType));
+            _hostType = hostType;
 
             _loadContext = AssemblyLoadContext.GetLoadContext(typeof(HostContext).GetTypeInfo().Assembly);
             _loadContext.Unloading += LoadContext_Unloading;
@@ -196,6 +199,16 @@ namespace GitHub.Runner.Common
                 }
             }
 
+            if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY")))
+            {
+                _trace.Warning($"Runner is running under insecure mode: HTTPS server certificate validation has been turned off by GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY environment variable.");
+            }
+
+            LoadDefaultUserAgents();
+        }
+
+        public void LoadDefaultUserAgents()
+        {
             if (string.IsNullOrEmpty(WebProxy.HttpProxyAddress) && string.IsNullOrEmpty(WebProxy.HttpsProxyAddress))
             {
                 _trace.Info($"No proxy settings were found based on environmental variables (http_proxy/https_proxy/HTTP_PROXY/HTTPS_PROXY)");
@@ -203,11 +216,6 @@ namespace GitHub.Runner.Common
             else
             {
                 _userAgents.Add(new ProductInfoHeaderValue("HttpProxyConfigured", bool.TrueString));
-            }
-
-            if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY")))
-            {
-                _trace.Warning($"Runner is running under insecure mode: HTTPS server certificate validation has been turned off by GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY environment variable.");
             }
 
             var credFile = GetConfigFile(WellKnownConfigFile.Credentials);
@@ -248,7 +256,7 @@ namespace GitHub.Runner.Common
             var currentProcess = Process.GetCurrentProcess();
             _userAgents.Add(new ProductInfoHeaderValue("Pid", currentProcess.Id.ToString()));
             _userAgents.Add(new ProductInfoHeaderValue("CreationTime", Uri.EscapeDataString(DateTime.UtcNow.ToString("O"))));
-            _userAgents.Add(new ProductInfoHeaderValue($"({hostType})"));
+            _userAgents.Add(new ProductInfoHeaderValue($"({_hostType})"));
         }
 
         public string GetDirectory(WellKnownDirectory directory)

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -237,6 +237,10 @@ namespace GitHub.Runner.Listener
                             File.SetAttributes(configFile, File.GetAttributes(configFile) | FileAttributes.Hidden);
                             Trace.Info($"Saved {configContent.Length} bytes to '{configFile}'.");
                         }
+
+                        // make sure we have the right user agent data added from the jitconfig
+                        HostContext.LoadDefaultUserAgents();
+                        VssUtil.InitializeVssClientSettings(HostContext.UserAgents, HostContext.WebProxy);
                     }
                     catch (Exception ex)
                     {

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -370,6 +370,11 @@ namespace GitHub.Runner.Common.Tests
                 Unloading(this, null);
             }
         }
+
+        public void LoadDefaultUserAgents()
+        {
+            return;
+        }
     }
 
     public class DelayEventArgs : EventArgs


### PR DESCRIPTION
user-agent for jitconfig runner:

before the fix:
```
User-Agent: VSServices/2.319.1.0 (NetStandard; Darwin 23.6.0 Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000) 
GitHubActionsRunner-osx-arm64/2.319.1 
HttpProxyConfigured/True 
CommitSHA/ddf41af7678a8bc585d9e6b8ab70d941cdb687b2 Pid/14771 CreationTime/2024-09-24T20%3A51%3A42.2059570Z (Runner) 
(Darwin 23.6.0 Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000)
```

After the fix:
```
User-Agent: VSServices/2.319.1.0 (NetStandard; Darwin 23.6.0 Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000) 
GitHubActionsRunner-osx-arm64/2.319.1 
HttpProxyConfigured/True 
ClientId/9a33a1f3-b0b8-4be9-a1f2-d427f0e64fee RunnerId/1211326 GroupId/1 
CommitSHA/ddf41af7678a8bc585d9e6b8ab70d941cdb687b2 Pid/14384 CreationTime/2024-09-24T20%3A51%3A24.5314530Z (Runner) 
(Darwin 23.6.0 Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000)
```
