### PR TITLE
Map RUNNER_TEMP for container action

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -169,6 +169,7 @@ namespace GitHub.Runner.Common
                 public static readonly string AllowRunnerContainerHooks = "DistributedTask.AllowRunnerContainerHooks";
                 public static readonly string AddCheckRunIdToJobContext = "actions_add_check_run_id_to_job_context";
                 public static readonly string DisplayHelpfulActionsDownloadErrors = "actions_display_helpful_actions_download_errors";
+                public static readonly string ContainerActionRunnerTemp = "actions_container_action_runner_temp";
             }
             
             // Node version migration related constants

--- a/src/Runner.Worker/FeatureManager.cs
+++ b/src/Runner.Worker/FeatureManager.cs
@@ -11,5 +11,10 @@ namespace GitHub.Runner.Worker
             var isContainerHooksPathSet = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.Hooks.ContainerHooksPath));
             return isContainerHookFeatureFlagSet && isContainerHooksPathSet;
         }
+
+        public static bool IsContainerActionRunnerTempEnabled(Variables variables)
+        {
+            return variables?.GetBoolean(Constants.Runner.Features.ContainerActionRunnerTemp) ?? false;
+        }
     }
 }

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -191,11 +191,19 @@ namespace GitHub.Runner.Worker.Handlers
             ArgUtil.Directory(tempWorkflowDirectory, nameof(tempWorkflowDirectory));
 
             container.MountVolumes.Add(new MountVolume("/var/run/docker.sock", "/var/run/docker.sock"));
+            if (FeatureManager.IsContainerActionRunnerTempEnabled(ExecutionContext.Global.Variables))
+            {
+                container.MountVolumes.Add(new MountVolume(tempDirectory, "/github/runner_temp"));
+            }
             container.MountVolumes.Add(new MountVolume(tempHomeDirectory, "/github/home"));
             container.MountVolumes.Add(new MountVolume(tempWorkflowDirectory, "/github/workflow"));
             container.MountVolumes.Add(new MountVolume(tempFileCommandDirectory, "/github/file_commands"));
             container.MountVolumes.Add(new MountVolume(defaultWorkingDirectory, "/github/workspace"));
 
+            if (FeatureManager.IsContainerActionRunnerTempEnabled(ExecutionContext.Global.Variables))
+            {
+                container.AddPathTranslateMapping(tempDirectory, "/github/runner_temp");
+            }
             container.AddPathTranslateMapping(tempHomeDirectory, "/github/home");
             container.AddPathTranslateMapping(tempWorkflowDirectory, "/github/workflow");
             container.AddPathTranslateMapping(tempFileCommandDirectory, "/github/file_commands");


### PR DESCRIPTION
Maps `RUNNER_TEMP` to `/github/runner_temp` for container actions.

Feature flag:
- `actions_container_action_runner_temp`

Below is a screenshot of the file structure. While testing, I created the file `foo` once inside the container action and confirmed it appeared twice in file structure (`touch /github/runner_temp/_runner_file_commands/foo`).

<img width="825" height="666" alt="image" src="https://github.com/user-attachments/assets/69ab4cd5-5313-4675-a9af-561f32479178" />
