### PR TITLE
Add JOB_ env vars

### DIFF
--- a/src/Runner.Worker/JobContext.cs
+++ b/src/Runner.Worker/JobContext.cs
@@ -1,10 +1,12 @@
-using GitHub.DistributedTask.Pipelines.ContextData;
+﻿using GitHub.DistributedTask.Pipelines.ContextData;
 using GitHub.Runner.Common.Util;
 using GitHub.Runner.Common;
+using System;
+using System.Collections.Generic;
 
 namespace GitHub.Runner.Worker
 {
-    public sealed class JobContext : DictionaryContextData
+    public sealed class JobContext : DictionaryContextData, IEnvironmentContextData
     {
         public ActionResult? Status
         {
@@ -144,6 +146,34 @@ namespace GitHub.Runner.Worker
             set
             {
                 this["workflow_file_path"] = value != null ? new StringContextData(value) : null;
+            }
+        }
+
+        private readonly HashSet<string> _contextEnvAllowlist = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "check_run_id",
+            "status",
+            "workflow_ref",
+            "workflow_sha",
+            "workflow_repository",
+            "workflow_file_path",
+        };
+
+        public IEnumerable<KeyValuePair<string, string>> GetRuntimeEnvironmentVariables()
+        {
+            foreach (var data in this)
+            {
+                if (_contextEnvAllowlist.Contains(data.Key))
+                {
+                    if (data.Value is StringContextData value)
+                    {
+                        yield return new KeyValuePair<string, string>($"JOB_{data.Key.ToUpperInvariant()}", value.ToString());
+                    }
+                    else if (data.Value is NumberContextData numberValue)
+                    {
+                        yield return new KeyValuePair<string, string>($"JOB_{data.Key.ToUpperInvariant()}", numberValue.ToString());
+                    }
+                }
             }
         }
     }

--- a/src/Test/L0/Worker/JobContextL0.cs
+++ b/src/Test/L0/Worker/JobContextL0.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Collections.Generic;
 using GitHub.DistributedTask.Pipelines.ContextData;
 using GitHub.Runner.Worker;
 using Xunit;
@@ -137,6 +138,30 @@ namespace GitHub.Runner.Common.Tests.Worker
             ctx.WorkflowFilePath = ".github/workflows/ci.yml";
             ctx.WorkflowFilePath = null;
             Assert.Null(ctx.WorkflowFilePath);
+        }
+
+        [Fact]
+        public void GetRuntimeEnvironmentVariables_ReturnsCorrectVariables()
+        {
+            var ctx = new JobContext();
+            ctx.CheckRunId = 12345;
+            ctx.Status = ActionResult.Success;
+            ctx.WorkflowRef = "owner/repo/.github/workflows/ci.yml@refs/heads/main";
+            ctx.WorkflowSha = "abc123def456";
+            ctx.WorkflowRepository = "owner/repo";
+            ctx.WorkflowFilePath = ".github/workflows/ci.yml";
+
+            var dict = new Dictionary<string, string>(ctx.GetRuntimeEnvironmentVariables());
+            Assert.Equal("12345", dict["JOB_CHECK_RUN_ID"]);
+            Assert.Equal("success", dict["JOB_STATUS"]);
+            Assert.Equal("owner/repo/.github/workflows/ci.yml@refs/heads/main", dict["JOB_WORKFLOW_REF"]);
+            Assert.Equal("abc123def456", dict["JOB_WORKFLOW_SHA"]);
+            Assert.Equal("owner/repo", dict["JOB_WORKFLOW_REPOSITORY"]);
+            Assert.Equal(".github/workflows/ci.yml", dict["JOB_WORKFLOW_FILE_PATH"]);
+
+            ctx = new JobContext();
+            dict = new Dictionary<string, string>(ctx.GetRuntimeEnvironmentVariables());
+            Assert.Empty(dict);
         }
     }
 }


### PR DESCRIPTION
Add env vars for top-level job context primitives, i.e.

  `job.check_run_id` => `$JOB_CHECK_RUN_ID`
  `job.status` => `$JOB_STATUS`
  `job.workflow_ref` => `$JOB_WORKFLOW_REF`
  `job.workflow_sha` => `$JOB_WORKFLOW_SHA`
  `job.workflow_repository` => `$JOB_WORKFLOW_REPOSITORY`
  `job.workflow_file_path` => `$JOB_WORKFLOW_FILE_PATH`

References
* https://github.com/actions/runner/issues/324
* https://github.com/orgs/community/discussions/129314
* https://github.com/orgs/community/discussions/8945#discussioncomment-14376552
* https://github.com/orgs/community/discussions/38659