### PR TITLE
Initial support building the runner on FreeBSD

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,10 @@
     <BUILD_OS Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">Linux</BUILD_OS>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'false'">
+    <BUILD_OS Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::FreeBSD)))' == 'true'">FreeBSD</BUILD_OS>
+  </PropertyGroup>
+
   <!-- Set OS vars -->
   <PropertyGroup Condition="'$(BUILD_OS)' == 'Windows'">
     <DefineConstants>$(DefineConstants);OS_WINDOWS</DefineConstants>
@@ -15,6 +19,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(BUILD_OS)' == 'Linux'">
     <DefineConstants>$(DefineConstants);OS_LINUX</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BUILD_OS)' == 'FreeBSD'">
+    <DefineConstants>$(DefineConstants);OS_FREEBSD</DefineConstants>
   </PropertyGroup>
 
   <!-- Set Platform/bitness vars -->
@@ -43,6 +50,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(BUILD_OS)' == 'Linux' AND '$(PackageRuntime)' == 'linux-arm64'">
     <DefineConstants>$(DefineConstants);ARM64</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BUILD_OS)' == 'FreeBSD' AND ('$(PackageRuntime)' == 'freebsd-x64' OR '$(PackageRuntime)' == '')">
+    <DefineConstants>$(DefineConstants);X64</DefineConstants>
   </PropertyGroup>
 
   <!-- Set TRACE/DEBUG vars -->

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -50,7 +50,8 @@ namespace GitHub.Runner.Common
         {
             OSX,
             Linux,
-            Windows
+            Windows,
+            FreeBSD
         }
 
         public enum Architecture
@@ -69,6 +70,8 @@ namespace GitHub.Runner.Common
             public static readonly OSPlatform Platform = OSPlatform.OSX;
 #elif OS_WINDOWS
             public static readonly OSPlatform Platform = OSPlatform.Windows;
+#elif OS_FREEBSD
+            public static readonly OSPlatform Platform = OSPlatform.FreeBSD;
 #else
             public static readonly OSPlatform Platform = OSPlatform.Linux;
 #endif

--- a/src/Runner.Common/Runner.Common.csproj
+++ b/src/Runner.Common/Runner.Common.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' != 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' == 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;freebsd-x64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>
     <Version>$(Version)</Version>

--- a/src/Runner.Common/Util/VarUtil.cs
+++ b/src/Runner.Common/Util/VarUtil.cs
@@ -12,6 +12,7 @@ namespace GitHub.Runner.Common.Util
                 {
                     case Constants.OSPlatform.Linux:
                     case Constants.OSPlatform.OSX:
+                    case Constants.OSPlatform.FreeBSD:
                         return StringComparer.Ordinal;
                     case Constants.OSPlatform.Windows:
                         return StringComparer.OrdinalIgnoreCase;
@@ -33,6 +34,8 @@ namespace GitHub.Runner.Common.Util
                         return "macOS";
                     case Constants.OSPlatform.Windows:
                         return "Windows";
+                    case Constants.OSPlatform.FreeBSD:
+                        return "FreeBSD";
                     default:
                         throw new NotSupportedException(); // Should never reach here.
                 }

--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -427,7 +427,7 @@ namespace GitHub.Runner.Listener.Configuration
                 serviceControlManager.ConfigureService(runnerSettings, command);
             }
 
-#elif OS_LINUX || OS_OSX
+#elif OS_LINUX || OS_OSX || OS_FREEBSD
             // generate service config script for OSX and Linux, GenerateScripts() will no-opt on windows.
             var serviceControlManager = HostContext.GetService<ILinuxServiceControlManager>();
             serviceControlManager.GenerateScripts(runnerSettings);

--- a/src/Runner.Listener/Configuration/RSAFileKeyManager.cs
+++ b/src/Runner.Listener/Configuration/RSAFileKeyManager.cs
@@ -1,4 +1,4 @@
-﻿#if OS_LINUX || OS_OSX
+﻿#if OS_LINUX || OS_OSX || OS_FREEBSD
 using System;
 using System.IO;
 using System.Security.Cryptography;

