### PR TITLE
show helpful error message when resolving actions directly with launch

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -168,6 +168,7 @@ namespace GitHub.Runner.Common
                 public static readonly string UseContainerPathForTemplate = "DistributedTask.UseContainerPathForTemplate";
                 public static readonly string AllowRunnerContainerHooks = "DistributedTask.AllowRunnerContainerHooks";
                 public static readonly string AddCheckRunIdToJobContext = "actions_add_check_run_id_to_job_context";
+                public static readonly string DisplayHelpfulActionsDownloadErrors = "actions_display_helpful_actions_download_errors";
             }
 
             public static readonly string InternalTelemetryIssueDataKey = "_internal_telemetry";

--- a/src/Runner.Common/LaunchServer.cs
+++ b/src/Runner.Common/LaunchServer.cs
@@ -15,7 +15,7 @@ namespace GitHub.Runner.Common
     {
         void InitializeLaunchClient(Uri uri, string token);
 
-        Task<ActionDownloadInfoCollection> ResolveActionsDownloadInfoAsync(Guid planId, Guid jobId, ActionReferenceList actionReferenceList, CancellationToken cancellationToken);
+        Task<ActionDownloadInfoCollection> ResolveActionsDownloadInfoAsync(Guid planId, Guid jobId, ActionReferenceList actionReferenceList, CancellationToken cancellationToken, bool displayHelpfulActionsDownloadErrors);
     }
 
     public sealed class LaunchServer : RunnerService, ILaunchServer
