### PR TITLE
Allow enable auth migration by default.

### DIFF
--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -268,7 +268,7 @@ namespace GitHub.Runner.Common
                 }
             }
 
-            _trace.Info($"Enable auth migration at {_deferredAuthMigrationTime.ToString("O")}.");
+            _trace.Info($"Enable auth migration at {DateTime.UtcNow.ToString("O")}.");
             AuthMigrationChanged?.Invoke(this, new AuthMigrationEventArgs(trace));
         }
 

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -309,6 +309,15 @@ namespace GitHub.Runner.Listener
                         _term.WriteLine("https://docs.github.com/en/actions/hosting-your-own-runners/autoscaling-with-self-hosted-runners#using-ephemeral-runners-for-autoscaling", ConsoleColor.Yellow);
                     }
 
+                    var cred = store.GetCredentials();
+                    if (cred != null &&
+                        cred.Scheme == Constants.Configuration.OAuth &&
+                        cred.Data.ContainsKey("EnableAuthMigrationByDefault"))
+                    {
+                        Trace.Info("Enable auth migration by default.");
+                        HostContext.EnableAuthMigration("EnableAuthMigrationByDefault");
+                    }
+
                     // Run the runner interactively or as service
                     return await RunAsync(settings, command.RunOnce || settings.Ephemeral);
                 }


### PR DESCRIPTION
This pull request introduces changes to enable authentication migration by default when certain conditions are met. The most important changes include modifications to the `EnableAuthMigration` method, updates to the `ExecuteCommand` method, and the addition of a new unit test to verify the new functionality.