### PR TITLE
Add `ACTIONS_RUNTIME_TOKEN` and runtime env vars to `ScriptHandler`

### DIFF
--- a/src/Runner.Worker/Handlers/ScriptHandler.cs
+++ b/src/Runner.Worker/Handlers/ScriptHandler.cs
@@ -311,11 +311,26 @@ namespace GitHub.Runner.Worker.Handlers
                 fileName = node;
             }
 #endif
+            // Add Actions Runtime server info
             var systemConnection = ExecutionContext.Global.Endpoints.Single(x => string.Equals(x.Name, WellKnownServiceEndpointNames.SystemVssConnection, StringComparison.OrdinalIgnoreCase));
+            Environment["ACTIONS_RUNTIME_URL"] = systemConnection.Url.AbsoluteUri;
+            Environment["ACTIONS_RUNTIME_TOKEN"] = systemConnection.Authorization.Parameters[EndpointAuthorizationParameters.AccessToken];
+            if (systemConnection.Data.TryGetValue("CacheServerUrl", out var cacheUrl) && !string.IsNullOrEmpty(cacheUrl))
+            {
+                Environment["ACTIONS_CACHE_URL"] = cacheUrl;
+            }
+            if (systemConnection.Data.TryGetValue("PipelinesServiceUrl", out var pipelinesServiceUrl) && !string.IsNullOrEmpty(pipelinesServiceUrl))
+            {
+                Environment["ACTIONS_RUNTIME_URL"] = pipelinesServiceUrl;
+            }
             if (systemConnection.Data.TryGetValue("GenerateIdTokenUrl", out var generateIdTokenUrl) && !string.IsNullOrEmpty(generateIdTokenUrl))
             {
                 Environment["ACTIONS_ID_TOKEN_REQUEST_URL"] = generateIdTokenUrl;
                 Environment["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = systemConnection.Authorization.Parameters[EndpointAuthorizationParameters.AccessToken];
+            }
+            if (systemConnection.Data.TryGetValue("ResultsServiceUrl", out var resultsUrl) && !string.IsNullOrEmpty(resultsUrl))
+            {
+                Environment["ACTIONS_RESULTS_URL"] = resultsUrl;
             }
 
             if (ExecutionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SetOrchestrationIdEnvForActions) ?? false)


### PR DESCRIPTION
`ScriptHandler` was missing the Actions Runtime environment variables (`ACTIONS_RUNTIME_URL`, `ACTIONS_RUNTIME_TOKEN`, `ACTIONS_CACHE_URL`, `ACTIONS_RESULTS_URL`) that `NodeScriptActionHandler` and `ContainerActionHandler` already expose. This meant run: steps and hook scripts couldn't interact with Actions runtime services (such as caching, artifacts, etc.) the same way Node/container actions(such as `@actions/upload-artifact`) can.

Added the same runtime env var block from `NodeScriptActionHandler` into `ScriptHandler`, placed before the existing `ACTIONS_ID_TOKEN_REQUEST_*` setup similar to `NodeScriptActionHandler`.