### PR TITLE
fix: prevent Node.js upgrade workflow from creating PRs with empty versions

### DIFF
--- a/.github/workflows/node-upgrade.yml
+++ b/.github/workflows/node-upgrade.yml
@@ -32,20 +32,47 @@ jobs:
           echo "Verifying availability in alpine_nodejs..."
           ALPINE_RELEASES=$(curl -s https://api.github.com/repos/actions/alpine_nodejs/releases | jq -r '.[].tag_name')
 
-          if ! echo "$ALPINE_RELEASES" | grep -q "^node20-$LATEST_NODE20$"; then
+          if ! echo "$ALPINE_RELEASES" | grep -q "^v$LATEST_NODE20$"; then
             echo "::warning title=Node 20 Fallback::Node 20 version $LATEST_NODE20 not found in alpine_nodejs releases, using fallback"
             # Fall back to latest available alpine_nodejs v20 release
-            LATEST_NODE20=$(echo "$ALPINE_RELEASES" | grep "^node20-" | head -1 | sed 's/^node20-//')
+            LATEST_NODE20=$(echo "$ALPINE_RELEASES" | grep "^v20\." | head -1 | sed 's/^v//')
             echo "Using latest available alpine_nodejs Node 20: $LATEST_NODE20"
           fi
 
-          if ! echo "$ALPINE_RELEASES" | grep -q "^node24-$LATEST_NODE24$"; then
+          if ! echo "$ALPINE_RELEASES" | grep -q "^v$LATEST_NODE24$"; then
             echo "::warning title=Node 24 Fallback::Node 24 version $LATEST_NODE24 not found in alpine_nodejs releases, using fallback"
             # Fall back to latest available alpine_nodejs v24 release
-            LATEST_NODE24=$(echo "$ALPINE_RELEASES" | grep "^node24-" | head -1 | sed 's/^node24-//')
+            LATEST_NODE24=$(echo "$ALPINE_RELEASES" | grep "^v24\." | head -1 | sed 's/^v//')
             echo "Using latest available alpine_nodejs Node 24: $LATEST_NODE24"
           fi
 
+          # Validate that we have non-empty version numbers
+          if [ -z "$LATEST_NODE20" ] || [ "$LATEST_NODE20" = "" ]; then
+            echo "::error title=Invalid Node 20 Version::Failed to determine valid Node 20 version. Got: '$LATEST_NODE20'"
+            echo "Available alpine_nodejs releases:"
+            echo "$ALPINE_RELEASES" | head -10
+            exit 1
+          fi
+
+          if [ -z "$LATEST_NODE24" ] || [ "$LATEST_NODE24" = "" ]; then
+            echo "::error title=Invalid Node 24 Version::Failed to determine valid Node 24 version. Got: '$LATEST_NODE24'"
+            echo "Available alpine_nodejs releases:"
+            echo "$ALPINE_RELEASES" | head -10
+            exit 1
+          fi
+
+          # Additional validation: ensure versions match expected format (x.y.z)
+          if ! echo "$LATEST_NODE20" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error title=Invalid Node 20 Format::Node 20 version '$LATEST_NODE20' does not match expected format (x.y.z)"
+            exit 1
+          fi
+
+          if ! echo "$LATEST_NODE24" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error title=Invalid Node 24 Format::Node 24 version '$LATEST_NODE24' does not match expected format (x.y.z)"
+            exit 1
+          fi
+
+          echo "✅ Validated Node versions: 20=$LATEST_NODE20, 24=$LATEST_NODE24"
           echo "latest_node20=$LATEST_NODE20" >> $GITHUB_OUTPUT
           echo "latest_node24=$LATEST_NODE24" >> $GITHUB_OUTPUT
 
@@ -82,13 +109,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Final validation before making changes
+          NODE20_VERSION="${{ steps.node-versions.outputs.latest_node20 }}"
+          NODE24_VERSION="${{ steps.node-versions.outputs.latest_node24 }}"
+          
+          echo "Final validation of versions before PR creation:"
+          echo "Node 20: '$NODE20_VERSION'"
+          echo "Node 24: '$NODE24_VERSION'"
+          
+          # Validate versions are not empty and match expected format
+          if [ -z "$NODE20_VERSION" ] || ! echo "$NODE20_VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error title=Invalid Node 20 Version::Refusing to create PR with invalid Node 20 version: '$NODE20_VERSION'"
+            exit 1
+          fi
+          
+          if [ -z "$NODE24_VERSION" ] || ! echo "$NODE24_VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error title=Invalid Node 24 Version::Refusing to create PR with invalid Node 24 version: '$NODE24_VERSION'"
+            exit 1
+          fi
+          
+          echo "✅ All versions validated successfully"
+
           # Update the files
           if [ "${{ steps.node-versions.outputs.needs_update20 }}" == "true" ]; then
-            sed -i 's/NODE20_VERSION="[^"]*"/NODE20_VERSION="${{ steps.node-versions.outputs.latest_node20 }}"/' src/Misc/externals.sh
+            sed -i 's/NODE20_VERSION="[^"]*"/NODE20_VERSION="'"$NODE20_VERSION"'"/' src/Misc/externals.sh
           fi
 
           if [ "${{ steps.node-versions.outputs.needs_update24 }}" == "true" ]; then
-            sed -i 's/NODE24_VERSION="[^"]*"/NODE24_VERSION="${{ steps.node-versions.outputs.latest_node24 }}"/' src/Misc/externals.sh
+            sed -i 's/NODE24_VERSION="[^"]*"/NODE24_VERSION="'"$NODE24_VERSION"'"/' src/Misc/externals.sh
+          fi
+
+          # Verify the changes were applied correctly
+          echo "Verifying changes in externals.sh:"
+          grep "NODE20_VERSION=" src/Misc/externals.sh
+          grep "NODE24_VERSION=" src/Misc/externals.sh
+          
+          # Ensure we actually have valid versions in the file
+          UPDATED_NODE20=$(grep "NODE20_VERSION=" src/Misc/externals.sh | cut -d'"' -f2)
+          UPDATED_NODE24=$(grep "NODE24_VERSION=" src/Misc/externals.sh | cut -d'"' -f2)
+          
+          if [ -z "$UPDATED_NODE20" ] || [ -z "$UPDATED_NODE24" ]; then
+            echo "::error title=Update Failed::Failed to properly update externals.sh"
+            echo "Updated Node 20: '$UPDATED_NODE20'"
+            echo "Updated Node 24: '$UPDATED_NODE24'"
+            exit 1
           fi
 
           # Configure git
@@ -98,15 +162,15 @@ jobs:
           # Create branch and commit changes
           branch_name="chore/update-node"
           git checkout -b "$branch_name"
-          git commit -a -m "chore: update Node versions (20: ${{ steps.node-versions.outputs.latest_node20 }}, 24: ${{ steps.node-versions.outputs.latest_node24 }})"
+          git commit -a -m "chore: update Node versions (20: $NODE20_VERSION, 24: $NODE24_VERSION)"
           git push --force origin "$branch_name"
 
           # Create PR body using here-doc for proper formatting
-          cat > pr_body.txt << 'EOF'
+          cat > pr_body.txt << EOF
           Automated Node.js version update:
 
-          - Node 20: ${{ steps.node-versions.outputs.current_node20 }} → ${{ steps.node-versions.outputs.latest_node20 }}
-          - Node 24: ${{ steps.node-versions.outputs.current_node24 }} → ${{ steps.node-versions.outputs.latest_node24 }}
+          - Node 20: ${{ steps.node-versions.outputs.current_node20 }} → $NODE20_VERSION
+          - Node 24: ${{ steps.node-versions.outputs.current_node24 }} → $NODE24_VERSION
 
           This update ensures we're using the latest stable Node.js versions for security and performance improvements.
 


### PR DESCRIPTION
# Fix broken Node.js upgrade workflow

The automated Node upgrade workflow has been creating useless PRs like this one: https://github.com/actions/runner/pull/4050

The problem was that it was looking for the wrong release tag format in the alpine_nodejs repo and ended up with empty version strings.

## What was broken

The workflow assumed alpine_nodejs releases were tagged like `node20-20.19.5` but they're actually just `v20.19.5`. So when it tried to fall back to alpine releases, the grep patterns failed and we got empty strings.

Result: PRs showing "Node 20: 20.19.5 → " with nothing after the arrow.

## What I fixed

1. **Fixed the tag patterns** - Changed from looking for `^node20-` to `^v20\.` which actually matches the real tags
2. **Added validation** - Now it checks that versions aren't empty and match the expected x.y.z format before doing anything
3. **Better error handling** - If something goes wrong, it shows you what releases are actually available instead of silently failing
4. **Verification** - Double-checks that the file updates actually worked

## Testing

Ran the grep patterns manually against the real alpine_nodejs releases and confirmed they work:
- `v20.19.5`, `v24.8.0` etc. are correctly parsed to `20.19.5`, `24.8.0`
- Validation correctly rejects empty strings and malformed versions

This should prevent any more broken automation PRs and make debugging easier when things do go wrong.