### PR TITLE
Fixed to be able to use ’shell: dotnet run {0}'

### DIFF
--- a/src/Runner.Worker/Handlers/ScriptHandlerHelpers.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandlerHelpers.cs
@@ -27,7 +27,8 @@ namespace GitHub.Runner.Worker.Handlers
             ["powershell"] = ".ps1",
             ["bash"] = ".sh",
             ["sh"] = ".sh",
-            ["python"] = ".py"
+            ["python"] = ".py",
+            ["dotnet"] = ".cs"
         };
 
         internal static string GetScriptArgumentsFormat(string scriptType)


### PR DESCRIPTION
## Summary
Since .NET10 Preview 4, it is possible to run a standalone `.cs` file directly.
```shell
$ ls
app.cs
$ dotnet run app.cs
```
ref: https://devblogs.microsoft.com/dotnet/announcing-dotnet-run-app/

So I would like to write the following code.
```yaml
- uses: actions/setup-dotnet@v4
  with:
    dotnet-version: "10.0.x"
    dotnet-quality: "preview"
- name: Sandbox
  shell: dotnet run {0}
  run: |
    Console.WriteLine("Hello, world!");
```

But I found that it only works if the extension is `.cs`.
```
$ dotnet run sample.cs    
Hello, World!
$ dotnet run sample2
Couldn't find a project to run. Ensure a project exists in /Users/hanachiru/Sandbox, or pass the path to the project using --project.
```

So I added the extension `.cs` if shellCommand is `dotnet`.

## Changes
- If the shellCommand is `dotnet`, add the extension `.cs`.

## Note
I would like to discuss with the reviewer whether to add `["dotnet"] = "run {0}"` to the `_defaultArguments`.
https://github.com/actions/runner/blob/acf3f2ba1286a3dd12454fb6effb3bcb6b03c304/src/Runner.Worker/Handlers/ScriptHandlerHelpers.cs#L13-L21