### PR TITLE
Add a non-busy path to safe_sleep for modern versions of bash

### DIFF
--- a/src/Misc/layoutroot/safe_sleep.sh
+++ b/src/Misc/layoutroot/safe_sleep.sh
@@ -8,7 +8,7 @@ if [[ -n "$BASH_VERSINFO" && "${BASH_VERSINFO[0]}" -ge 4 ]]; then
     # Bash has no sleep builtin, but read with a timeout can behave in same way.
     read -rt "$1" <> <(:) || :
 fi
-# Fall back to busy wait;
+# Fallback to busy wait.
 while [[ $SECONDS -lt $1 ]]; do
     echo bar
     :


### PR DESCRIPTION
The current implementation of `safe_sleep.sh` is a busy wait.

This seems to exist because `sleep` is not a shell builtin, and it can't be assumed all environments have the sleep binary.

Bash 4 and above support the builtin `read` command, which can be used as a sleep with the timeout feature. This pattern is described here:
https://github.com/dylanaraps/pure-bash-bible?tab=readme-ov-file#use-read-as-an-alternative-to-the-sleep-command

Despite Bash 4 shipping 16 years ago, bash 3.x is still the default shipped on MacOS due to 4+ being licensed as GPL3, so the busy wait was retained as a fallback.

Also the condition in the busy wait was switched from `!=` to `-lt`, which is a safer comparison and avoids possibility of an infinite loop.

Fixes #2380 

#3143 has another similar approach, which relies on conditionally checking for sleep or ping binaries to provide a sleep functionality.