### PR TITLE
Redirect supported OS doc section to current public Docs location

### DIFF
--- a/docs/start/envlinux.md
+++ b/docs/start/envlinux.md
@@ -4,7 +4,7 @@
 
 ## Supported Distributions and Versions
 
-Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#linux)."
+Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/reference/runners/self-hosted-runners#linux)."
 
 ## Install .Net Core 3.x Linux Dependencies
 

--- a/docs/start/envosx.md
+++ b/docs/start/envosx.md
@@ -4,6 +4,6 @@
 
 ## Supported Versions
 
-Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#macos)."
+Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/reference/runners/self-hosted-runners#macos)."
 
 ## [More .Net Core Prerequisites Information](https://docs.microsoft.com/en-us/dotnet/core/macos-prerequisites?tabs=netcore30)

--- a/docs/start/envwin.md
+++ b/docs/start/envwin.md
@@ -2,6 +2,6 @@
 
 ## Supported Versions
 
-Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#windows)."
+Please see "[Supported architectures and operating systems for self-hosted runners](https://docs.github.com/en/actions/reference/runners/self-hosted-runners#windows)."
 
 ## [More .NET Core Prerequisites Information](https://docs.microsoft.com/en-us/dotnet/core/windows-prerequisites?tabs=netcore30)


### PR DESCRIPTION
Public Docs content has moved where previous links currently settle on "[Self-hosted runners](https://docs.github.com/en/actions/concepts/runners/self-hosted-runners)", which no longer contains details regarding supported architectures nor operating systems.

This PR updates the links to the current public Docs page for this content and information, "[Self-hosted runners reference](https://docs.github.com/en/actions/reference/runners/self-hosted-runners)".