### PR TITLE
Fix name of generated of artifact builds from GitHub workflow for arm artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Package Release
       if: github.event_name != 'pull_request'
       run: |
-        ${{ matrix.devScript }} package Release
+        ${{ matrix.devScript }} package Release ${{ matrix.runtime }}
       working-directory: src
 
     # Upload runner package tar.gz/zip as artifact


### PR DESCRIPTION
The tar.gz file names generated from the `build.yml` workflow inside `runner-package-${{ matrix.runtime }}.zip` are all named `actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz`

The logic in `src/dev.sh` is:
```bash
DEV_TARGET_RUNTIME=$3
...
elif [[ "$CURRENT_PLATFORM" == 'linux' ]]; then
    RUNTIME_ID="linux-x64"
    if command -v uname > /dev/null; then
        CPU_NAME=$(uname -m)
        case $CPU_NAME in
            armv7l) RUNTIME_ID="linux-arm";;
            aarch64) RUNTIME_ID="linux-arm64";;
        esac
    fi
...
if [[ -n "$DEV_TARGET_RUNTIME" ]]; then
    RUNTIME_ID="$DEV_TARGET_RUNTIME"
fi
...
    runner_pkg_name="actions-runner-${RUNTIME_ID}-${runner_ver}"

    heading "Packaging ${runner_pkg_name}"
...
    if [[ ("$CURRENT_PLATFORM" == "linux") || ("$CURRENT_PLATFORM" == "darwin") ]]; then
        tar_name="${runner_pkg_name}.tar.gz"
        echo "Creating $tar_name in ${LAYOUT_DIR}"
        tar -czf "${tar_name}" -C "${LAYOUT_DIR}" .
```

But `RUNTIME_ID` never gets set for the arm packages since those are cross-compiled on `linux-x64`.

This is a small fix for that.