### PR TITLE
Unformatted trace logging for step telemetry in ExecutionContext

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1145,7 +1145,7 @@ namespace GitHub.Runner.Worker
                         }
                     }
 
-                    Trace.Info($"Publish step telemetry for current step {StringUtil.ConvertToJson(StepTelemetry)}.");
+                    Trace.Info($"Publish step telemetry for current step {StringUtil.ConvertToJson(StepTelemetry, Formatting.None)}.");
                     Global.StepsTelemetry.Add(StepTelemetry);
                     _stepTelemetryPublished = true;
                 }


### PR DESCRIPTION
Don't apply JSON formatting during the trace logging for step telemetry. By default `StringUtil.ConvertToJson` uses `Formatting.Indented` which causes multi-line logs for this particular json object.

The data contained in this particular log line is useful for operators of self-hosted runners who are looking to use log aggregates to understand their overall usage and performance. Parsing multi-line data in log aggregates is very hard to get right, if not outright impossible depending on how logs are aggregated.

## Note to reviewers

Unfortunately I found it hard to add a test for this (and arguably adding a test for a Trace is perhaps not something one may want to do?) given that the `Tracing` object is private so testing via something like TraceListener looked like it would entail a lot more changes. However the test logs confirm that indeed it now prints the relevant log in a single line rather than multiple

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/1bc686b4-706e-46eb-806e-5cd86a162349">

