### PR TITLE
fix(safe_sleep): assert arg is int to block code-injection

### DIFF
--- a/src/Misc/layoutroot/safe_sleep.sh
+++ b/src/Misc/layoutroot/safe_sleep.sh
@@ -6,6 +6,12 @@ if [ -x "$(command -v sleep)" ]; then
     exit 0
 fi
 
+# assert integer
+if ! builtin printf %d "$1" &>/dev/null; then
+    echo "safe_sleep: invalid time interval ‘$1’"
+    exit 1
+fi
+
 # try to use ping if available
 if [ -x "$(command -v ping)" ]; then
     ping -c $(( $1 + 1 )) 127.0.0.1 > /dev/null


### PR DESCRIPTION
I've implemented [the fix mentioned here](https://github.com/koalaman/shellcheck/issues/3067#issuecomment-3359293981).

The (currently dormant) vulnerability was introduced by 2 PRs:
- https://github.com/actions/runner/pull/4146/changes#r2609103908
- https://github.com/actions/runner/pull/3157#issuecomment-3638892152

The assertion doesn't exit if the integer is signed (negative), but I assume that's not a problem for `ping` and `read`