### PR TITLE
Add loongarch64 partial

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -44,6 +44,9 @@
   <PropertyGroup Condition="'$(BUILD_OS)' == 'Linux' AND '$(PackageRuntime)' == 'linux-arm64'">
     <DefineConstants>$(DefineConstants);ARM64</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(BUILD_OS)' == 'Linux' AND '$(PackageRuntime)' == 'linux-loongarch64'">
+    <DefineConstants>$(DefineConstants);LOONGARCH64</DefineConstants>
+  </PropertyGroup>
 
   <!-- Set TRACE/DEBUG vars -->
   <PropertyGroup>

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -59,7 +59,8 @@ namespace GitHub.Runner.Common
             X86,
             X64,
             Arm,
-            Arm64
+            Arm64,
+            LoongArch64
         }
 
         public static class Runner
@@ -82,6 +83,8 @@ namespace GitHub.Runner.Common
             public static readonly Architecture PlatformArchitecture = Architecture.Arm;
 #elif ARM64
             public static readonly Architecture PlatformArchitecture = Architecture.Arm64;
+#elif LOONGARCH64
+            public static readonly Architecture PlatformArchitecture = Architecture.LoongArch64;
 #else
             public static readonly Architecture PlatformArchitecture = Architecture.X64;
 #endif

--- a/src/Runner.Common/Runner.Common.csproj
+++ b/src/Runner.Common/Runner.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;linux-loongarch64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>
     <Version>$(Version)</Version>

--- a/src/Runner.Common/Util/VarUtil.cs
+++ b/src/Runner.Common/Util/VarUtil.cs
@@ -53,6 +53,8 @@ namespace GitHub.Runner.Common.Util
                         return "ARM";
                     case Constants.Architecture.Arm64:
                         return "ARM64";
+                    case Constants.Architecture.LoongArch64:
+                        return "LOONGARCH64";
                     default:
                         throw new NotSupportedException(); // Should never reach here.
                 }

--- a/src/Runner.Listener/Runner.Listener.csproj
+++ b/src/Runner.Listener/Runner.Listener.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;linux-loongarch64</RuntimeIdentifiers>
     <SelfContained>true</SelfContained>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Runner.PluginHost/Runner.PluginHost.csproj
+++ b/src/Runner.PluginHost/Runner.PluginHost.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;linux-loongarch64</RuntimeIdentifiers>
     <SelfContained>true</SelfContained>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Runner.Plugins/Runner.Plugins.csproj
+++ b/src/Runner.Plugins/Runner.Plugins.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;linux-loongarch64</RuntimeIdentifiers>
     <SelfContained>true</SelfContained>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Runner.Sdk/Runner.Sdk.csproj
+++ b/src/Runner.Sdk/Runner.Sdk.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;linux-loongarch64</RuntimeIdentifiers>
     <SelfContained>true</SelfContained>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Runner.Worker/Runner.Worker.csproj
+++ b/src/Runner.Worker/Runner.Worker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;linux-loongarch64</RuntimeIdentifiers>
     <SelfContained>true</SelfContained>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Sdk/Sdk.csproj
+++ b/src/Sdk/Sdk.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <OutputType>Library</OutputType>
-        <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64;linux-loongarch64</RuntimeIdentifiers>
         <!-- <SelfContained>true</SelfContained> -->
         <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
         <NoWarn>NU1701;NU1603;SYSLIB0050;SYSLIB0051</NoWarn>

--- a/src/Test/L0/ConstantGenerationL0.cs
+++ b/src/Test/L0/ConstantGenerationL0.cs
@@ -20,6 +20,7 @@ namespace GitHub.Runner.Common.Tests
                 "linux-x64",
                 "linux-arm",
                 "linux-arm64",
+                "linux-loongarch64",
                 "osx-x64",
                 "osx-arm64"
             };


### PR DESCRIPTION
As now the nodejs and dotnet-sdk of LoongArch64 are still not published officially, this PR aims to add LoongArch64 constants and RID information only. 

* [LA] Add LoongArch64 to Constants
* [LA] Add linux-loongarch64 to RuntimeIdentifiers in csprojs
* [LA] Add LOONGARCH64 to DefineConstants conditionally

The runner I built locally with the unofficially built nodejs and dotnet-sdk can work under `self-hosted` mode normally.