### PR TITLE
feat: add job_name to github context

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -871,11 +871,13 @@ namespace GitHub.Runner.Worker
             var base64EncodedToken = Convert.ToBase64String(Encoding.UTF8.GetBytes($"x-access-token:{githubAccessToken}"));
             HostContext.SecretMasker.AddValue(base64EncodedToken);
             var githubJob = Global.Variables.Get("system.github.job");
+            var githubJobName = Global.Variables.Get("system.jobDisplayName") || githubJob;
             var githubContext = new GitHubContext();
             githubContext["token"] = githubAccessToken;
             if (!string.IsNullOrEmpty(githubJob))
             {
                 githubContext["job"] = new StringContextData(githubJob);
+                githubContext["job_name"] = new StringContextData(githubJobName);
             }
             var githubDictionary = ExpressionValues["github"].AssertDictionary("github");
             foreach (var pair in githubDictionary)


### PR DESCRIPTION
> [!Important]
> **Solved** see https://github.com/actions/runner/pull/3489#issuecomment-2726751087 for a stable workaround.

---

Currently there is no system variable that contains a job id value that can be used to request the github api for a job.
`system.jobId`contains a GUID and therefore is useless for[ job API endpoint](https://docs.github.com/en/rest/actions/workflow-jobs?apiVersion=2022-11-28#get-a-job-for-a-workflow-run)

By providing the real/effective job name (as in the github api response of jobs), we are able to determine and request the current job by using [list-jobs-for-a-workflow-run-attempt API endpoint](https://docs.github.com/en/rest/actions/workflow-jobs?apiVersion=2022-11-28#list-jobs-for-a-workflow-run-attempt) and find the actual job by its name.

```typescript
const currentJob = await octokit.paginate(octokit.rest.actions.listJobsForWorkflowRunAttempt, {
  owner: 'qoomon',
  repo: 'sandbox',
  run_id: parseInt(process.env.GITHUB_RUN_ID),
  attempt_number: parseInt(process.env.GITHUB_RUN_ATTEMPT),
})
  .then((jobs) => jobs.filter((job) => job.name === process.env.GITHUB_JOB_NAME && job.runner_name === process.env.RUNNER_NAME))
  .then((jobs) => {
    if (jobs.length != 1) { 
      throw new Error('Could not determine current job')
    } else { 
      return
    }
  })
```

This would solve a lot of community requests e.g., https://github.com/orgs/community/discussions/8945

There was an attempt from attempt already from @TingluoHuang to fix this issue two years ago https://github.com/actions/runner/pull/1950

**Update**
It looks like the job.name of the api response job objects getting truncated at 100 characters 🤯.
So to make this work always the api response need to be adjusted as well.
