### PR TITLE
Create launch httpclient using the right handler and setting.

### DIFF
--- a/src/Runner.Common/LaunchServer.cs
+++ b/src/Runner.Common/LaunchServer.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using GitHub.DistributedTask.WebApi;
+using GitHub.Runner.Sdk;
+using GitHub.Services.Common;
 using GitHub.Services.Launch.Client;
-using GitHub.Services.WebApi;
 
 namespace GitHub.Runner.Common
 {
@@ -23,8 +24,21 @@ namespace GitHub.Runner.Common
 
         public void InitializeLaunchClient(Uri uri, string token)
         {
-            var httpMessageHandler = HostContext.CreateHttpClientHandler();
-            this._launchClient = new LaunchHttpClient(uri, httpMessageHandler, token, disposeHandler: true);
+            // Using default 100 timeout
+            RawClientHttpRequestSettings settings = VssUtil.GetHttpRequestSettings(null);
+
+            // Create retry handler
+            IEnumerable<DelegatingHandler> delegatingHandlers = new List<DelegatingHandler>();
+            if (settings.MaxRetryRequest > 0)
+            {
+                delegatingHandlers = new DelegatingHandler[] { new VssHttpRetryMessageHandler(settings.MaxRetryRequest) };
+            }
+
+            // Setup RawHttpMessageHandler without credentials
+            var httpMessageHandler = new RawHttpMessageHandler(new NoOpCredentials(null), settings);
+            var pipeline = HttpClientFactory.CreatePipeline(httpMessageHandler, delegatingHandlers);
+
+            this._launchClient = new LaunchHttpClient(uri, pipeline, token, disposeHandler: true);
         }
 
         public Task<ActionDownloadInfoCollection> ResolveActionsDownloadInfoAsync(Guid planId, Guid jobId, ActionReferenceList actionReferenceList,


### PR DESCRIPTION
Before the fix:
`user_agent: VSServices/2.319.1.0 (NetStandard; Linux 6.8.0-1014-azure #16~22.04.1-Ubuntu SMP Thu Aug 15 21:31:41 UTC 2024)`

After the fix:
`user_agent: VSServices/2.319.1.0 (NetStandard; Darwin 23.6.0 Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000) GitHubActionsRunner-osx-arm64/2.319.1 HttpProxyConfigured/True ClientId/35a4cd10-7c23-4381-9127-aa02faad2da1 RunnerId/903167 GroupId/1 CommitSHA/8e5dbb42d2c5a45e9591e44857cad945fe1e5609 Pid/20225 CreationTime/2024-09-30T14%3A53%3A09.9584480Z (Worker) OrchestrationId/17559e24-a491-44b3-bc21-817419507194.build.__default (Darwin 23.6.0 Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000)`