### PR TITLE
Set Restart=always on systemd service for added resilience

### DIFF
--- a/src/Misc/layoutbin/actions.runner.service.template
+++ b/src/Misc/layoutbin/actions.runner.service.template
@@ -9,6 +9,8 @@ WorkingDirectory={{RunnerRoot}}
 KillMode=process
 KillSignal=SIGTERM
 TimeoutStopSec=5min
+Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This update ensures that the runner will restart if crashed.
We've experienced that under certain network conditions, or github server errors, the runner can crash.
With this change, the service will be started back up and can try again.