### PR TITLE
feat: Add wget to the image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -8,7 +8,7 @@ ARG RUNNER_CONTAINER_HOOKS_VERSION=0.7.0
 ARG DOCKER_VERSION=28.2.1
 ARG BUILDX_VERSION=0.24.0
 
-RUN apt update -y && apt install curl unzip -y
+RUN apt update -y && apt install curl wget unzip -y
 
 WORKDIR /actions-runner
 RUN export RUNNER_ARCH=${TARGETARCH} \


### PR DESCRIPTION
This provides more consistent behavior to the GitHub-provided runners when using the default image compared to self-hosted runners using ARC.