### PR TITLE
chore: migrate Husky config from v8 to v9 format

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-cd src/Misc/expressionFunc/hashFiles
-
-npx lint-staged
+cd src/Misc/expressionFunc/hashFiles && npx lint-staged

--- a/src/Misc/expressionFunc/hashFiles/package.json
+++ b/src/Misc/expressionFunc/hashFiles/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint src/**/*.ts",
     "pack": "ncc build -o ../../layoutbin/hashFiles",
     "all": "npm run format && npm run lint && npm run build && npm run pack",
-    "prepare": "cd ../../../../ && husky install"
+    "prepare": "cd ../../../../ && husky"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Replace `husky install` with `husky` in prepare script
- Remove shebang and husky.sh import from pre-commit hook
- Maintain existing

V9 is a non-breaking change is is backwards compatible so we don't need to upgrade this in any rush even though v9 is now in main.