### PR TITLE
Fix sporadic failures of TestRunnerJobRequestMessageFromRunService_AuthMigrationFallback

### DIFF
--- a/src/Test/L0/Listener/RunnerL0.cs
+++ b/src/Test/L0/Listener/RunnerL0.cs
@@ -978,7 +978,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 _messageListener.Verify(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()), Times.AtLeast(2));
                 _messageListener.Verify(x => x.DeleteMessageAsync(It.IsAny<TaskAgentMessage>()), Times.AtLeast(2));
                 _messageListener.Verify(x => x.DeleteSessionAsync(), Times.Once());
-                _credentialManager.Verify(x => x.LoadCredentials(true), Times.Exactly(2));
+                _credentialManager.Verify(x => x.LoadCredentials(true), Times.AtLeast(2));
 
                 Assert.False(hc.AllowAuthMigration);
             }


### PR DESCRIPTION
I ran into an issue where `TestRunnerJobRequestMessageFromRunService_AuthMigrationFallback` would fail with the following error:

```
#25 360.8   Starting test execution, please wait...
#25 362.1   A total of 1 test files matched the specified pattern.
#25 460.2   [xUnit.net 00:01:27.31]     GitHub.Runner.Common.Tests.Listener.RunnerL0.TestRunnerJobRequestMessageFromRunService_AuthMigrationFallback [FAIL]
#25 461.2     Failed GitHub.Runner.Common.Tests.Listener.RunnerL0.TestRunnerJobRequestMessageFromRunService_AuthMigrationFallback [177 ms]
#25 461.4 EXEC : error Message:  [/opt/runner/src/dir.proj]
#25 461.4      Moq.MockException : 
#25 461.4   Expected invocation on the mock exactly 2 times, but was 3 times: x => x.LoadCredentials(True)
#25 461.4   
#25 461.4   Performed invocations:
#25 461.4   
#25 461.4      Mock<ICredentialManager:33> (x):
#25 461.4   
#25 461.4         IRunnerService.Initialize(TestHostContext)
#25 461.4         IRunnerService.Initialize(TestHostContext)
#25 461.4         ICredentialManager.LoadCredentials(True)
#25 461.4         ICredentialManager.LoadCredentials(False)
#25 461.4         ICredentialManager.LoadCredentials(True)
#25 461.4         IRunnerService.Initialize(TestHostContext)
#25 461.4         ICredentialManager.LoadCredentials(True)
#25 461.4   
#25 461.4     Stack Trace:
#25 461.4        at Moq.Mock.Verify(Mock mock, LambdaExpression expression, Times times, String failMessage) in /_/src/Moq/Mock.cs:line 332
#25 461.4      at Moq.Mock`1[[GitHub.Runner.Listener.Configuration.ICredentialManager, Runner.Listener, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]].Verify[VssCredentials](Expression`1 expression, Times times) in /_/src/Moq/Mock`1.cs:line 825
#25 461.4      at GitHub.Runner.Common.Tests.Listener.RunnerL0.TestRunnerJobRequestMessageFromRunService_AuthMigrationFallback() in /opt/runner/src/Test/L0/Listener/RunnerL0.cs:line 981
#25 461.4   --- End of stack trace from previous location ---
#25 463.1   Results File: /opt/runner/src/Test/TestResults/_buildkitsandbox_2025-05-27_00_18_24.trx
#25 463.1   
#25 463.2   Failed!  - Failed:     1, Passed:   682, Skipped:     0, Total:   683, Duration: 1 m 21 s - Test.dll (net8.0)
#25 464.3 /opt/runner/src/dir.proj(60,9): error MSB3073: The command "dotnet test Test/Test.csproj -c Debug --no-build --logger:trx" exited with code 1.
#25 464.8 Failed: failed tests
```

As far as I was able to determine, this happens because it's executed in emulation (it's part of docker image build for various platforms) which makes it slow, while this test depends on timing of particular events happening.

Suggested change might not be the right fix: I'm making a guess that additional calls to `LoadCredentials` are ok in the context of this test.

@TingluoHuang  Please take a look, thanks.