### PR TITLE
Try to infer runner is on hosted/ghes when githuburl is empty.

### DIFF
--- a/src/Runner.Common/ConfigurationStore.cs
+++ b/src/Runner.Common/ConfigurationStore.cs
@@ -77,6 +77,12 @@ namespace GitHub.Runner.Common
                 }
                 else
                 {
+                    // feature flag env in case the new logic is wrong.
+                    if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_FORCE_EMPTY_GITHUB_URL_IS_HOSTED")))
+                    {
+                        return true;
+                    }
+
                     // GitHubUrl will be empty for jit configured runner
                     // We will try to infer it from the ServerUrl/ServerUrlV2
                     if (StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("GITHUB_ACTIONS_RUNNER_FORCE_GHES")))


### PR DESCRIPTION
https://github.com/github/c2c-actions-support/issues/5708