### PR TITLE
Fix local action display name showing `Run /./` instead of `Run ./`

### DIFF
--- a/src/Runner.Worker/ActionRunner.cs
+++ b/src/Runner.Worker/ActionRunner.cs
@@ -379,7 +379,14 @@ namespace GitHub.Runner.Worker
             {
                 prefix = PipelineTemplateConstants.RunDisplayPrefix;
                 var repositoryReference = action.Reference as RepositoryPathReference;
-                var pathString = string.IsNullOrEmpty(repositoryReference.Path) ? string.Empty : $"/{repositoryReference.Path}";
+                var pathString = string.Empty;
+                if (!string.IsNullOrEmpty(repositoryReference.Path))
+                {
+                    // For local actions (Name is empty), don't prepend "/" to avoid "/./"
+                    pathString = string.IsNullOrEmpty(repositoryReference.Name)
+                        ? repositoryReference.Path
+                        : $"/{repositoryReference.Path}";
+                }
                 var repoString = string.IsNullOrEmpty(repositoryReference.Ref) ? $"{repositoryReference.Name}{pathString}" :
                     $"{repositoryReference.Name}{pathString}@{repositoryReference.Ref}";
                 tokenToParse = new StringToken(null, null, null, repoString);

--- a/src/Test/L0/Worker/ActionRunnerL0.cs
+++ b/src/Test/L0/Worker/ActionRunnerL0.cs
@@ -319,6 +319,94 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        public void EvaluateDisplayNameForLocalAction()
+        {
+            // Arrange
+            Setup();
+            var actionId = Guid.NewGuid();
+            var action = new Pipelines.ActionStep()
+            {
+                Name = "action",
+                Id = actionId,
+                Reference = new Pipelines.RepositoryPathReference()
+                {
+                    RepositoryType = Pipelines.PipelineConstants.SelfAlias,
+                    Path = "./"
+                }
+            };
+            _actionRunner.Action = action;
+
+            // Act
+            var validDisplayName = _actionRunner.EvaluateDisplayName(_context, _actionRunner.ExecutionContext, out bool updated);
+
+            // Assert
+            Assert.True(validDisplayName);
+            Assert.True(updated);
+            Assert.Equal("Run ./", _actionRunner.DisplayName);  // NOT "Run /./"
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void EvaluateDisplayNameForLocalActionWithPath()
+        {
+            // Arrange
+            Setup();
+            var actionId = Guid.NewGuid();
+            var action = new Pipelines.ActionStep()
+            {
+                Name = "action",
+                Id = actionId,
+                Reference = new Pipelines.RepositoryPathReference()
+                {
+                    RepositoryType = Pipelines.PipelineConstants.SelfAlias,
+                    Path = "./.github/actions/my-action"
+                }
+            };
+            _actionRunner.Action = action;
+
+            // Act
+            var validDisplayName = _actionRunner.EvaluateDisplayName(_context, _actionRunner.ExecutionContext, out bool updated);
+
+            // Assert
+            Assert.True(validDisplayName);
+            Assert.True(updated);
+            Assert.Equal("Run ./.github/actions/my-action", _actionRunner.DisplayName);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void EvaluateDisplayNameForRemoteActionWithPath()
+        {
+            // Arrange
+            Setup();
+            var actionId = Guid.NewGuid();
+            var action = new Pipelines.ActionStep()
+            {
+                Name = "action",
+                Id = actionId,
+                Reference = new Pipelines.RepositoryPathReference()
+                {
+                    Name = "owner/repo",
+                    Path = "subdir",
+                    Ref = "v1"
+                }
+            };
+            _actionRunner.Action = action;
+
+            // Act
+            var validDisplayName = _actionRunner.EvaluateDisplayName(_context, _actionRunner.ExecutionContext, out bool updated);
+
+            // Assert
+            Assert.True(validDisplayName);
+            Assert.True(updated);
+            Assert.Equal("Run owner/repo/subdir@v1", _actionRunner.DisplayName);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
         public async void WarnInvalidInputs()
         {
             //Arrange
@@ -459,7 +547,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
             _handlerFactory = new Mock<IHandlerFactory>();
             _defaultStepHost = new Mock<IDefaultStepHost>();
-            
+
             var actionManifestLegacy = new ActionManifestManagerLegacy();
             actionManifestLegacy.Initialize(_hc);
             _hc.SetSingleton<IActionManifestManagerLegacy>(actionManifestLegacy);


### PR DESCRIPTION
For local actions (`uses: ./`), the display name was incorrectly showing `Run /./` due to a leading `/` being prepended to the path. This change fixes the `GenerateDisplayName` method to not prepend `/` when the repository Name is empty, which is the case for local/self-repo actions.

The Path already contains the full relative path (e.g., `./` or `./.github/actions/foo`), so no leading `/` is needed.

Fixes: https://github.com/orgs/community/discussions/26245#discussioncomment-15646272