### PR TITLE
Link to an extant discussion category

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🛑 Request a feature in the runner application
-    url: https://github.com/orgs/community/discussions/categories/actions-and-packages
-    about: If you have feature requests for GitHub Actions, please use the Actions and Packages section on the Github Product Feedback page.
+    url: https://github.com/orgs/community/discussions/categories/actions
+    about: If you have feature requests for GitHub Actions, please use the Actions section on the Github Product Feedback page.
   - name: ✅ Support for GitHub Actions
     url: https://github.community/c/code-to-cloud/52
     about: If you have questions about GitHub Actions or need support writing workflows, please ask in the GitHub Community Support forum.

--- a/.github/workflows/close-features-bot.yml
+++ b/.github/workflows/close-features-bot.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          close-issue-message: "Thank you for your interest in the runner application and taking the time to provide your valuable feedback. We kindly ask you to redirect this feedback to the [GitHub Community Support Forum](https://github.com/orgs/community/discussions/categories/actions-and-packages) which our team actively monitors and would be a better place to start a discussion for new feature requests in GitHub Actions. For more information on this policy please [read our contribution guidelines](https://github.com/actions/runner#contribute). 😃"
+          close-issue-message: "Thank you for your interest in the runner application and taking the time to provide your valuable feedback. We kindly ask you to redirect this feedback to the [GitHub Community Support Forum](https://github.com/orgs/community/discussions/categories/actions) which our team actively monitors and would be a better place to start a discussion for new feature requests in GitHub Actions. For more information on this policy please [read our contribution guidelines](https://github.com/actions/runner#contribute). 😃"
           exempt-issue-labels: "keep"
           stale-issue-label: "actions-feature"
           only-labels: "actions-feature"


### PR DESCRIPTION
https://github.com/orgs/community/discussions/categories/actions-and-packages doesn't exist:
<img width="330" height="525" alt="image" src="https://github.com/user-attachments/assets/d7f1c6df-163d-4ef4-a0e5-9ec3935ba690" />

Whereas

https://github.com/orgs/community/discussions/categories/actions
does:
<img width="987" height="693" alt="image" src="https://github.com/user-attachments/assets/1797eab8-5332-43e2-badd-98fbd0f31c3b" />

This has been the case for a long time.