### PR TITLE
修復 #10: 新增可配置 worker 數量的部署腳本

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,153 @@
+# Deployment Scripts
+
+This directory contains scripts for deploying GitHub Actions self-hosted runners.
+
+## gen-compose.sh
+
+Generate docker-compose configurations for deploying multiple GitHub Actions runner workers.
+
+### Quick Start
+
+```bash
+# Generate with default 3 workers
+./gen-compose.sh
+
+# Generate with custom number of workers
+./gen-compose.sh -w 5
+
+# Specify custom output file
+./gen-compose.sh -w 10 -o my-runners.yml
+```
+
+### Usage
+
+```
+./gen-compose.sh [OPTIONS]
+
+Options:
+  -w, --workers NUM    Number of workers per repo (default: 3)
+  -o, --output FILE    Output file name (default: docker-compose.yml)
+  -h, --help           Display help message
+```
+
+### Examples
+
+#### Default Configuration
+```bash
+./gen-compose.sh
+```
+Generates `docker-compose.yml` with 3 runner workers.
+
+#### Custom Worker Count
+```bash
+./gen-compose.sh -w 5
+```
+Generates `docker-compose.yml` with 5 runner workers.
+
+#### Custom Output File
+```bash
+./gen-compose.sh -w 10 -o production-runners.yml
+```
+Generates `production-runners.yml` with 10 runner workers.
+
+### Setup and Deployment
+
+After generating the docker-compose file:
+
+1. **Create a `.env` file** in the same directory with the following variables:
+   ```env
+   REPO_URL=https://github.com/your-org/your-repo
+   RUNNER_TOKEN=your_github_runner_registration_token
+   ```
+
+2. **Start the runners**:
+   ```bash
+   docker-compose up -d
+   ```
+
+3. **Check runner status**:
+   ```bash
+   docker-compose ps
+   ```
+
+4. **View runner logs**:
+   ```bash
+   docker-compose logs -f runner-worker-1
+   ```
+
+### Getting a Runner Token
+
+To get a registration token for your runners:
+
+1. Navigate to your repository settings
+2. Go to **Actions** → **Runners**
+3. Click **New self-hosted runner**
+4. Copy the token from the configuration command
+
+Or use the GitHub API:
+```bash
+# For a repository
+curl -X POST \
+  -H "Authorization: token YOUR_PAT" \
+  https://api.github.com/repos/OWNER/REPO/actions/runners/registration-token
+
+# For an organization
+curl -X POST \
+  -H "Authorization: token YOUR_PAT" \
+  https://api.github.com/orgs/ORG/actions/runners/registration-token
+```
+
+### Configuration Details
+
+Each runner worker includes:
+- Unique container name (`runner-worker-1`, `runner-worker-2`, etc.)
+- Dedicated work volume for isolation
+- Docker socket access for running containerized actions
+- Auto-restart policy
+- Shared network for communication
+
+### Scaling
+
+To scale up or down:
+
+1. Generate a new configuration with desired worker count:
+   ```bash
+   ./gen-compose.sh -w 10
+   ```
+
+2. Apply the changes:
+   ```bash
+   docker-compose up -d
+   ```
+
+Docker Compose will automatically add new workers or remove excess ones.
+
+### Troubleshooting
+
+**Issue**: Workers not registering with GitHub
+- **Solution**: Verify `REPO_URL` and `RUNNER_TOKEN` in `.env` file
+
+**Issue**: Permission errors
+- **Solution**: Ensure script is executable: `chmod +x gen-compose.sh`
+
+**Issue**: Docker socket permission denied
+- **Solution**: Ensure Docker daemon is running and user has Docker permissions
+
+### Requirements
+
+- Docker Engine 20.10+
+- Docker Compose 1.29+
+- Valid GitHub PAT with `repo` or `admin:org` scope
+
+### Notes
+
+- Runner tokens expire after 1 hour
+- Each worker runs independently and can execute jobs concurrently
+- Workers share the same network but have isolated file systems
+- Default configuration uses the latest runner image from ghcr.io
+
+### Related Documentation
+
+- [GitHub Actions Self-Hosted Runners](https://docs.github.com/en/actions/hosting-your-own-runners)
+- [Docker Compose Documentation](https://docs.docker.com/compose/)
+- [Actions Runner Image](https://github.com/actions/runner)

--- a/deployment/gen-compose.sh
+++ b/deployment/gen-compose.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -e
+
+# Script to generate docker-compose configuration for self-hosted runners
+# Supports N workers for each repo with a default of 3
+
+# Default values
+WORKERS_PER_REPO=3
+COMPOSE_FILE="docker-compose.yml"
+
+# Help message
+show_help() {
+    cat << EOF
+Usage: ./gen-compose.sh [OPTIONS]
+
+Generate a docker-compose configuration for GitHub Actions self-hosted runners.
+
+Options:
+    -w, --workers NUM       Number of workers per repo (default: 3)
+    -o, --output FILE       Output file name (default: docker-compose.yml)
+    -h, --help              Display this help message
+
+Examples:
+    ./gen-compose.sh                    # Generate with default 3 workers
+    ./gen-compose.sh -w 5               # Generate with 5 workers per repo
+    ./gen-compose.sh -w 10 -o runners.yml  # Generate with 10 workers, output to runners.yml
+
+EOF
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -w|--workers)
+            WORKERS_PER_REPO="$2"
+            shift 2
+            ;;
+        -o|--output)
+            COMPOSE_FILE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Validate workers parameter
+if ! [[ "$WORKERS_PER_REPO" =~ ^[0-9]+$ ]] || [ "$WORKERS_PER_REPO" -lt 1 ]; then
+    echo "Error: Workers per repo must be a positive integer"
+    exit 1
+fi
+
+echo "Generating docker-compose configuration..."
+echo "Workers per repo: $WORKERS_PER_REPO"
+echo "Output file: $COMPOSE_FILE"
+
+# Generate docker-compose.yml
+cat > "$COMPOSE_FILE" << EOF
+version: '3.8'
+
+services:
+EOF
+
+# Generate service definitions for each worker
+for i in $(seq 1 $WORKERS_PER_REPO); do
+    cat >> "$COMPOSE_FILE" << EOF
+  runner-worker-${i}:
+    image: ghcr.io/actions/actions-runner:latest
+    container_name: runner-worker-${i}
+    environment:
+      - RUNNER_NAME=runner-worker-${i}
+      - RUNNER_WORKDIR=/home/runner/work
+      - RUNNER_ALLOW_RUNASROOT=1
+    env_file:
+      - .env
+    volumes:
+      - runner-work-${i}:/home/runner/work
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+    networks:
+      - runner-network
+
+EOF
+done
+
+# Add volumes section
+cat >> "$COMPOSE_FILE" << EOF
+volumes:
+EOF
+
+for i in $(seq 1 $WORKERS_PER_REPO); do
+    cat >> "$COMPOSE_FILE" << EOF
+  runner-work-${i}:
+EOF
+done
+
+# Add networks section
+cat >> "$COMPOSE_FILE" << EOF
+
+networks:
+  runner-network:
+    driver: bridge
+EOF
+
+echo "Successfully generated $COMPOSE_FILE with $WORKERS_PER_REPO worker(s)"
+echo ""
+echo "Next steps:"
+echo "1. Create a .env file with required environment variables:"
+echo "   - REPO_URL (e.g., https://github.com/owner/repo)"
+echo "   - RUNNER_TOKEN (GitHub runner registration token)"
+echo "2. Run: docker-compose up -d"
+echo ""


### PR DESCRIPTION
## 問題描述

此 PR 解決了 Issue #10，新增了支援為每個 repo 配置 N 個 workers 的部署腳本，預設值為 3 個 workers。

## 變更摘要

### 新增檔案
1. **deployment/gen-compose.sh** - 可執行的部署腳本
   - 支援透過命令列參數配置 worker 數量
   - 預設生成 3 個 workers
   - 自動生成 docker-compose.yml 配置檔

2. **deployment/README.md** - 完整的使用文件

### 主要功能

#### 命令列選項
- `-w, --workers NUM`: 指定每個 repo 的 worker 數量（預設：3）
- `-o, --output FILE`: 指定輸出檔案名稱（預設：docker-compose.yml）
- `-h, --help`: 顯示說明訊息

#### 腳本特點
- **輸入驗證**：驗證 worker 數量為正整數
- **Docker Compose 生成**：
  - 為每個 worker 建立獨立的服務定義
  - 每個 worker 擁有：
    - 唯一的容器名稱（runner-worker-1, runner-worker-2 等）
    - 專屬的工作卷冊
    - Docker socket 存取權限
    - 環境變數配置
    - 自動重啟策略

- **網路配置**：建立 bridge 網路供 runners 通訊
- **卷冊管理**：為每個 worker 建立命名卷冊，確保資料持久性

### 使用範例

\`\`\`bash
# 使用預設 3 個 workers 生成
./deployment/gen-compose.sh

# 生成 5 個 workers
./deployment/gen-compose.sh -w 5

# 生成 10 個 workers，自訂輸出檔案
./deployment/gen-compose.sh -w 10 -o runners.yml
\`\`\`

## 測試執行

已完成以下測試：
1. ✅ 說明命令測試：確認說明輸出正確顯示
2. ✅ 預設配置測試：生成預設 3 個 workers 的配置檔
3. ✅ 自訂 worker 數量測試：生成 5 個 workers 的配置檔
4. ✅ 錯誤處理測試：
   - 無效的 worker 數量（0）：正確拒絕
   - 非數字輸入：正確拒絕
5. ✅ 輸出檔案驗證：確認生成的 YAML 結構正確

## 技術細節

### 生成的 Docker Compose 結構
- **版本**：3.8
- **服務**：N 個 worker 服務（可配置）
- **映像**：ghcr.io/actions/actions-runner:latest
- **卷冊**：每個 worker 一個命名卷冊
- **網路**：單一 bridge 網路供所有 workers 使用
- **環境變數**：
  - 支援 .env 檔案進行敏感配置
  - 每個 worker 擁有唯一的 RUNNER_NAME
  - 配置為 root 執行（RUNNER_ALLOW_RUNASROOT=1）

## 關聯 Issue

Fixes #10

---

此 PR 由 beaver-the-worker worker-v0.2.6 自動產生