### PR TITLE
Set JWT.alg to PS256 with PssPadding.

### DIFF
--- a/src/Sdk/WebApi/WebApi/Jwt/JsonWebToken.cs
+++ b/src/Sdk/WebApi/WebApi/Jwt/JsonWebToken.cs
@@ -25,7 +25,10 @@ namespace GitHub.Services.WebApi.Jwt
         HS256,
 
         [EnumMember]
-        RS256
+        RS256,
+
+        [EnumMember]
+        PS256,
     }
 
     //JsonWebToken is marked as DataContract so
@@ -286,6 +289,7 @@ namespace GitHub.Services.WebApi.Jwt
             {
                 case JWTAlgorithm.HS256:
                 case JWTAlgorithm.RS256:
+                case JWTAlgorithm.PS256:
                     return signingCredentials.SignData(bytes);
 
                 default:

--- a/src/Sdk/WebApi/WebApi/VssSigningCredentials.cs
+++ b/src/Sdk/WebApi/WebApi/VssSigningCredentials.cs
@@ -166,6 +166,21 @@ namespace GitHub.Services.WebApi
                 }
             }
 
+            public override JWTAlgorithm SignatureAlgorithm
+            {
+                get
+                {
+                    if (m_signaturePadding == RSASignaturePadding.Pss)
+                    {
+                        return JWTAlgorithm.PS256;
+                    }
+                    else
+                    {
+                        return base.SignatureAlgorithm;
+                    }
+                }
+            }
+
             protected override Byte[] GetSignature(Byte[] input)
             {
                 using (var rsa = m_factory())


### PR DESCRIPTION
When using `RSASignaturePadding.Pss`, we should set `alg` in JWT to `PS256` instead of `RS256`.