### PR TITLE
fix(dockerfile): set more lenient permissions on /home/runner

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -54,14 +54,15 @@ RUN add-apt-repository ppa:git-core/ppa \
     && apt install -y git \
     && rm -rf /var/lib/apt/lists/*
 
+WORKDIR /home/runner
+
 RUN adduser --disabled-password --gecos "" --uid 1001 runner \
     && groupadd docker --gid 123 \
     && usermod -aG sudo runner \
     && usermod -aG docker runner \
     && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers \
-    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
-
-WORKDIR /home/runner
+    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers \
+    && chmod 777 /home/runner
 
 COPY --chown=runner:docker --from=build /actions-runner .
 COPY --from=build /usr/local/lib/docker/cli-plugins/docker-buildx /usr/local/lib/docker/cli-plugins/docker-buildx


### PR DESCRIPTION
Currently, the permissions of /home/runner are 750. In some container runtimes and Kubernetes distributions (including OpenShift), a different uid/gid (not `runner`) may be used when running the image.

The runner expects to be able to read and execute scripts within the home directory, and it will also write ephemeral files, diagnostic data, etc. into the directory as well. Therefore, to support the ability to use the runner as a user apart from `runner`, full 777 permissions are needed.

A longer-term change to consider which may improve the security posture here would be to separate the executable portions of the application (scripts, etc.) from the places where temporary data is written, and control the permissions of these separately.