### PR TITLE
Acknowledge runner request

### DIFF
--- a/src/Runner.Common/BrokerServer.cs
+++ b/src/Runner.Common/BrokerServer.cs
@@ -23,6 +23,8 @@ namespace GitHub.Runner.Common
 
         Task<TaskAgentMessage> GetRunnerMessageAsync(Guid? sessionId, TaskAgentStatus status, string version, string os, string architecture, bool disableUpdate, CancellationToken token);
 
+        Task AcknowledgeRunnerRequestAsync(string runnerRequestId, Guid? sessionId, TaskAgentStatus status, string version, string os, string architecture, CancellationToken token);
+
         Task UpdateConnectionIfNeeded(Uri serverUri, VssCredentials credentials);
 
         Task ForceRefreshConnection(VssCredentials credentials);
@@ -67,8 +69,15 @@ namespace GitHub.Runner.Common
             var brokerSession = RetryRequest<TaskAgentMessage>(
                 async () => await _brokerHttpClient.GetRunnerMessageAsync(sessionId, version, status, os, architecture, disableUpdate, cancellationToken), cancellationToken, shouldRetry: ShouldRetryException);
 
-
             return brokerSession;
+        }
+
+        public async Task AcknowledgeRunnerRequestAsync(string runnerRequestId, Guid? sessionId, TaskAgentStatus status, string version, string os, string architecture, CancellationToken cancellationToken)
+        {
+            CheckConnection();
+
+            // No retries
+            await _brokerHttpClient.AcknowledgeRunnerRequestAsync(runnerRequestId, sessionId, version, status, os, architecture, cancellationToken);
         }
 
         public async Task DeleteSessionAsync(CancellationToken cancellationToken)

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -32,6 +32,7 @@ namespace GitHub.Runner.Listener
         Task DeleteSessionAsync();
         Task<TaskAgentMessage> GetNextMessageAsync(CancellationToken token);
         Task DeleteMessageAsync(TaskAgentMessage message);
+        Task AcknowledgeMessageAsync(string runnerRequestId, CancellationToken cancellationToken);
 
         Task RefreshListenerTokenAsync();
         void OnJobStatus(object sender, JobStatusEventArgs e);
@@ -52,7 +53,7 @@ namespace GitHub.Runner.Listener
         private readonly TimeSpan _sessionConflictRetryLimit = TimeSpan.FromMinutes(4);
         private readonly TimeSpan _clockSkewRetryLimit = TimeSpan.FromMinutes(30);
         private readonly Dictionary<string, int> _sessionCreationExceptionTracker = new();
-        private TaskAgentStatus runnerStatus = TaskAgentStatus.Online;
+        private TaskAgentStatus _runnerStatus = TaskAgentStatus.Online;
         private CancellationTokenSource _getMessagesTokenSource;
         private VssCredentials _creds;
         private VssCredentials _credsV2;
@@ -217,7 +218,7 @@ namespace GitHub.Runner.Listener
         public void OnJobStatus(object sender, JobStatusEventArgs e)
         {
             Trace.Info("Received job status event. JobState: {0}", e.Status);
-            runnerStatus = e.Status;
+            _runnerStatus = e.Status;
             try
             {
                 _getMessagesTokenSource?.Cancel();
@@ -250,7 +251,7 @@ namespace GitHub.Runner.Listener
                     message = await _runnerServer.GetAgentMessageAsync(_settings.PoolId,
                                                                 _session.SessionId,
                                                                 _lastMessageId,
-                                                                runnerStatus,
+                                                                _runnerStatus,
                                                                 BuildConstants.RunnerPackage.Version,
                                                                 VarUtil.OS,
                                                                 VarUtil.OSArchitecture,
@@ -274,7 +275,7 @@ namespace GitHub.Runner.Listener
                         }
 
                         message = await _brokerServer.GetRunnerMessageAsync(_session.SessionId,
-                                                                        runnerStatus,
+                                                                        _runnerStatus,
                                                                         BuildConstants.RunnerPackage.Version,
                                                                         VarUtil.OS,
                                                                         VarUtil.OSArchitecture,
@@ -435,6 +436,21 @@ namespace GitHub.Runner.Listener
             await _runnerServer.RefreshConnectionAsync(RunnerConnectionType.MessageQueue, TimeSpan.FromSeconds(60));
             _credsV2 = _credMgr.LoadCredentials(allowAuthUrlV2: true);
             await _brokerServer.ForceRefreshConnection(_credsV2);
+        }
+
+        public async Task AcknowledgeMessageAsync(string runnerRequestId, CancellationToken cancellationToken)
+        {
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5)); // Short timeout
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+            Trace.Info($"Acknowledging runner request '{runnerRequestId}'.");
+            await _brokerServer.AcknowledgeRunnerRequestAsync(
+                runnerRequestId,
+                _session.SessionId,
+                _runnerStatus,
+                BuildConstants.RunnerPackage.Version,
+                VarUtil.OS,
+                VarUtil.OSArchitecture,
+                linkedCts.Token);
         }
 
         private TaskAgentMessage DecryptMessage(TaskAgentMessage message)

--- a/src/Runner.Listener/RunnerJobRequestRef.cs
+++ b/src/Runner.Listener/RunnerJobRequestRef.cs
@@ -10,6 +10,9 @@ namespace GitHub.Runner.Listener
         
         [DataMember(Name = "runner_request_id")]
         public string RunnerRequestId { get; set; }
+
+        [DataMember(Name = "should_acknowledge")]
+        public bool ShouldAcknowledge { get; set; }
         
         [DataMember(Name = "run_service_url")]
         public string RunServiceUrl { get; set; }


### PR DESCRIPTION
This change is required to distinguish user error vs infra error during acquire timeout.

The runner will ACK after receiving a job request from Broker Listener and before attempting to acquire the full job message from Run Service.