@@ -42,12 +42,16 @@ namespace GitHub.Runner.Common
         }
 
         public Task<ActionDownloadInfoCollection> ResolveActionsDownloadInfoAsync(Guid planId, Guid jobId, ActionReferenceList actionReferenceList,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken, bool displayHelpfulActionsDownloadErrors)
         {
             if (_launchClient != null)
             {
-                return _launchClient.GetResolveActionsDownloadInfoAsync(planId, jobId, actionReferenceList,
-                    cancellationToken: cancellationToken);
+                if (!displayHelpfulActionsDownloadErrors)
+                {
+                    return _launchClient.GetResolveActionsDownloadInfoAsync(planId, jobId, actionReferenceList,
+                        cancellationToken: cancellationToken);
+                }
+                return _launchClient.GetResolveActionsDownloadInfoAsyncV2(planId, jobId, actionReferenceList, cancellationToken);
             }
 
             throw new InvalidOperationException("Launch client is not initialized.");

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -688,7 +688,8 @@ namespace GitHub.Runner.Worker
                 {
                     if (MessageUtil.IsRunServiceJob(executionContext.Global.Variables.Get(Constants.Variables.System.JobRequestType)))
                     {
-                        actionDownloadInfos = await launchServer.ResolveActionsDownloadInfoAsync(executionContext.Global.Plan.PlanId, executionContext.Root.Id, new WebApi.ActionReferenceList { Actions = actionReferences }, executionContext.CancellationToken);
+                        var displayHelpfulActionsDownloadErrors = executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DisplayHelpfulActionsDownloadErrors) ?? false;
+                        actionDownloadInfos = await launchServer.ResolveActionsDownloadInfoAsync(executionContext.Global.Plan.PlanId, executionContext.Root.Id, new WebApi.ActionReferenceList { Actions = actionReferences }, executionContext.CancellationToken, displayHelpfulActionsDownloadErrors);
                     }
                     else
                     {

--- a/src/Sdk/WebApi/WebApi/LaunchContracts.cs
+++ b/src/Sdk/WebApi/WebApi/LaunchContracts.cs
@@ -29,7 +29,7 @@ namespace GitHub.Services.Launch.Contracts
     {
         [DataMember(EmitDefaultValue = false, Name = "authentication")]
         public ActionDownloadAuthenticationResponse Authentication { get; set; }
-        
+
         [DataMember(EmitDefaultValue = false, Name = "package_details")]
         public ActionDownloadPackageDetailsResponse PackageDetails { get; set; }
 
@@ -64,7 +64,7 @@ namespace GitHub.Services.Launch.Contracts
 
 
     [DataContract]
-    public class ActionDownloadPackageDetailsResponse 
+    public class ActionDownloadPackageDetailsResponse
     {
         [DataMember(EmitDefaultValue = false, Name = "version")]
         public string Version { get; set; }
@@ -80,5 +80,26 @@ namespace GitHub.Services.Launch.Contracts
         /// <remarks>The key is the full name of the action plus version, e.g. "actions/checkout@v2".</remarks>
         [DataMember(EmitDefaultValue = false, Name = "actions")]
         public IDictionary<string, ActionDownloadInfoResponse> Actions { get; set; }
+    }
+
+    [DataContract]
+    public class ActionDownloadResolutionError
+    {
+        /// <summary>
+        /// The error message associated with the action download error.
+        /// </summary>
+        [DataMember(EmitDefaultValue = false, Name = "message")]
+        public string Message { get; set; }
+    }
+
+    [DataContract]
+    public class ActionDownloadResolutionErrorCollection
+    {
+        /// <summary>
+        /// A mapping of action specifications to their download errors.
+        /// <remarks>The key is the full name of the action plus version, e.g. "actions/checkout@v2".</remarks>
+        /// </summary>
+        [DataMember(EmitDefaultValue = false, Name = "errors")]
+        public IDictionary<string, ActionDownloadResolutionError> Errors { get; set; }
     }
 }

--- a/src/Sdk/WebApi/WebApi/LaunchHttpClient.cs
+++ b/src/Sdk/WebApi/WebApi/LaunchHttpClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
 using System.Net.Http.Headers;
@@ -32,11 +33,49 @@ namespace GitHub.Services.Launch.Client
         public async Task<ActionDownloadInfoCollection> GetResolveActionsDownloadInfoAsync(Guid planId, Guid jobId, ActionReferenceList actionReferenceList, CancellationToken cancellationToken)
         {
             var GetResolveActionsDownloadInfoURLEndpoint = new Uri(m_launchServiceUrl, $"/actions/build/{planId.ToString()}/jobs/{jobId.ToString()}/runnerresolve/actions");
-            return ToServerData(await GetLaunchSignedURLResponse<ActionReferenceRequestList, ActionDownloadInfoResponseCollection>(GetResolveActionsDownloadInfoURLEndpoint, ToGitHubData(actionReferenceList), cancellationToken));
+            var response = await GetLaunchSignedURLResponse<ActionReferenceRequestList>(GetResolveActionsDownloadInfoURLEndpoint, ToGitHubData(actionReferenceList), cancellationToken);
+            return ToServerData(await ReadJsonContentAsync<ActionDownloadInfoResponseCollection>(response, cancellationToken));
         }
 
-        // Resolve Actions
-        private async Task<T> GetLaunchSignedURLResponse<R, T>(Uri uri, R request, CancellationToken cancellationToken)
+        public async Task<ActionDownloadInfoCollection> GetResolveActionsDownloadInfoAsyncV2(Guid planId, Guid jobId, ActionReferenceList actionReferenceList, CancellationToken cancellationToken)
+        {
+            var GetResolveActionsDownloadInfoURLEndpoint = new Uri(m_launchServiceUrl, $"/actions/build/{planId.ToString()}/jobs/{jobId.ToString()}/runnerresolve/actions");
+            var response = await GetLaunchSignedURLResponse<ActionReferenceRequestList>(GetResolveActionsDownloadInfoURLEndpoint, ToGitHubData(actionReferenceList), cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                // Success response - deserialize the action download info
+                return ToServerData(await ReadJsonContentAsync<ActionDownloadInfoResponseCollection>(response, cancellationToken));
+            }
+
+            var responseError = response.ReasonPhrase ?? "";
+            if (response.StatusCode == HttpStatusCode.UnprocessableEntity)
+            {
+                // 422 response - unresolvable actions, error details are in the body
+                var errors = await ReadJsonContentAsync<ActionDownloadResolutionErrorCollection>(response, cancellationToken);
+                string combinedErrorMessage;
+                if (errors?.Errors != null && errors.Errors.Any())
+                {
+                    combinedErrorMessage = String.Join(". ", errors.Errors.Select(kvp => kvp.Value.Message));
+                }
+                else
+                {
+                    combinedErrorMessage = responseError;
+                }
+
+                throw new UnresolvableActionDownloadInfoException(combinedErrorMessage);
+            }
+            else if (response.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                throw new NonRetryableActionDownloadInfoException(responseError + " (GitHub has reached an internal rate limit, please try again later)");
+            }
+            else
+            {
+                throw new Exception(responseError);
+            }
+        }
+
+        private async Task<HttpResponseMessage> GetLaunchSignedURLResponse<R>(Uri uri, R request, CancellationToken cancellationToken)
         {
             using (HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Post, uri))
             {
@@ -46,10 +85,7 @@ namespace GitHub.Services.Launch.Client
                 using (HttpContent content = new ObjectContent<R>(request, m_formatter))
                 {
                     requestMessage.Content = content;
-                    using (var response = await SendAsync(requestMessage, HttpCompletionOption.ResponseContentRead, cancellationToken: cancellationToken))
-                    {
-                        return await ReadJsonContentAsync<T>(response, cancellationToken);
-                    }
+                    return await SendAsync(requestMessage, HttpCompletionOption.ResponseContentRead, cancellationToken: cancellationToken);
                 }
             }
         }

--- a/src/Sdk/WebApi/WebApi/LaunchHttpClient.cs
+++ b/src/Sdk/WebApi/WebApi/LaunchHttpClient.cs
@@ -67,6 +67,9 @@ namespace GitHub.Services.Launch.Client
             }
             else if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
