### PR TITLE
Create vssconnection to actions service when URL provided.

### DIFF
--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -360,7 +360,7 @@ namespace GitHub.Runner.Listener
             }
         }
 
-        private IMessageListener GetMesageListener(RunnerSettings settings)
+        private IMessageListener GetMessageListener(RunnerSettings settings)
         {
             if (settings.UseV2Flow)
             {
@@ -379,7 +379,7 @@ namespace GitHub.Runner.Listener
             try
             {
                 Trace.Info(nameof(RunAsync));
-                _listener = GetMesageListener(settings);
+                _listener = GetMessageListener(settings);
                 CreateSessionResult createSessionResult = await _listener.CreateSessionAsync(HostContext.RunnerShutdownToken);
                 if (createSessionResult == CreateSessionResult.SessionConflict)
                 {

--- a/src/Test/L0/Listener/BrokerMessageListenerL0.cs
+++ b/src/Test/L0/Listener/BrokerMessageListenerL0.cs
@@ -16,6 +16,7 @@ namespace GitHub.Runner.Common.Tests.Listener
         private readonly RunnerSettings _settings;
         private readonly Mock<IConfigurationManager> _config;
         private readonly Mock<IBrokerServer> _brokerServer;
+        private readonly Mock<IRunnerServer> _runnerServer;
         private readonly Mock<ICredentialManager> _credMgr;
         private Mock<IConfigurationStore> _store;
 
@@ -28,6 +29,7 @@ namespace GitHub.Runner.Common.Tests.Listener
             _credMgr = new Mock<ICredentialManager>();
             _store = new Mock<IConfigurationStore>();
             _brokerServer = new Mock<IBrokerServer>();
+            _runnerServer = new Mock<IRunnerServer>();
         }
 
         [Fact]
@@ -75,6 +77,7 @@ namespace GitHub.Runner.Common.Tests.Listener
             tc.SetSingleton<ICredentialManager>(_credMgr.Object);
             tc.SetSingleton<IConfigurationStore>(_store.Object);
             tc.SetSingleton<IBrokerServer>(_brokerServer.Object);
+            tc.SetSingleton<IRunnerServer>(_runnerServer.Object);
             return tc;
         }
     }


### PR DESCRIPTION
RunnerSetting will have the following 3 stages during migration.

1. `{"ServerURL": "https://pipelines.xxxxx"}`

- Create session and start long-poll with actions-dotnet
- Depends on job type, renew request with run-service or actions-dotnet. When renew with actions-dotnet, the same connection during creation session is re-used.

2 `{"ServerURL": "https://pipelines.xxxxx", "ServerUrlV2":"https://broker.xxxx", "UseV2Flow": true}`

- Create session and start long-poll with broker-listener
- Depends on job type, renew request with run-service or actions-dotnet. The runner is failing for jobs that come from actions-dotnet.

3 `{"ServerUrlV2":"https://broker.xxxx", "UseV2Flow": true}`

- Create session and start long-poll with broker-listener
- Renew request with run-service

This PR make sure `Case 2` works by always creating an VssConnection for actions-dotnet even we create session with broker-listener.

Without this change, when runner start renew request with actions-dotnet, the runner will throw exception about:
```
[2025-03-14 15:35:44Z ERR  JobDispatcher] Catch exception during renew runner jobrequest 1114883.
[2025-03-14 15:35:44Z ERR  JobDispatcher] System.InvalidOperationException: SetConnection JobRequest
   at GitHub.Runner.Common.RunnerServer.CheckConnection(RunnerConnectionType connectionType) in /Users/tingluohuang/repo/runner/src/Runner.Common/RunnerServer.cs:line 195
   at GitHub.Runner.Common.RunnerServer.RenewAgentRequestAsync(Int32 poolId, Int64 requestId, Guid lockToken, String orchestrationId, CancellationToken cancellationToken) in /Users/tingluohuang/repo/runner/src/Runner.Common/RunnerServer.cs:line 287
   at GitHub.Runner.Listener.JobDispatcher.RenewJobRequestAsync(IRunnerServer runnerServer, Int32 poolId, Int64 requestId, Guid lockToken, String orchestrationId, TaskCompletionSource`1 firstJobRequestRenewed, CancellationToken token) in /Users/tingluohuang/repo/runner/src/Runner.Listener/JobDispatcher.cs:line 856
```
