### PR TITLE
Fix composite post-step marker display names

### DIFF
--- a/src/Runner.Worker/Handlers/CompositeActionHandler.cs
+++ b/src/Runner.Worker/Handlers/CompositeActionHandler.cs
@@ -312,7 +312,14 @@ namespace GitHub.Runner.Worker.Handlers
                 // Emit start marker after full context setup so display name expressions resolve correctly
                 if (emitCompositeMarkers)
                 {
-                    step.TryUpdateDisplayName(out _);
+                    try
+                    {
+                        step.EvaluateDisplayName(step.ExecutionContext.ExpressionValues, step.ExecutionContext, out _);
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.Warning("Caught exception while evaluating embedded step display name. {0}", ex);
+                    }
                     ExecutionContext.Output($"##[start-action display={EscapeProperty(SanitizeDisplayName(step.DisplayName))};id={EscapeProperty(markerId)}]");
                     stepStopwatch = Stopwatch.StartNew();
                 }


### PR DESCRIPTION
### Motivation

PR #4243 introduced `##[start-action]` / `##[end-action]` markers for composite action steps. Two issues remain with the display name used in these markers:

1. **Post-step markers show `"run"` instead of the resolved name.** `TryUpdateDisplayName` skips evaluation during the Post stage, so embedded composite post steps fall back to `"run"`.

2. **`TryUpdateDisplayName` sends unnecessary server updates for embedded steps.** Embedded steps share the parent's timeline record, so updating the display name overwrites the parent step's name in the UI.

### Fix

Call `EvaluateDisplayName` directly instead of `TryUpdateDisplayName` in the composite marker emission path. This resolves the name in-memory without sending a timeline record update. Gated behind existing feature flag `actions_runner_emit_composite_markers`.