+                // Here we want to add a message so customers don't think it's a rate limit scoped to them
+                // Ideally this would be 500 but the runner retries 500s, which we don't want to do when we're being rate limited
+                // See: https://github.com/github/ecosystem-api/issues/4084
                 throw new NonRetryableActionDownloadInfoException(responseError + " (GitHub has reached an internal rate limit, please try again later)");
             }
             else

--- a/src/Test/L0/Sdk/LaunchWebApi/LaunchHttpClientL0.cs
+++ b/src/Test/L0/Sdk/LaunchWebApi/LaunchHttpClientL0.cs
@@ -1,0 +1,126 @@
+using GitHub.Actions.RunService.WebApi;
+using GitHub.DistributedTask.WebApi;
+using GitHub.Services.Launch.Client;
+using GitHub.Services.Launch.Contracts;
+using Moq;
+using Moq.Protected;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GitHub.Actions.RunService.WebApi.Tests
+{
+    public sealed class LaunchHttpClientL0
+    {
+        [Fact]
+        public async Task GetResolveActionsDownloadInfoAsync_SuccessResponse()
+        {
+            var baseUrl = new Uri("https://api.github.com/");
+            var planId = Guid.NewGuid();
+            var jobId = Guid.NewGuid();
+            var token = "fake-token";
+
+            var actionReferenceList = new ActionReferenceList
+            {
+                Actions = new List<ActionReference>
+                {
+                    new ActionReference
+                    {
+                        NameWithOwner = "owner1/action1",
+                        Ref = "0123456789"
+                    }
+                }
+            };
+
+            var responseContent = @"{
+                ""actions"": {
+                    ""owner1/action1@0123456789"": {
+                        ""name"": ""owner1/action1"",
+                        ""resolved_name"": ""owner1/action1"",
+                        ""resolved_sha"": ""0123456789"",
+                        ""version"": ""0123456789"",
+                        ""zip_url"": ""https://github.com/owner1/action1/zip"",
+                        ""tar_url"": ""https://github.com/owner1/action1/tar""
+                    }
+                }
+            }";
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json"),
+                RequestMessage = new HttpRequestMessage()
+                {
+                    RequestUri = new Uri($"{baseUrl}actions/build/{planId}/jobs/{jobId}/runnerresolve/actions")
+                }
+            };
+
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(httpResponse);
+
+            var client = new LaunchHttpClient(baseUrl, mockHandler.Object, token, false);
+            var result = await client.GetResolveActionsDownloadInfoAsyncV2(planId, jobId, actionReferenceList, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotEmpty(result.Actions);
+            Assert.Equal(actionReferenceList.Actions.Count, result.Actions.Count);
+            Assert.True(result.Actions.ContainsKey("owner1/action1@0123456789"));
+        }
+
+        [Fact]
+        public async Task GetResolveActionsDownloadInfoAsync_UnprocessableEntityResponse()
+        {
+            var baseUrl = new Uri("https://api.github.com/");
+            var planId = Guid.NewGuid();
+            var jobId = Guid.NewGuid();
+            var token = "fake-token";
+
+            var actionReferenceList = new ActionReferenceList
+            {
+                Actions = new List<ActionReference>
+                {
+                    new ActionReference
+                    {
+                        NameWithOwner = "owner1/action1",
+                        Ref = "0123456789"
+                    }
+                }
+            };
+
+            var responseContent = @"{
+                ""errors"": {
+                    ""owner1/invalid-action@0123456789"": {
+                        ""message"": ""Unable to resolve action 'owner1/invalid-action@0123456789', repository not found""
+                    }
+                }
+            }";
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.UnprocessableEntity)
+            {
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json"),
+                RequestMessage = new HttpRequestMessage()
+                {
+                    RequestUri = new Uri($"{baseUrl}actions/build/{planId}/jobs/{jobId}/runnerresolve/actions")
+                }
+            };
+
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(httpResponse);
+
+            var client = new LaunchHttpClient(baseUrl, mockHandler.Object, token, false);
+
+            var exception = await Assert.ThrowsAsync<UnresolvableActionDownloadInfoException>(
+                () => client.GetResolveActionsDownloadInfoAsyncV2(planId, jobId, actionReferenceList, CancellationToken.None));
+            
+            Assert.Contains("repository not found", exception.Message);
+        }
+    }
+}

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -2411,8 +2411,8 @@ runs:
                 });
 
             _launchServer = new Mock<ILaunchServer>();
