### PR TITLE
Add libicu76 to support Debian 13

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -110,7 +110,7 @@ then
             exit 1
         fi
 
-        apt_get_with_fallbacks libicu72 libicu71 libicu70 libicu69 libicu68 libicu67 libicu66 libicu65 libicu63 libicu60 libicu57 libicu55 libicu52
+        apt_get_with_fallbacks libicu76 libicu72 libicu71 libicu70 libicu69 libicu68 libicu67 libicu66 libicu65 libicu63 libicu60 libicu57 libicu55 libicu52
         if [ $? -ne 0 ]
         then
             echo "'$apt_get' failed with exit code '$?'"


### PR DESCRIPTION
This PR adds `libicu76` to the list of available libicu packages to `installdependencies.sh` script.

Debian stable repositories bumped libicu to version 76 and that version is the only one available in Debian 13.