### PR TITLE
:whale: Dockerfile: add zstd better compression missing for codeQL

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -8,7 +8,7 @@ ARG RUNNER_CONTAINER_HOOKS_VERSION=0.7.0
 ARG DOCKER_VERSION=28.5.1
 ARG BUILDX_VERSION=0.29.1
 
-RUN apt update -y && apt install curl unzip -y
+RUN apt update -y && apt install curl unzip zstd -y
 
 WORKDIR /actions-runner
 RUN export RUNNER_ARCH=${TARGETARCH} \


### PR DESCRIPTION
This is based on the problems reported in the following issues:

* https://github.com/github/codeql-action/issues/2705 
* https://github.com/github/codeql-action/issues/2400 

The problem is that the base docker image doesn't include `zstd` compression tool. 

# ⚠️ Error in latest Runner

* The error occurs running codeQL:

```console
 Finished downloading CodeQL bundle to /home/runner/_work/_temp/ca3b4527-1a21-43d9-8713-81909027bb0a (11.1s).
  Extracting CodeQL bundle.
  ##[debug]Extracting to /home/runner/_work/_temp/c2146770-b178-4be5-9164-0a0e8345e244.
  tar -x --zstd --warning=no-unknown-keyword --overwrite -f /home/runner/_work/_temp/ca3b4527-1a21-43d9-8713-81909027bb0a -C /home/runner/_work/_temp/c2146770-b178-4be5-9164-0a0e8345e244
  tar (child): zstd: Cannot exec: No such file or directory
  tar (child): Error is not recoverable: exiting now
  tar: Child returned status 2
  tar: Error is not recoverable: exiting now
  ##[debug]Cleaning up extraction destination directory.
  ##[debug]Cleaned up extraction destination directory.
  ##[debug]Cleaning up CodeQL bundle archive.
  ##[debug]Cleaned up CodeQL bundle archive.
  Error: Unable to download and extract CodeQL CLI: Failed to run "tar -x --zstd --warning=no-unknown-keyword --overwrite -f /home/runner/_work/_temp/ca3b4527-1a21-43d9-8713-81909027bb0a -C /home/runner/_work/_temp/c2146770-b178-4be5-9164-0a0e8345e244". Exit code was 2 and last log line was: n/a. See the logs for more details.
  
  Details: Error: Failed to run "tar -x --zstd --warning=no-unknown-keyword --overwrite -f /home/runner/_work/_temp/ca3b4527-1a21-43d9-8713-81909027bb0a -C /home/runner/_work/_temp/c2146770-b178-4be5-9164-0a0e8345e244". Exit code was 2 and last log line was: n/a. See the logs for more details.
      at ChildProcess.<anonymous> (/home/runner/_work/_actions/github/codeql-action/v3.28.1/lib/tar.js:171:28)
      at ChildProcess.emit (node:events:519:28)
      at ChildProcess._handle.onexit (node:internal/child_process:294:12)
```

# ❓ Why

it will drastically increase performance while downloading codeQL.

# 🔧 Fixes in codeQL

* A fix was pushed to https://github.com/github/codeql-action/pull/2710 but it hasn't been released. Just including zstd will guarantee to use the best compression tool other than tar.