### PR TITLE
Eager BFS resolution: pre-resolve all reachable actions upfront

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -178,6 +178,7 @@ namespace GitHub.Runner.Common
                 public static readonly string SendJobLevelAnnotations = "actions_send_job_level_annotations";
                 public static readonly string EmitCompositeMarkers = "actions_runner_emit_composite_markers";
                 public static readonly string BatchActionResolution = "actions_batch_action_resolution";
+                public static readonly string EagerActionResolution = "actions_eager_action_resolution";
                 public static readonly string UseBearerTokenForCodeload = "actions_use_bearer_token_for_codeload";
                 public static readonly string OverrideDebuggerWelcomeMessage = "actions_runner_override_debugger_welcome_message";
             }

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -81,6 +81,12 @@ namespace GitHub.Runner.Worker
             var containerSetupSteps = new List<JobExtensionRunner>();
             var batchActionResolution = (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.BatchActionResolution) ?? false)
                 || StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION"));
+            // Eager BFS pre-resolution builds on top of the batched path (it
+            // relies on the shared resolvedDownloadInfos cache), so it only
+            // takes effect when batch resolution is also enabled.
+            var eagerActionResolution = ((executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.EagerActionResolution) ?? false)
+                || StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("ACTIONS_EAGER_ACTION_RESOLUTION")))
+                && batchActionResolution;
             // Stack-local cache: same action (owner/repo@ref) is resolved only once,
             // even if it appears at multiple depths in a composite tree.
             var resolvedDownloadInfos = batchActionResolution
@@ -109,6 +115,18 @@ namespace GitHub.Runner.Worker
             }
             IEnumerable<Pipelines.ActionStep> actions = steps.OfType<Pipelines.ActionStep>();
             executionContext.Output("Prepare all required actions");
+
+            // Eagerly discover, resolve, and download all reachable actions via
+            // BFS before the recursive walk begins. This collapses all network
+            // I/O into a tight loop so the recursive walk is purely local (zero
+            // API calls, zero downloads). Behind its own EagerActionResolution
+            // feature flag, which additionally requires batch resolution to be
+            // enabled since it relies on the shared resolvedDownloadInfos cache.
+            if (eagerActionResolution && rootStepId == default(Guid))
+            {
+                await EagerlyResolveAllReachableActionsAsync(executionContext, actions.ToList(), resolvedDownloadInfos);
+            }
+
             PrepareActionsState result = new PrepareActionsState();
             try
             {
@@ -986,6 +1004,212 @@ namespace GitHub.Runner.Worker
                     resolvedDownloadInfos[kvp.Key] = kvp.Value;
                 }
             }
