### PR TITLE
Update Node20 and Node24 to latest

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -6,7 +6,7 @@ NODE_URL=https://nodejs.org/dist
 NODE_ALPINE_URL=https://github.com/actions/alpine_nodejs/releases/download
 # When you update Node versions you must also create a new release of alpine_nodejs at that updated version.
 # Follow the instructions here: https://github.com/actions/alpine_nodejs?tab=readme-ov-file#getting-started
-NODE20_VERSION="20.19.3"
+NODE20_VERSION="20.19.4"
 NODE24_VERSION="24.5.0"
 
 get_abs_path() {

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -7,7 +7,7 @@ NODE_ALPINE_URL=https://github.com/actions/alpine_nodejs/releases/download
 # When you update Node versions you must also create a new release of alpine_nodejs at that updated version.
 # Follow the instructions here: https://github.com/actions/alpine_nodejs?tab=readme-ov-file#getting-started
 NODE20_VERSION="20.19.3"
-NODE24_VERSION="24.4.0"
+NODE24_VERSION="24.5.0"
 
 get_abs_path() {
   # exploits the fact that pwd will print abs path when no args


### PR DESCRIPTION
Updating Node24 to 24.5.0 to address CVE-2025-27209.
https://github.com/actions/alpine_nodejs/actions/runs/16699347061
Updating Node20 to 20.19.4 to address CVE-2025-27210
https://github.com/actions/alpine_nodejs/actions/runs/16394323675