### PR TITLE
Add caching of downloaded actions to achieve parity with the tool cache functionality

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -256,6 +256,7 @@ namespace GitHub.Runner.Common
                 public static readonly string ForcedActionsNodeVersion = "ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION";
                 public static readonly string PrintLogToStdout = "ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT";
                 public static readonly string ActionArchiveCacheDirectory = "ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE";
+                public static readonly string ActionArchiveExternalCachingEnabled = "ACTIONS_RUNNER_ACTION_ARCHIVE_EXTERNAL_CACHING_ENABLED";
             }
 
             public static class System

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -795,16 +795,17 @@ namespace GitHub.Runner.Worker
                 var useActionArchiveCache = false;
                 var hasActionArchiveCache = false;
                 var actionArchiveCacheDir = Environment.GetEnvironmentVariable(Constants.Variables.Agent.ActionArchiveCacheDirectory);
+                var externalCachingEnabled = Convert.ToBoolean(Environment.GetEnvironmentVariable(Constants.Variables.Agent.ActionArchiveExternalCachingEnabled) ?? "false");
+#if OS_WINDOWS
+                var cacheArchiveFile = Path.Combine(actionArchiveCacheDir, downloadInfo.ResolvedNameWithOwner.Replace(Path.DirectorySeparatorChar, '_').Replace(Path.AltDirectorySeparatorChar, '_'), $"{downloadInfo.ResolvedSha}.zip");
+#else
+                var cacheArchiveFile = Path.Combine(actionArchiveCacheDir, downloadInfo.ResolvedNameWithOwner.Replace(Path.DirectorySeparatorChar, '_').Replace(Path.AltDirectorySeparatorChar, '_'), $"{downloadInfo.ResolvedSha}.tar.gz");
+#endif
                 if (!string.IsNullOrEmpty(actionArchiveCacheDir) &&
                     Directory.Exists(actionArchiveCacheDir))
                 {
                     hasActionArchiveCache = true;
                     Trace.Info($"Check if action archive '{downloadInfo.ResolvedNameWithOwner}@{downloadInfo.ResolvedSha}' already exists in cache directory '{actionArchiveCacheDir}'");
-#if OS_WINDOWS
-                    var cacheArchiveFile = Path.Combine(actionArchiveCacheDir, downloadInfo.ResolvedNameWithOwner.Replace(Path.DirectorySeparatorChar, '_').Replace(Path.AltDirectorySeparatorChar, '_'), $"{downloadInfo.ResolvedSha}.zip");
-#else
-                    var cacheArchiveFile = Path.Combine(actionArchiveCacheDir, downloadInfo.ResolvedNameWithOwner.Replace(Path.DirectorySeparatorChar, '_').Replace(Path.AltDirectorySeparatorChar, '_'), $"{downloadInfo.ResolvedSha}.tar.gz");
-#endif
                     if (File.Exists(cacheArchiveFile))
                     {
                         try
@@ -830,6 +831,12 @@ namespace GitHub.Runner.Worker
                 if (!useActionArchiveCache)
                 {
                     await DownloadRepositoryArchive(executionContext, link, downloadInfo.Authentication?.Token, archiveFile);
+                    if (hasActionArchiveCache && externalCachingEnabled)
+                    {
+                        executionContext.Output($"Saving archive file to cache at '{cacheArchiveFile}'");
+                        Directory.CreateDirectory(Path.GetDirectoryName(cacheArchiveFile));
+                        File.Copy(archiveFile, cacheArchiveFile, true);
+                    }
                 }
 
                 var stagingDirectory = Path.Combine(tempDirectory, "_staging");


### PR DESCRIPTION
## This added functionality makes the use of real time NFS tool and actions caching possible.

### Actual Changes
- add environment variable `ACTIONS_RUNNER_ACTION_ARCHIVE_EXTERNAL_CACHING_ENABLED` which maintains current actions caching functionality (downloads actions without caching) while allowing for external caching functionality
- extended the functionality of actions downloads to copy to cache location if not found in cache location if the above environment variable is `true`
- added workflow output to indicate that the copy took place

## Authored by
- [Tucker Fowler](https://github.com/einsteinsbrd) (The Home Depot, [tucker_fowler1@homedepot.com](mailto:tucker_fowler1@homedepot.com))
- [Benjamin Taillon](https://github.com/Benjamint22) (The Home Depot, [benjamin_taillon@homedepot.com](benjamin_taillon@homedepot.com))