### PR TITLE
Allow to overwrite ACTIONS_CACHE_URL environment variable

### DIFF
--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -219,7 +219,13 @@ namespace GitHub.Runner.Worker.Handlers
             var systemConnection = ExecutionContext.Global.Endpoints.Single(x => string.Equals(x.Name, WellKnownServiceEndpointNames.SystemVssConnection, StringComparison.OrdinalIgnoreCase));
             Environment["ACTIONS_RUNTIME_URL"] = systemConnection.Url.AbsoluteUri;
             Environment["ACTIONS_RUNTIME_TOKEN"] = systemConnection.Authorization.Parameters[EndpointAuthorizationParameters.AccessToken];
-            if (systemConnection.Data.TryGetValue("CacheServerUrl", out var cacheUrl) && !string.IsNullOrEmpty(cacheUrl))
+
+            string customCacheUrl = System.Environment.GetEnvironmentVariable("CUSTOM_ACTIONS_CACHE_URL");
+            if (!string.IsNullOrEmpty(customCacheUrl))
+            {
+                Environment["ACTIONS_CACHE_URL"] = customCacheUrl;
+            }
+            else if (systemConnection.Data.TryGetValue("CacheServerUrl", out var cacheUrl) && !string.IsNullOrEmpty(cacheUrl))
             {
                 Environment["ACTIONS_CACHE_URL"] = cacheUrl;
             }

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -54,7 +54,13 @@ namespace GitHub.Runner.Worker.Handlers
             var systemConnection = ExecutionContext.Global.Endpoints.Single(x => string.Equals(x.Name, WellKnownServiceEndpointNames.SystemVssConnection, StringComparison.OrdinalIgnoreCase));
             Environment["ACTIONS_RUNTIME_URL"] = systemConnection.Url.AbsoluteUri;
             Environment["ACTIONS_RUNTIME_TOKEN"] = systemConnection.Authorization.Parameters[EndpointAuthorizationParameters.AccessToken];
-            if (systemConnection.Data.TryGetValue("CacheServerUrl", out var cacheUrl) && !string.IsNullOrEmpty(cacheUrl))
+
+            string customCacheUrl = System.Environment.GetEnvironmentVariable("CUSTOM_ACTIONS_CACHE_URL");
+            if (!string.IsNullOrEmpty(customCacheUrl))
+            {
+                Environment["ACTIONS_CACHE_URL"] = customCacheUrl;
+            }
+            else if (systemConnection.Data.TryGetValue("CacheServerUrl", out var cacheUrl) && !string.IsNullOrEmpty(cacheUrl))
             {
                 Environment["ACTIONS_CACHE_URL"] = cacheUrl;
             }


### PR DESCRIPTION
The runner script sets the `ACTIONS_CACHE_URL` using the value from the system connection. Currently, there's no way to override it.

Some community users use custom cache solutions with self-hosted runners. They need to maintain a fork of `actions/runner` or `actions/toolkit`, and `actions/cache` to override the value in their solution. However it leads to significant maintenance work.

If the runner script allows the `ACTIONS_CACHE_URL` value to be overridden by the `CUSTOM_ACTIONS_CACHE_URL` environment variable, it makes life a lot easier for the community, includes myself.

An alternative solution could involve allowing the base URL value in `actions/toolkit` to be overridden. Several individuals have submitted similar PRs to this one https://github.com/actions/toolkit/pull/1695, but they have not received adequate attention from the maintainers.