-            _launchServer.Setup(x => x.ResolveActionsDownloadInfoAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ActionReferenceList>(), It.IsAny<CancellationToken>()))
-                .Returns((Guid planId, Guid jobId, ActionReferenceList actions, CancellationToken cancellationToken) =>
+            _launchServer.Setup(x => x.ResolveActionsDownloadInfoAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ActionReferenceList>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+                .Returns((Guid planId, Guid jobId, ActionReferenceList actions, CancellationToken cancellationToken, bool displayHelpfulActionsDownloadErrors) =>
                 {
                     var result = new ActionDownloadInfoCollection { Actions = new Dictionary<string, ActionDownloadInfo>() };
                     foreach (var action in actions.Actions)


### PR DESCRIPTION
Related: https://github.com/github/actions-runtime/issues/5135

Before:
<img width="637" alt="Screenshot 2025-05-27 at 22 45 04" src="https://github.com/user-attachments/assets/f34b79d2-d4dc-445f-af57-a9c2bfc244bd" />

vs. After:
<img width="1088" alt="Screenshot 2025-05-27 at 22 45 17" src="https://github.com/user-attachments/assets/4dcbd252-f537-46e1-bdb9-bed788cc9224" />

actions-dotnet implementation: https://github.com/github/actions-dotnet/blob/f9322e925c9f23d04fb974295604864fd4a195cc/Launch/Sdk/Server/LaunchApi.cs#L87-L98