### PR TITLE
add ref and type to job completion in run service

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -508,6 +508,8 @@ namespace GitHub.Runner.Worker
                     Status = _record.State,
                     Number = _record.Order,
                     Name = _record.Name,
+                    Ref = StepTelemetry?.Ref,
+                    Type = StepTelemetry?.Type,
                     StartedAt = _record.StartTime,
                     CompletedAt = _record.FinishTime,
                     Annotations = new List<Annotation>()

--- a/src/Sdk/RSWebApi/Contracts/StepResult.cs
+++ b/src/Sdk/RSWebApi/Contracts/StepResult.cs
@@ -18,10 +18,10 @@ namespace GitHub.Actions.RunService.WebApi
 
         [DataMember(Name = "name", EmitDefaultValue = false)]
         public string Name { get; set; }
-        
+
         [DataMember(Name = "ref", EmitDefaultValue = false)]
         public string Ref { get; set; }
-        
+
         [DataMember(Name = "type", EmitDefaultValue = false)]
         public string Type { get; set; }
 

--- a/src/Sdk/RSWebApi/Contracts/StepResult.cs
+++ b/src/Sdk/RSWebApi/Contracts/StepResult.cs
@@ -18,6 +18,12 @@ namespace GitHub.Actions.RunService.WebApi
 
         [DataMember(Name = "name", EmitDefaultValue = false)]
         public string Name { get; set; }
+        
+        [DataMember(Name = "ref", EmitDefaultValue = false)]
+        public string Ref { get; set; }
+        
+        [DataMember(Name = "type", EmitDefaultValue = false)]
+        public string Type { get; set; }
 
         [DataMember(Name = "status")]
         public TimelineRecordState? Status { get; set; }


### PR DESCRIPTION
Adding `ref` and `type`, so that run-service get those details, for our telemetry purpose

Also see https://github.com/github/actions-runtime/issues/4744#issuecomment-2400671393