### PR TITLE
Include k8s novolume (version v0.8.0)

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -21,6 +21,10 @@ RUN curl -f -L -o runner-container-hooks.zip https://github.com/actions/runner-c
     && unzip ./runner-container-hooks.zip -d ./k8s \
     && rm runner-container-hooks.zip
 
+RUN curl -f -L -o runner-container-hooks.zip https://github.com/actions/runner-container-hooks/releases/download/v0.8.0/actions-runner-hooks-k8s-0.8.0.zip \
+    && unzip ./runner-container-hooks.zip -d ./k8s-novolume \
+    && rm runner-container-hooks.zip
+
 RUN export RUNNER_ARCH=${TARGETARCH} \
     && if [ "$RUNNER_ARCH" = "amd64" ]; then export DOCKER_ARCH=x86_64 ; fi \
     && if [ "$RUNNER_ARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \


### PR DESCRIPTION
Once the hook v0.8.0 is released, pull it down into a separate directory.
The change in the v0.8.0 is fairly risky, so we ideally want to apply the fallback mechanism to the current version of the hook v0.7.0.

ARC PR: https://github.com/actions/actions-runner-controller/pull/4250 introduces a new mode, including this path to the hook.
