### PR TITLE
Add support for running JavaScript actions on Alpine Linux arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           devScript: ./dev.sh
 
         - runtime: linux-arm64
-          os: ubuntu-latest
+          os: ubuntu-24.04-arm
           devScript: ./dev.sh
 
         - runtime: linux-arm
@@ -63,7 +63,7 @@ jobs:
       run: |
         ${{ matrix.devScript }} test
       working-directory: src
-      if: matrix.runtime != 'linux-arm64' && matrix.runtime != 'linux-arm' && matrix.runtime != 'osx-arm64' && matrix.runtime != 'win-arm64'
+      if: matrix.runtime != 'linux-arm' && matrix.runtime != 'osx-arm64' && matrix.runtime != 'win-arm64'
 
     # Create runner package tar.gz/zip
     - name: Package Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           devScript: ./dev.sh
 
         - runtime: linux-arm64
-          os: ubuntu-latest
+          os: ubuntu-24.04-arm
           devScript: ./dev.sh
 
         - runtime: linux-arm

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -172,6 +172,7 @@ fi
 
 if [[ "$PACKAGERUNTIME" == "linux-arm64" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-arm64.tar.gz" node20 fix_nested_dir
+    acquireExternalTool "$NODE_ALPINE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-alpine-arm64.tar.gz" node20_alpine
 fi
 
 if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then

--- a/src/Runner.Worker/Handlers/StepHost.cs
+++ b/src/Runner.Worker/Handlers/StepHost.cs
@@ -265,11 +265,11 @@ namespace GitHub.Runner.Worker.Handlers
         private string CheckPlatformForAlpineContainer(IExecutionContext executionContext, string preferredVersion)
         {
             string nodeExternal = preferredVersion;
-            if (!Constants.Runner.PlatformArchitecture.Equals(Constants.Architecture.X64))
+            if (!Constants.Runner.PlatformArchitecture.Equals(Constants.Architecture.X64) && !Constants.Runner.PlatformArchitecture.Equals(Constants.Architecture.Arm64))
             {
                 var os = Constants.Runner.Platform.ToString();
                 var arch = Constants.Runner.PlatformArchitecture.ToString();
-                var msg = $"JavaScript Actions in Alpine containers are only supported on x64 Linux runners. Detected {os} {arch}";
+                var msg = $"JavaScript Actions in Alpine containers are only supported on x64 and arm64 Linux runners. Detected {os} {arch}";
                 throw new NotSupportedException(msg);
             }
             nodeExternal = $"{preferredVersion}_alpine";


### PR DESCRIPTION
Closes #801 

When testing the [new Linux arm64 runners](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) that are now in Public Preview, I [ran into the following error](https://github.com/dennisameling/sharp/actions/runs/12838109751/job/35803083398?pr=1#step:7:18):

> JavaScript Actions in Alpine containers are only supported on x64 Linux runners. Detected Linux Arm64

I found #601 with a feature request for it. I started by adding commit 282063edb568a7a43236b6eca08260691ef34a1a to run the Linux arm64 tests in this repo on the new runners, but it [failed](https://github.com/dennisameling/runner/actions/runs/12838318784/job/35803700129#step:4:61) with the exact same error.

Then I added 72b88ccfebcc6711164195b5928f511027769cfb, and the tests are passing on native Linux arm. There's one more piece to the puzzle though, which is https://github.com/actions/alpine_nodejs/pull/7. Curious if the team has considered merging that one.

Thanks!