### PR TITLE
Add support for libssl3 and libssl3t64 for newer Debian/Ubuntu versions

### DIFF
--- a/docs/start/envlinux.md
+++ b/docs/start/envlinux.md
@@ -28,7 +28,7 @@ Debian based OS (Debian, Ubuntu, Linux Mint)
 - liblttng-ust1 or liblttng-ust0
 - libkrb5-3
 - zlib1g
-- libssl1.1, libssl1.0.2 or libssl1.0.0
+- libssl3t64, libssl3, libssl1.1, libssl1.0.2 or libssl1.0.0
 - libicu76, libicu75, ..., libicu66, libicu65, libicu63, libicu60, libicu57, libicu55, or libicu52
 
 Fedora based OS (Fedora, Red Hat Enterprise Linux, CentOS, Oracle Linux 7)

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -102,7 +102,7 @@ then
             exit 1
         fi
 
-        apt_get_with_fallbacks libssl1.1$ libssl1.0.2$ libssl1.0.0$
+        apt_get_with_fallbacks libssl3t64$ libssl3$ libssl1.1$ libssl1.0.2$ libssl1.0.0$
         if [ $? -ne 0 ]
         then
             echo "'$apt_get' failed with exit code '$?'"


### PR DESCRIPTION
## What

Add support for libssl3 and libssl3t64 in the install script in order to run the script on Debian bookwarm https://packages.debian.org/bookworm/libssl3 and trixie https://packages.debian.org/trixie/libssl3t64 and related Ubuntu versions.

Related: https://github.com/actions/runner/pull/4098

## Why

The libssl1.1 package is not supported on bookwarm and trixie.

## How

Add them into the array of installed versions in the script. Also I've added them in its document.

## Misc

I've been building a Docker image for actions/runner based on Ubuntu 24.04 Noble Numbat with this fix for a while. Specifically, I've added the following script to my Dockerfile:

```dockerfile
RUN grep -q 'apt_get_with_fallbacks libssl1.1\$ libssl1.0.2\$ libssl1.0.0\$' ./bin/installdependencies.sh && \
    sed -i 's/apt_get_with_fallbacks libssl1.1.*$/\$apt_get install -y libssl3t64/' ./bin/installdependencies.sh && \
    ./bin/installdependencies.sh
```

Please note that `apt_get_with_fallbacks` has a bug that it doesn't throw an error even if none of given packages can be installed, so one may not be able to notice the failure of installation. A fix for this bug was sent as https://github.com/actions/runner/pull/3825.