+        }
+
+        // Maximum number of action tarballs to download in parallel during the
+        // eager BFS pre-resolution pass. Kept deliberately conservative so a
+        // workflow with many unique actions at a single depth cannot overwhelm
+        // the action download service. (Addresses review feedback on #4297.)
+        private const int MaxEagerDownloadConcurrency = 2;
+
+        /// <summary>
+        /// BFS discovery loop: resolve and download all reachable actions upfront
+        /// so the recursive walk makes zero network calls.
+        /// </summary>
+        private async Task EagerlyResolveAllReachableActionsAsync(
+            IExecutionContext executionContext,
+            List<Pipelines.ActionStep> initialActions,
+            Dictionary<string, WebApi.ActionDownloadInfo> resolvedDownloadInfos)
+        {
+            // downloadedKeys tracks repo downloads (owner/repo@ref — no path).
+            // scannedKeys tracks which sub-path action.ymls have been scanned
+            // (owner/repo/path@ref) so we don't re-scan the same composite.
+            var downloadedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var scannedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var pending = new List<Pipelines.ActionStep>(initialActions);
+
+            while (pending.Count > 0)
+            {
+                // Collect repo actions we haven't scanned yet
+                var repoActions = new List<Pipelines.ActionStep>();
+                foreach (var action in pending)
+                {
+                    if (action.Reference.Type != Pipelines.ActionSourceType.Repository)
+                    {
+                        continue;
+                    }
+                    var scanKey = GetScanKey(action);
+                    if (!string.IsNullOrEmpty(scanKey) && scannedKeys.Add(scanKey))
+                    {
+                        repoActions.Add(action);
+                    }
+                }
+                pending.Clear();
+
+                if (repoActions.Count == 0)
+                {
+                    break;
+                }
+
+                // Resolve only repos not yet in the cache
+                var toResolve = repoActions
+                    .Where(a =>
+                    {
+                        var key = GetDownloadInfoLookupKey(a);
+                        return !string.IsNullOrEmpty(key) && !downloadedKeys.Contains(key);
+                    })
+                    .ToList();
+
+                if (toResolve.Count > 0)
+                {
+                    await ResolveNewActionsAsync(executionContext, toResolve, resolvedDownloadInfos);
+
+                    // Download in parallel, but bound concurrency with a
+                    // semaphore so a single wavefront containing many unique
+                    // actions cannot overwhelm the action download service.
+                    using (var downloadThrottle = new SemaphoreSlim(MaxEagerDownloadConcurrency, MaxEagerDownloadConcurrency))
+                    {
+                        var downloadTasks = new List<Task>();
+                        foreach (var action in toResolve)
+                        {
+                            var key = GetDownloadInfoLookupKey(action);
+                            if (downloadedKeys.Add(key) && resolvedDownloadInfos.TryGetValue(key, out var info))
+                            {
+                                downloadTasks.Add(DownloadRepositoryActionWithThrottleAsync(executionContext, info, downloadThrottle));
+                            }
+                        }
+                        await Task.WhenAll(downloadTasks);
+                    }
+                }
+
+                // Scan ALL actions for composite sub-references (including
+                // sub-paths of already-downloaded repos).
+                foreach (var action in repoActions)
+                {
+                    var subRefs = ScanForRepoReferences(executionContext, action);
+                    if (subRefs != null)
+                    {
+                        pending.AddRange(subRefs);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Downloads a single action tarball while holding a slot in the supplied
+        /// throttle, bounding overall eager-download concurrency.
+        /// </summary>
+        private async Task DownloadRepositoryActionWithThrottleAsync(
+            IExecutionContext executionContext,
+            WebApi.ActionDownloadInfo downloadInfo,
+            SemaphoreSlim throttle)
+        {
+            await throttle.WaitAsync(executionContext.CancellationToken);
+            try
+            {
+                await DownloadRepositoryActionAsync(executionContext, downloadInfo);
+            }
+            finally
+            {
+                throttle.Release();
+            }
+        }
+
+        /// <summary>
+        /// Returns a scan key that includes the sub-path, so that different
+        /// sub-paths within the same repo are scanned independently.
+        /// Format: "owner/repo/path@ref" or "owner/repo@ref" when no path.
+        /// </summary>
+        private static string GetScanKey(Pipelines.ActionStep action)
+        {
+            if (action.Reference.Type != Pipelines.ActionSourceType.Repository)
+            {
+                return null;
+            }
+
+            var repoRef = action.Reference as Pipelines.RepositoryPathReference;
+            if (repoRef == null ||
+                string.Equals(repoRef.RepositoryType, Pipelines.PipelineConstants.SelfAlias, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            if (!string.IsNullOrEmpty(repoRef.Path))
+            {
+                return $"{repoRef.Name}/{repoRef.Path}@{repoRef.Ref}";
+            }
+            return $"{repoRef.Name}@{repoRef.Ref}";
+        }
+
+        /// <summary>
+        /// Lightweight scan: load an action's manifest and return any repository
+        /// references from composite steps, without side effects (no GUID
+        /// assignment, no step caching).
+        /// </summary>
+        private List<Pipelines.ActionStep> ScanForRepoReferences(
+            IExecutionContext executionContext,
+            Pipelines.ActionStep action)
+        {
+            var repoRef = action.Reference as Pipelines.RepositoryPathReference;
+            if (repoRef == null ||
+                string.Equals(repoRef.RepositoryType, Pipelines.PipelineConstants.SelfAlias, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            string destDirectory = Path.Combine(
+                HostContext.GetDirectory(WellKnownDirectory.Actions),
+                repoRef.Name.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar),
+                repoRef.Ref);
+            string actionEntryDirectory = destDirectory;
+            if (!string.IsNullOrEmpty(repoRef.Path))
+            {
+                actionEntryDirectory = Path.Combine(destDirectory, repoRef.Path);
+            }
+
+            var actionManifest = Path.Combine(actionEntryDirectory, Constants.Path.ActionManifestYmlFile);
+            var actionManifestYaml = Path.Combine(actionEntryDirectory, Constants.Path.ActionManifestYamlFile);
+
+            ActionDefinitionData actionDef = null;
+            try
+            {
+                var manifestManager = HostContext.GetService<IActionManifestManagerWrapper>();
+                if (File.Exists(actionManifest))
+                {
+                    actionDef = manifestManager.Load(executionContext, actionManifest);
+                }
+                else if (File.Exists(actionManifestYaml))
+                {
+                    actionDef = manifestManager.Load(executionContext, actionManifestYaml);
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.Warning($"Failed to scan action manifest for {repoRef.Name}: {ex.Message}");
+                return null;
+            }
+
+            if (actionDef?.Execution?.ExecutionType != ActionExecutionType.Composite)
+            {
+                return null;
+            }
+
+            var compositeAction = actionDef.Execution as CompositeActionExecutionData;
+            if (compositeAction?.Steps == null)
+            {
+                return null;
+            }
+
+            var result = new List<Pipelines.ActionStep>();
+            foreach (var step in compositeAction.Steps)
+            {
+                if (step is Pipelines.ActionStep actionStep &&
+                    actionStep.Reference?.Type == Pipelines.ActionSourceType.Repository)
+                {
+                    result.Add(actionStep);
+                }
+            }
+            return result.Count > 0 ? result : null;
         }
 
         private async Task DownloadRepositoryActionAsync(IExecutionContext executionContext, WebApi.ActionDownloadInfo downloadInfo)

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -3468,5 +3468,119 @@ runs:
                 Teardown();
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async void PrepareActions_EagerResolution_AllDownloadsBeforeRecursion()
+        {
+            // Eager BFS pre-resolution is gated behind its own feature
+            // flag and additionally requires batch resolution.
+            Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", "true");
+            Environment.SetEnvironmentVariable("ACTIONS_EAGER_ACTION_RESOLUTION", "true");
+            // Verifies that the eager BFS resolution loop resolves and
+            // downloads ALL reachable actions before the recursive walk
+            // begins.  We detect this by checking that all watermarks exist
+            // at the time of the FIRST resolve callback that the recursion
+            // would normally trigger (i.e. the eager loop should have
+            // already completed all downloads by then).
+            //
+            // Action tree (3 levels):
+            //   CompositePrestep → [Node, CompositePrestep2]
+            //   CompositePrestep2 → [Node, Docker]
+            //
+            // With eager BFS all 4 watermarks should exist after the BFS
+            // loop, before recursion.  We verify by recording watermark
+            // state during the very last resolve call.
+            try
+            {
+                //Arrange
+                Setup();
+                _hc.EnqueueInstance<IActionRunner>(new Mock<IActionRunner>().Object);
+                _hc.EnqueueInstance<IActionRunner>(new Mock<IActionRunner>().Object);
+                _hc.EnqueueInstance<IActionRunner>(new Mock<IActionRunner>().Object);
+
+                var resolveCallCount = 0;
+                var allWatermarksAtLastResolve = new Dictionary<string, bool>();
+                _jobServer.Setup(x => x.ResolveActionDownloadInfoAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ActionReferenceList>(), It.IsAny<CancellationToken>()))
+                    .Returns((Guid scopeIdentifier, string hubName, Guid planId, Guid jobId, ActionReferenceList actions, CancellationToken cancellationToken) =>
+                    {
+                        resolveCallCount++;
+                        // On each resolve call, snapshot which watermarks exist.
+                        // After the final call, all earlier downloads should be done.
+                        var actionsDir = _hc.GetDirectory(WellKnownDirectory.Actions);
+                        allWatermarksAtLastResolve["CompositePrestep"] = File.Exists(Path.Combine(actionsDir, "TingluoHuang/runner_L0", "CompositePrestep.completed"));
+                        allWatermarksAtLastResolve["Node"] = File.Exists(Path.Combine(actionsDir, "TingluoHuang/runner_L0", "RepositoryActionWithWrapperActionfile_Node.completed"));
+                        allWatermarksAtLastResolve["CompositePrestep2"] = File.Exists(Path.Combine(actionsDir, "TingluoHuang/runner_L0", "CompositePrestep2.completed"));
+                        allWatermarksAtLastResolve["Docker"] = File.Exists(Path.Combine(actionsDir, "TingluoHuang/runner_L0", "RepositoryActionWithWrapperActionfile_Docker.completed"));
+
+                        var result = new ActionDownloadInfoCollection { Actions = new Dictionary<string, ActionDownloadInfo>() };
+                        foreach (var action in actions.Actions)
+                        {
+                            var key = $"{action.NameWithOwner}@{action.Ref}";
+                            result.Actions[key] = new ActionDownloadInfo
+                            {
+                                NameWithOwner = action.NameWithOwner,
+                                Ref = action.Ref,
+                                ResolvedNameWithOwner = action.NameWithOwner,
+                                ResolvedSha = $"{action.Ref}-sha",
+                                TarballUrl = $"https://api.github.com/repos/{action.NameWithOwner}/tarball/{action.Ref}",
+                                ZipballUrl = $"https://api.github.com/repos/{action.NameWithOwner}/zipball/{action.Ref}",
+                            };
+                        }
+                        return Task.FromResult(result);
+                    });
+
+                var actions = new List<Pipelines.ActionStep>
+                {
+                    new Pipelines.ActionStep()
+                    {
+                        Name = "action",
+                        Id = Guid.NewGuid(),
+                        Reference = new Pipelines.RepositoryPathReference()
+                        {
+                            Name = "TingluoHuang/runner_L0",
+                            Ref = "CompositePrestep",
+                            RepositoryType = "GitHub"
+                        }
+                    }
+                };
+
+                //Act
+                var result = await _actionManager.PrepareActionsAsync(_ec.Object, actions);
+
+                //Assert
+                // All resolve calls should happen during the eager BFS loop
+                // (3 calls: one per BFS wavefront).
+                Assert.Equal(3, resolveCallCount);
+
+                // At the time of the LAST resolve call (call 3 for Docker),
+                // the first two wavefronts should already be fully downloaded:
+                Assert.True(allWatermarksAtLastResolve["CompositePrestep"],
+                    "CompositePrestep should be downloaded before last resolve call");
+                Assert.True(allWatermarksAtLastResolve["Node"],
+                    "Node should be downloaded before last resolve call");
+                Assert.True(allWatermarksAtLastResolve["CompositePrestep2"],
+                    "CompositePrestep2 should be downloaded before last resolve call");
+                // Docker is resolved in the last call, so it's NOT yet downloaded
+                // at that point — that's expected.
+                Assert.False(allWatermarksAtLastResolve["Docker"],
+                    "Docker should NOT yet be downloaded during its own resolve call");
+
+                // After PrepareActionsAsync completes, ALL should be downloaded
+                var actionsDir2 = _hc.GetDirectory(WellKnownDirectory.Actions);
+                Assert.True(File.Exists(Path.Combine(actionsDir2, "TingluoHuang/runner_L0", "CompositePrestep.completed")));
+                Assert.True(File.Exists(Path.Combine(actionsDir2, "TingluoHuang/runner_L0", "RepositoryActionWithWrapperActionfile_Node.completed")));
+                Assert.True(File.Exists(Path.Combine(actionsDir2, "TingluoHuang/runner_L0", "CompositePrestep2.completed")));
+                Assert.True(File.Exists(Path.Combine(actionsDir2, "TingluoHuang/runner_L0", "RepositoryActionWithWrapperActionfile_Docker.completed")));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", null);
+                Environment.SetEnvironmentVariable("ACTIONS_EAGER_ACTION_RESOLUTION", null);
+                Teardown();
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## Summary

Builds on #4296 (batch + dedup, now merged). Before the recursive composite walk begins, a BFS loop eagerly discovers, resolves, and downloads **all** reachable actions so the recursion makes zero network calls.

The loop iteratively:
1. Resolves pending actions in one batch API call
2. Downloads all tarballs in parallel (**bounded by `SemaphoreSlim(2)`** — see review feedback below)
3. Scans downloaded `action.yml` files for composite sub-action references
4. Feeds newly discovered actions back into the loop until none remain

### Feature flag

Gated behind a **new, separate** feature flag `actions_eager_action_resolution` (env: `ACTIONS_EAGER_ACTION_RESOLUTION`). Because it reuses the batched path's shared `resolvedDownloadInfos` cache, it additionally requires batch resolution (`actions_batch_action_resolution`) to be enabled. This lets eager BFS roll out independently of the already-deployed batch flag.

### Review feedback addressed

> unbounded `Task.WhenAll` on tarball downloads could slam our infrastructure if a workflow has a large number of unique actions at one depth. I'd be more comfortable with a conservative concurrency limit. Maybe `SemaphoreSlim(2)`? — @ericsciple

Done. Per-wavefront downloads now run through a `SemaphoreSlim(MaxEagerDownloadConcurrency = 2)` (`DownloadRepositoryActionWithThrottleAsync`), so no more than 2 tarballs download concurrently regardless of how many unique actions appear at one depth.

### Key design detail

Separate tracking for **downloads** (keyed by `owner/repo@ref` — path excluded, since sub-paths share one tarball) vs **scans** (keyed by `owner/repo/path@ref` — so each sub-path's `action.yml` is scanned for its composite children independently).

## Performance (controlled A/B/C, 3 repetitions)

Re-measured on a self-hosted runner built from this rebased branch (`SemaphoreSlim(2)` in place). **Same runner binary, same composite action graph** ([resolution-test](https://github.com/stefanpenner/resolution-test) `deep-composite-test.yml`); only the feature flags differ between configs. The metric is the **"Set up job" step duration** reported by the GitHub Actions API — this is the phase where action resolution + download happens. 3 runs per config:

| Config | Flags | min | **median** | mean | max | Speedup vs Off (median) |
|---|---|---|---|---|---|---|
| **Off** (legacy) | none | 111 s | **115 s** | 113.7 s | 115 s | 1× |
| **Batch** (#4296) | `actions_batch_action_resolution` | 18 s | **19 s** | 18.7 s | 19 s | **~6.1×** |
| **Eager BFS** (this PR) | batch + `actions_eager_action_resolution` + `SemaphoreSlim(2)` | 12 s | **12 s** | 12.3 s | 13 s | **~9.6×** |

Eager BFS adds **~1.6× on top of batch alone** (19 s → 12 s median). All 9 jobs completed successfully, so correctness held in every config — including with the new `SemaphoreSlim(2)` cap on. Total job time (resolve + step execution): Off ≈ 140 s, Batch ≈ 43 s, Eager ≈ 38 s.

<details><summary>Per-run links (3 reps × 3 configs)</summary>

| | Off | Batch | Eager |
|---|---|---|---|
| Rep 1 | [run](https://github.com/stefanpenner/resolution-test/actions/runs/26656519375) | [run](https://github.com/stefanpenner/resolution-test/actions/runs/26656644734) | [run](https://github.com/stefanpenner/resolution-test/actions/runs/26656694609) |
| Rep 2 | [run](https://github.com/stefanpenner/resolution-test/actions/runs/26656740717) | [run](https://github.com/stefanpenner/resolution-test/actions/runs/26656865507) | [run](https://github.com/stefanpenner/resolution-test/actions/runs/26656914339) |
| Rep 3 | [run](https://github.com/stefanpenner/resolution-test/actions/runs/26656965875) | [run](https://github.com/stefanpenner/resolution-test/actions/runs/26657089545) | [run](https://github.com/stefanpenner/resolution-test/actions/runs/26657138797) |

</details>

> Note: the figures above are verified GitHub-API wall-clock timings for the setup phase. The exact **resolve-API-call counts** (the "311 → 8 → 4" figures from the original write-up) were measured in earlier hand-run smoke tests and are not re-derived here.

## Test plan

- [x] All existing `ActionManagerL0` tests pass (38/38, no regression)
- [x] New test `PrepareActions_EagerResolution_AllDownloadsBeforeRecursion` — verifies all earlier BFS wavefronts are downloaded before the final resolve fires (enables both flags)
- [x] Self-hosted A/B/C benchmark, 3 reps per config (see table + run links above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
