### PR TITLE
Implement termination grace period support for the runner

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -257,6 +257,7 @@ namespace GitHub.Runner.Common
                 public static readonly string ForcedActionsNodeVersion = "ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION";
                 public static readonly string PrintLogToStdout = "ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT";
                 public static readonly string ActionArchiveCacheDirectory = "ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE";
+                public static readonly string ActionsTerminationGracePeriodSeconds = "ACTIONS_RUNNER_TERMINATION_GRACE_PERIOD_SECONDS";
             }
 
             public static class System

--- a/src/Test/L0/Listener/RunnerL0.cs
+++ b/src/Test/L0/Listener/RunnerL0.cs
@@ -126,7 +126,7 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                     });
 
-                hc.EnqueueInstance<IJobDispatcher>(_jobDispatcher.Object);
+                hc.SetSingleton<IJobDispatcher>(_jobDispatcher.Object);
 
                 _configStore.Setup(x => x.IsServiceConfigured()).Returns(false);
                 //Act
@@ -309,7 +309,7 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                     });
 
-                hc.EnqueueInstance<IJobDispatcher>(_jobDispatcher.Object);
+                hc.SetSingleton<IJobDispatcher>(_jobDispatcher.Object);
 
                 _configStore.Setup(x => x.IsServiceConfigured()).Returns(false);
                 //Act
@@ -413,7 +413,7 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                     });
 
-                hc.EnqueueInstance<IJobDispatcher>(_jobDispatcher.Object);
+                hc.SetSingleton<IJobDispatcher>(_jobDispatcher.Object);
 
                 _configStore.Setup(x => x.IsServiceConfigured()).Returns(false);
                 //Act
@@ -503,7 +503,7 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                     });
 
-                hc.EnqueueInstance<IJobDispatcher>(_jobDispatcher.Object);
+                hc.SetSingleton<IJobDispatcher>(_jobDispatcher.Object);
 
                 _configStore.Setup(x => x.IsServiceConfigured()).Returns(false);
                 //Act
@@ -578,7 +578,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 hc.SetSingleton<IConfigurationStore>(_configStore.Object);
                 hc.SetSingleton<ICredentialManager>(_credentialManager.Object);
                 hc.EnqueueInstance<IErrorThrottler>(_acquireJobThrottler.Object);
-                hc.EnqueueInstance<IJobDispatcher>(_jobDispatcher.Object);
+                hc.SetSingleton<IJobDispatcher>(_jobDispatcher.Object);
 
                 runner.Initialize(hc);
                 var settings = new RunnerSettings
@@ -679,7 +679,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 hc.SetSingleton<ICredentialManager>(_credentialManager.Object);
                 hc.EnqueueInstance<IErrorThrottler>(_acquireJobThrottler.Object);
                 hc.EnqueueInstance<IActionsRunServer>(_actionsRunServer.Object);
-                hc.EnqueueInstance<IJobDispatcher>(_jobDispatcher.Object);
+                hc.SetSingleton<IJobDispatcher>(_jobDispatcher.Object);
 
                 runner.Initialize(hc);
                 var settings = new RunnerSettings
@@ -780,7 +780,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 hc.SetSingleton<ICredentialManager>(_credentialManager.Object);
                 hc.EnqueueInstance<IErrorThrottler>(_acquireJobThrottler.Object);
                 hc.EnqueueInstance<IRunServer>(_runServer.Object);
-                hc.EnqueueInstance<IJobDispatcher>(_jobDispatcher.Object);
+                hc.SetSingleton<IJobDispatcher>(_jobDispatcher.Object);
 
                 runner.Initialize(hc);
                 var settings = new RunnerSettings
@@ -880,7 +880,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 hc.SetSingleton<ISelfUpdater>(_updater.Object);
                 hc.SetSingleton<ICredentialManager>(_credentialManager.Object);
                 hc.EnqueueInstance<IErrorThrottler>(_acquireJobThrottler.Object);
-                hc.EnqueueInstance<IJobDispatcher>(_jobDispatcher.Object);
+                hc.SetSingleton<IJobDispatcher>(_jobDispatcher.Object);
                 hc.EnqueueInstance<IRunServer>(_runServer.Object);
                 hc.EnqueueInstance<IRunServer>(_runServer.Object);
 

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -339,7 +339,7 @@ namespace GitHub.Runner.Common.Tests
             return _traceManager[name];
         }
 
-        public void ShutdownRunner(ShutdownReason reason)
+        public void ShutdownRunner(ShutdownReason reason, TimeSpan delay = default)
         {
             ArgUtil.NotNull(reason, nameof(reason));
             RunnerShutdownReason = reason;


### PR DESCRIPTION
`export ACTIONS_RUNNER_TERMINATION_GRACE_PERIOD_SECONDS=100`

The runner will not cancel its current runner step during the grace period.

However, depends on how child process launched in the step, those process might still exit by itself if they dont' `trap '' INT TERM`.

Try to improve: https://github.com/actions/runner/issues/3308