--- a/src/Runner.Listener/Configuration/ServiceControlManager.cs
+++ b/src/Runner.Listener/Configuration/ServiceControlManager.cs
@@ -76,7 +76,7 @@ namespace GitHub.Runner.Listener.Configuration
 
             Trace.Info($"Service name '{serviceName}' display name '{serviceDisplayName}' will be used for service configuration.");
         }
-#if (OS_LINUX || OS_OSX)
+#if (OS_LINUX || OS_OSX || OS_FREEBSD)
         const int MaxServiceNameLength = 150;
         const int MaxRepoOrgCharacters = 70;
 #elif OS_WINDOWS

--- a/src/Runner.Listener/Program.cs
+++ b/src/Runner.Listener/Program.cs
@@ -53,6 +53,13 @@ namespace GitHub.Runner.Listener
                         return Constants.Runner.ReturnCode.TerminatedError;
                     }
                     break;
+                case Constants.OSPlatform.FreeBSD:
+                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+                    {
+                        terminal.WriteLine("This runner version is built for FreeBSD. Please install a correct build for your OS.");
+                        return Constants.Runner.ReturnCode.TerminatedError;
+                    }
+                    break;
                 case Constants.OSPlatform.Windows:
                     if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {

--- a/src/Runner.Listener/Runner.Listener.csproj
+++ b/src/Runner.Listener/Runner.Listener.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' != 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' == 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;freebsd-x64</RuntimeIdentifiers>
     <SelfContained>true</SelfContained>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Runner.Listener/SelfUpdater.cs
+++ b/src/Runner.Listener/SelfUpdater.cs
@@ -103,7 +103,7 @@ namespace GitHub.Runner.Listener
 #if OS_WINDOWS
                     invokeScript.StartInfo.FileName = WhichUtil.Which("cmd.exe", trace: Trace);
                     invokeScript.StartInfo.Arguments = $"/c \"{updateScript}\"";
-#elif (OS_OSX || OS_LINUX)
+#elif (OS_OSX || OS_LINUX || OS_FREEBSD)
                     invokeScript.StartInfo.FileName = WhichUtil.Which("bash", trace: Trace);
                     invokeScript.StartInfo.Arguments = $"\"{updateScript}\"";
 #endif

--- a/src/Runner.Listener/SelfUpdaterV2.cs
+++ b/src/Runner.Listener/SelfUpdaterV2.cs
@@ -103,7 +103,7 @@ namespace GitHub.Runner.Listener
 #if OS_WINDOWS
                     invokeScript.StartInfo.FileName = WhichUtil.Which("cmd.exe", trace: Trace);
                     invokeScript.StartInfo.Arguments = $"/c \"{updateScript}\"";
-#elif (OS_OSX || OS_LINUX)
+#elif (OS_OSX || OS_LINUX || OS_FREEBSD)
                     invokeScript.StartInfo.FileName = WhichUtil.Which("bash", trace: Trace);
                     invokeScript.StartInfo.Arguments = $"\"{updateScript}\"";
 #endif

--- a/src/Runner.PluginHost/Runner.PluginHost.csproj
+++ b/src/Runner.PluginHost/Runner.PluginHost.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' != 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' == 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;freebsd-x64</RuntimeIdentifiers>
     <SelfContained>true</SelfContained>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Runner.Plugins/Runner.Plugins.csproj
+++ b/src/Runner.Plugins/Runner.Plugins.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' != 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' == 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;freebsd-x64</RuntimeIdentifiers>
     <SelfContained>true</SelfContained>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Runner.Sdk/Runner.Sdk.csproj
+++ b/src/Runner.Sdk/Runner.Sdk.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' != 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' == 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;freebsd-x64</RuntimeIdentifiers>
     <SelfContained>true</SelfContained>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Runner.Worker/Runner.Worker.csproj
+++ b/src/Runner.Worker/Runner.Worker.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' != 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BUILD_OS)' == 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;freebsd-x64</RuntimeIdentifiers>
     <SelfContained>true</SelfContained>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Sdk/Sdk.csproj
+++ b/src/Sdk/Sdk.csproj
@@ -3,7 +3,8 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <OutputType>Library</OutputType>
-        <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifiers Condition="'$(BUILD_OS)' != 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifiers Condition="'$(BUILD_OS)' == 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;freebsd-x64</RuntimeIdentifiers>
         <!-- <SelfContained>true</SelfContained> -->
         <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
         <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Test/L0/ConstantGenerationL0.cs
+++ b/src/Test/L0/ConstantGenerationL0.cs
@@ -21,7 +21,8 @@ namespace GitHub.Runner.Common.Tests
                 "linux-arm",
                 "linux-arm64",
                 "osx-x64",
-                "osx-arm64"
+                "osx-arm64",
+                "freebsd-x64"
             };
 
             Assert.Equal(40, BuildConstants.Source.CommitHash.Length);

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifiers Condition="'$(BUILD_OS)' != 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifiers Condition="'$(BUILD_OS)' == 'FreeBSD'">win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;freebsd-x64</RuntimeIdentifiers>
         <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
         <NoWarn>NU1701;NU1603;NU1603;xUnit2013;SYSLIB0050;SYSLIB0051</NoWarn>
     </PropertyGroup>

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -35,7 +35,7 @@ if [[ "$DEV_CONFIG" == "Release" ]]; then
 fi
 
 CURRENT_PLATFORM="windows"
