### PR TITLE
Fix symlink handling in CopyDirectory method

### DIFF
--- a/src/Runner.Sdk/Util/IOUtil.cs
+++ b/src/Runner.Sdk/Util/IOUtil.cs
@@ -399,23 +399,49 @@ namespace GitHub.Runner.Sdk
             ArgUtil.NotNull(cancellationToken, nameof(cancellationToken));
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Get the file contents of the directory to copy.
+            DirectoryInfo sourceDir = new(source);
+
+            if (sourceDir.Attributes.HasFlag(FileAttributes.ReparsePoint))
+            {
+                DirectoryInfo targetDir = new(target);
+
+                if (targetDir.Exists &&
+                    targetDir.Attributes.HasFlag(FileAttributes.ReparsePoint) &&
+                    targetDir.LinkTarget.Equals(sourceDir.LinkTarget, StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                Directory.CreateSymbolicLink(target, sourceDir.LinkTarget);
+                return;
+            }
+
             // Create the target directory.
             Directory.CreateDirectory(target);
 
-            // Get the file contents of the directory to copy.
-            DirectoryInfo sourceDir = new(source);
             foreach (FileInfo sourceFile in sourceDir.GetFiles() ?? new FileInfo[0])
             {
-                // Check if the file already exists.
                 cancellationToken.ThrowIfCancellationRequested();
+
+                // Check if the file already exists.
                 FileInfo targetFile = new(Path.Combine(target, sourceFile.Name));
-                if (!targetFile.Exists ||
-                    sourceFile.Length != targetFile.Length ||
-                    sourceFile.LastWriteTime != targetFile.LastWriteTime)
+                if (targetFile.Exists &&
+                    sourceFile.Length == targetFile.Length &&
+                    sourceFile.LastWriteTime == targetFile.LastWriteTime)
+                {
+                    continue;
+                }
+
+                // Check if source is a symlink
+                if (!sourceFile.Attributes.HasFlag(FileAttributes.ReparsePoint))
                 {
                     // Copy the file.
                     sourceFile.CopyTo(targetFile.FullName, true);
+                    continue;
                 }
+
+                File.CreateSymbolicLink(targetFile.FullName, sourceFile.LinkTarget);
             }
 
             // Copy the subdirectories.


### PR DESCRIPTION
Fixes #3234

This change adds proper support for symbolic links
in the CopyDirectory method.

NOTE: This patch was developed with GitHub Copilot
assistance. I has **NO** C# experience at all and
is not familiar with actions/runner. This change
has not been tested in a local environment. Please
review this patch carefully.

Signed-off-by: Chen Linxuan <me@black-desk.cn>
