### PR TITLE
Enable FIPS by default.

### DIFF
--- a/src/Runner.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Runner.Listener/Configuration/ConfigurationManager.cs
@@ -366,7 +366,7 @@ namespace GitHub.Runner.Listener.Configuration
                     {
                         { "clientId", agent.Authorization.ClientId.ToString("D") },
                         { "authorizationUrl", agent.Authorization.AuthorizationUrl.AbsoluteUri },
-                        { "requireFipsCryptography", agent.Properties.GetValue("RequireFipsCryptography", false).ToString() }
+                        { "requireFipsCryptography", agent.Properties.GetValue("RequireFipsCryptography", true).ToString() }
                     },
                 };
 


### PR DESCRIPTION
https://github.com/github/actions-dotnet/commit/ad96f4b84445405a10dc25a4135d4903dadc8516#diff-9c953667712e95dd913e8a59cc8b04ce06803279593a85929c2f9f531acba185L28

FIPS has been enabled by default for 4+ years, flip the default in the runner, so we don't have to provide the field from runner-admin.