### PR TITLE
Exit hosted runner cleanly during deprovisioning.

### DIFF
--- a/src/Runner.Common/BrokerServer.cs
+++ b/src/Runner.Common/BrokerServer.cs
@@ -93,7 +93,7 @@ namespace GitHub.Runner.Common
 
         public bool ShouldRetryException(Exception ex)
         {
-            if (ex is AccessDeniedException || ex is RunnerNotFoundException)
+            if (ex is AccessDeniedException || ex is RunnerNotFoundException || ex is HostedRunnerDeprovisionedException)
             {
                 return false;
             }

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -249,6 +249,11 @@ namespace GitHub.Runner.Listener
                     Trace.Info("Runner OAuth token has been revoked. Unable to pull message.");
                     throw;
                 }
+                catch (HostedRunnerDeprovisionedException)
+                {
+                    Trace.Info("Hosted runner has been deprovisioned.");
+                    throw;
+                }
                 catch (AccessDeniedException e) when (e.ErrorCode == 1)
                 {
                     throw;

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -304,6 +304,11 @@ namespace GitHub.Runner.Listener
                     _accessTokenRevoked = true;
                     throw;
                 }
+                catch (HostedRunnerDeprovisionedException)
+                {
+                    Trace.Info("Hosted runner has been deprovisioned.");
+                    throw;
+                }
                 catch (AccessDeniedException e) when (e.ErrorCode == 1)
                 {
                     throw;

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -697,6 +697,10 @@ namespace GitHub.Runner.Listener
             {
                 Trace.Info("Runner OAuth token has been revoked. Shutting down.");
             }
+            catch (HostedRunnerDeprovisionedException)
+            {
+                Trace.Info("Hosted runner has been deprovisioned. Shutting down.");
+            }
 
             return Constants.Runner.ReturnCode.Success;
         }

--- a/src/Sdk/RSWebApi/Contracts/BrokerErrorKind.cs
+++ b/src/Sdk/RSWebApi/Contracts/BrokerErrorKind.cs
@@ -7,5 +7,6 @@ namespace GitHub.Actions.RunService.WebApi
     {
         public const string RunnerNotFound = "RunnerNotFound";
         public const string RunnerVersionTooOld = "RunnerVersionTooOld";
+        public const string HostedRunnerDeprovisioned = "HostedRunnerDeprovisioned";
     }
 }

--- a/src/Sdk/WebApi/WebApi/BrokerHttpClient.cs
+++ b/src/Sdk/WebApi/WebApi/BrokerHttpClient.cs
@@ -122,6 +122,8 @@ namespace GitHub.Actions.RunService.WebApi
                         {
                             ErrorCode = 1
                         };
+                    case BrokerErrorKind.HostedRunnerDeprovisioned:
+                        throw new HostedRunnerDeprovisionedException(brokerError.Message);
                     default:
                         break;
                 }

--- a/src/Sdk/WebApi/WebApi/Exceptions/HostedRunnerDeprovisionedException.cs
+++ b/src/Sdk/WebApi/WebApi/Exceptions/HostedRunnerDeprovisionedException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace GitHub.Services.WebApi
+{
+    [Serializable]
+    public sealed class HostedRunnerDeprovisionedException : Exception
+    {
+        public HostedRunnerDeprovisionedException()
+            : base()
+        {
+        }
+
+        public HostedRunnerDeprovisionedException(String message)
+            : base(message)
+        {
+        }
+
+        public HostedRunnerDeprovisionedException(String message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
We were using `TaskAgentAccessTokenExpiredException` with actions-dotnet to exit the runner during deprovisioning since the token will get revoked first.

With broker-listener, the token won't get revoked, but the server will return different error to indicate the hosted is deprovisioned.