### PR TITLE
Add support for libicu73-76 for newer Debian/Ubuntu versions

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -110,7 +110,7 @@ then
             exit 1
         fi
 
-        apt_get_with_fallbacks libicu72 libicu71 libicu70 libicu69 libicu68 libicu67 libicu66 libicu65 libicu63 libicu60 libicu57 libicu55 libicu52
+        apt_get_with_fallbacks libicu76 libicu75 libicu74 libicu73 libicu72 libicu71 libicu70 libicu69 libicu68 libicu67 libicu66 libicu65 libicu63 libicu60 libicu57 libicu55 libicu52
         if [ $? -ne 0 ]
         then
             echo "'$apt_get' failed with exit code '$?'"


### PR DESCRIPTION
## Description
Adds support for newer libicu versions (73-76) to enable runner installation on Debian 13 (Trixie) and future Debian/Ubuntu releases.

## Related Issue
Fixes #4097

## Changes
- Added libicu76, libicu75, libicu74, libicu73 to the `apt_get_with_fallbacks` function in `src/Misc/externals.sh`
- Maintains backward compatibility with all existing libicu versions

## Problem
The runner's dependency installation script fails on Debian 13 (Trixie) because it doesn't recognize libicu76, which is the version shipped with Debian 13.

## Solution
The `apt_get_with_fallbacks` function tries each libicu version in order until it finds one available on the system. By adding the newer versions at the beginning of the list, the script can now successfully install dependencies on Debian 13 while maintaining compatibility with older distributions.

## Testing
- Tested on Debian 13 (Trixie) with libicu76
- The fallback mechanism ensures compatibility with older distributions