### PR TITLE
Add telemetry tracking for deprecated set-output and save-state commands

### DIFF
--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -318,6 +318,17 @@ namespace GitHub.Runner.Worker
                 context.AddIssue(issue, ExecutionContextLogOptions.Default);
             }
 
+            if (!context.Global.HasDeprecatedSetOutput)
+            {
+                context.Global.HasDeprecatedSetOutput = true;
+                var telemetry = new JobTelemetry
+                {
+                    Type = JobTelemetryType.ActionCommand,
+                    Message = "DeprecatedCommand: set-output"
+                };
+                context.Global.JobTelemetry.Add(telemetry);
+            }
+
             if (!command.Properties.TryGetValue(SetOutputCommandProperties.Name, out string outputName) || string.IsNullOrEmpty(outputName))
             {
                 throw new Exception("Required field 'name' is missing in ##[set-output] command.");
@@ -351,6 +362,17 @@ namespace GitHub.Runner.Worker
                 };
                 issue.Data[Constants.Runner.InternalTelemetryIssueDataKey] = Constants.Runner.UnsupportedCommand;
                 context.AddIssue(issue, ExecutionContextLogOptions.Default);
+            }
+
+            if (!context.Global.HasDeprecatedSaveState)
+            {
+                context.Global.HasDeprecatedSaveState = true;
+                var telemetry = new JobTelemetry
+                {
+                    Type = JobTelemetryType.ActionCommand,
+                    Message = "DeprecatedCommand: save-state"
+                };
+                context.Global.JobTelemetry.Add(telemetry);
             }
 
             if (!command.Properties.TryGetValue(SaveStateCommandProperties.Name, out string stateName) || string.IsNullOrEmpty(stateName))

--- a/src/Runner.Worker/GlobalContext.cs
+++ b/src/Runner.Worker/GlobalContext.cs
@@ -31,5 +31,7 @@ namespace GitHub.Runner.Worker
         public JObject ContainerHookState { get; set; }
         public bool HasTemplateEvaluatorMismatch { get; set; }
         public bool HasActionManifestMismatch { get; set; }
+        public bool HasDeprecatedSetOutput { get; set; }
+        public bool HasDeprecatedSaveState { get; set; }
     }
 }


### PR DESCRIPTION
- Add HasDeprecatedSetOutput and HasDeprecatedSaveState flags to GlobalContext
- Emit JobTelemetry once per job when deprecated commands are used
- Add unit tests verifying once-per-job telemetry behavior