### PR TITLE
Devcontainer: bump base image Ubuntu version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Actions Runner Devcontainer",
-  "image": "mcr.microsoft.com/devcontainers/base:jammy",
+  "image": "mcr.microsoft.com/devcontainers/base:noble",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/dotnet": {


### PR DESCRIPTION
Can't open dev container on Mac with silicon chip because of older Ubuntu focal (20.04) base image. Bumping to <s>jammy (22.04)</s> noble (24.04) (and also bumping `docker-in-docker`) fixes it.

```
$ docker pull mcr.microsoft.com/devcontainers/base:focal
Error response from daemon: no match for platform in manifest: not found

$ docker pull mcr.microsoft.com/devcontainers/base:noble
noble: Pulling from devcontainers/base
Digest: sha256:3dcb059253b2ebb44de3936620e1cff3dadcd2c1c982d579081ca8128c1eb319
Status: Image is up to date for mcr.microsoft.com/devcontainers/base:noble
mcr.microsoft.com/devcontainers/base:noble
```