-if [[ ($(uname) == "Linux") || ($(uname) == "Darwin") ]]; then
+if [[ ($(uname) == "Linux") || ($(uname) == "Darwin") || ($(uname) == "FreeBSD")]]; then
     CURRENT_PLATFORM=$(uname | awk '{print tolower($0)}')
 fi
 
@@ -64,6 +64,8 @@ elif [[ "$CURRENT_PLATFORM" == 'darwin' ]]; then
             arm64) RUNTIME_ID="osx-arm64";;
         esac
     fi
+elif [[ "$CURRENT_PLATFORM" == 'freebsd' ]]; then
+    RUNTIME_ID='freebsd-x64'
 fi
 
 if [[ -n "$DEV_TARGET_RUNTIME" ]]; then
@@ -183,7 +185,7 @@ function package ()
 
     pushd "$PACKAGE_DIR" > /dev/null
 
-    if [[ ("$CURRENT_PLATFORM" == "linux") || ("$CURRENT_PLATFORM" == "darwin") ]]; then
+    if [[ ("$CURRENT_PLATFORM" == "linux") || ("$CURRENT_PLATFORM" == "darwin") || ("$CURRENT_PLATFORM" == "freebsd")]]; then
         tar_name="${runner_pkg_name}.tar.gz"
         echo "Creating $tar_name in ${LAYOUT_DIR}"
         tar -czf "${tar_name}" -C "${LAYOUT_DIR}" .

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -220,6 +220,10 @@ if [[ (! -d "${DOTNETSDK_INSTALLDIR}") || (! -e "${DOTNETSDK_INSTALLDIR}/.${DOTN
         sdkinstallwindow_path=${DOTNETSDK_INSTALLDIR:1}
         sdkinstallwindow_path=${sdkinstallwindow_path:0:1}:${sdkinstallwindow_path:1}
         $POWERSHELL -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "& \"./Misc/dotnet-install.ps1\" -Version ${DOTNETSDK_VERSION} -InstallDir \"${sdkinstallwindow_path}\" -NoPath; exit \$LastExitCode;" || checkRC dotnet-install.ps1
+    # FIXME: binary for freebsd is not on https://dotnetcli.azureedge.net
+    elif [[ ("$CURRENT_PLATFORM" == "freebsd") ]]; then
+        echo "Skip installing dotnet, use system dotnet"
+        command -v dotnet
     else
         bash ./Misc/dotnet-install.sh --version ${DOTNETSDK_VERSION} --install-dir "${DOTNETSDK_INSTALLDIR}" --no-path || checkRC dotnet-install.sh
     fi


### PR DESCRIPTION
I tried to address #385.

The dotnet binary for FreeBSD is not available on https://dotnetcli.azureedge.net, so I am using the system's dotnet.

I have adjusted the build process to support FreeBSD, following the examples of other operating systems.
The following steps have been tested and confirmed to pass successfully.

```
./dev.sh layout Release freebsd-x64
./dev.sh package Release
```

I have confirmed that `./dev.sh test` passes, except for tests that require pre-built binaries such as node.
However, the operation of the runner on FreeBSD is not fully guaranteed, so please note that this is a PR that enables building for FreeBSD.