### PR TITLE
Add Amazon Linux support to installdependencies.sh

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -117,16 +117,16 @@ then
             print_errormessage
             exit 1
         fi
-    elif [ -e /etc/redhat-release ]
+    elif [ -e /etc/redhat-release ] || grep -q '^ID="amzn"' /etc/os-release
     then
         echo "The current OS is Fedora based"
-        echo "--Fedora/RHEL/CentOS Version--"
-        cat /etc/redhat-release
+        echo "--Fedora/RHEL/CentOS/Amazon Linux Version--"
+        cat /etc/redhat-release 2>/dev/null || cat /etc/system-release 2>/dev/null
         echo "------------------------------"
 
-        # use dnf on fedora
-        # use yum on centos and rhel
-        if [ -e /etc/fedora-release ]
+        # use dnf on fedora and amazon linux 2023
+        # use yum on centos, rhel, and amazon linux 2
+        if [ -e /etc/fedora-release ] || (grep -q '^ID="amzn"' /etc/os-release && grep -q '^VERSION_ID="2023"' /etc/os-release)
         then
             command -v dnf
             if [ $? -eq 0 ]


### PR DESCRIPTION
- Detect Amazon Linux via /etc/os-release ID check
- Use dnf for Amazon Linux 2023, yum for Amazon Linux 2
- Fall back to /etc/system-release when /etc/redhat-release is missing
