### PR TITLE
Fix infinite retry loop when runner registration is not found

### DIFF
--- a/src/Runner.Common/BrokerServer.cs
+++ b/src/Runner.Common/BrokerServer.cs
@@ -7,6 +7,7 @@ using GitHub.DistributedTask.Pipelines;
 using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Sdk;
 using GitHub.Services.Common;
+using GitHub.Services.OAuth;
 using GitHub.Services.WebApi;
 using Sdk.RSWebApi.Contracts;
 using Sdk.WebApi.WebApi.RawClient;
@@ -109,6 +110,14 @@ namespace GitHub.Runner.Common
         public bool ShouldRetryException(Exception ex)
         {
             if (ex is AccessDeniedException || ex is RunnerNotFoundException || ex is HostedRunnerDeprovisionedException)
+            {
+                return false;
+            }
+
+            // "invalid_client" means the runner registration has been deleted from the server.
+            // Retrying will never succeed, so bail out immediately.
+            if (ex is VssOAuthTokenRequestException oAuthEx &&
+                string.Equals(oAuthEx.Error, "invalid_client", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -444,11 +444,18 @@ namespace GitHub.Runner.Listener
                 Trace.Info($"Non-retriable exception: {ex.Message}");
                 return false;
             }
-            else
+
+            // "invalid_client" means the runner registration has been deleted from the server.
+            // This is permanent — retrying will never succeed.
+            if (ex is VssOAuthTokenRequestException oAuthEx &&
+                string.Equals(oAuthEx.Error, "invalid_client", StringComparison.OrdinalIgnoreCase))
             {
-                Trace.Info($"Retriable exception: {ex.Message}");
-                return true;
+                Trace.Info($"Non-retriable exception: runner registration deleted. {ex.Message}");
+                return false;
             }
+
+            Trace.Info($"Retriable exception: {ex.Message}");
+            return true;
         }
 
         private bool IsSessionCreationExceptionRetriable(Exception ex)

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -511,6 +511,22 @@ namespace GitHub.Runner.Listener
 
                     jobDispatcher.JobStatus += _listener.OnJobStatus;
 
+                    // For ephemeral runners, set up an idle timeout. If no job is received within
+                    // this period, the runner exits to free up the slot for a replacement.
+                    // This prevents orphaned runners (e.g., from pod recreation or session conflicts)
+                    // from blocking scale set capacity indefinitely.
+                    Task idleTimeoutTask = Task.Delay(Timeout.Infinite, messageQueueLoopTokenSource.Token);
+                    if (runOnce)
+                    {
+                        var idleTimeoutEnv = Environment.GetEnvironmentVariable("ACTIONS_RUNNER_IDLE_TIMEOUT_MINUTES");
+                        var idleTimeoutMinutes = int.TryParse(idleTimeoutEnv, out var parsed) ? parsed : 10;
+                        if (idleTimeoutMinutes > 0)
+                        {
+                            Trace.Info($"Ephemeral runner idle timeout set to {idleTimeoutMinutes} minutes.");
+                            idleTimeoutTask = Task.Delay(TimeSpan.FromMinutes(idleTimeoutMinutes), messageQueueLoopTokenSource.Token);
+                        }
+                    }
+
                     while (!HostContext.RunnerShutdownToken.IsCancellationRequested)
                     {
                         // Check if we need to restart the session and can do so (job dispatcher not busy)
@@ -527,6 +543,30 @@ namespace GitHub.Runner.Listener
                         try
                         {
                             Task<TaskAgentMessage> getNextMessage = _listener.GetNextMessageAsync(messageQueueLoopTokenSource.Token);
+
+                            // For ephemeral runners that haven't received a job yet,
+                            // race the message poll against the idle timeout.
+                            if (runOnce && !runOnceJobReceived && !idleTimeoutTask.IsCompleted)
+                            {
+                                Task completedTask = await Task.WhenAny(getNextMessage, idleTimeoutTask);
+                                if (completedTask == idleTimeoutTask)
+                                {
+                                    Trace.Info("Ephemeral runner idle timeout reached without receiving a job. Exiting.");
+                                    _term.WriteError($"{DateTime.UtcNow:u}: Ephemeral runner idle timeout reached without receiving a job. Exiting to free up capacity.");
+                                    messageQueueLoopTokenSource.Cancel();
+                                    try
+                                    {
+                                        await getNextMessage;
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        Trace.Info($"Ignore any exception after cancel message loop. {ex}");
+                                    }
+
+                                    return Constants.Runner.ReturnCode.TerminatedError;
+                                }
+                            }
+
                             if (autoUpdateInProgress)
                             {
                                 Trace.Verbose("Auto update task running at backend, waiting for getNextMessage or selfUpdateTask to finish.");

--- a/src/Test/L0/Listener/BrokerMessageListenerL0.cs
+++ b/src/Test/L0/Listener/BrokerMessageListenerL0.cs
@@ -7,6 +7,7 @@ using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Listener;
 using GitHub.Runner.Listener.Configuration;
 using GitHub.Services.Common;
+using GitHub.Services.OAuth;
 using Moq;
 using Xunit;
 
@@ -404,6 +405,87 @@ namespace GitHub.Runner.Common.Tests.Listener
                 // Verify LoadSettings was never called
                 _config.Verify(x => x.LoadSettings(), Times.Never());
             }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async Task GetNextMessage_ThrowsNonRetryableOnInvalidClientOAuth()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+
+                var expectedSession = new TaskAgentSession();
+                _brokerServer
+                    .Setup(x => x.CreateSessionAsync(
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                // Simulate "Registration was not found" — OAuth invalid_client error
+                _brokerServer
+                    .Setup(x => x.GetRunnerMessageAsync(
+                        It.IsAny<Guid?>(),
+                        It.IsAny<TaskAgentStatus>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new VssOAuthTokenRequestException("Registration abc-123 was not found.") { Error = "invalid_client" });
+
+                // Act.
+                BrokerMessageListener listener = new();
+                listener.Initialize(tc);
+
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(CreateSessionResult.Success, result);
+
+                // Assert — should throw NonRetryableException, not retry forever
+                var ex = await Assert.ThrowsAsync<NonRetryableException>(() => listener.GetNextMessageAsync(tokenSource.Token));
+                Assert.Contains("non-retryable", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+                // Should have been called exactly once (no retries)
+                _brokerServer.Verify(x => x.GetRunnerMessageAsync(
+                    It.IsAny<Guid?>(),
+                    It.IsAny<TaskAgentStatus>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()), Times.Once());
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public void ShouldRetryException_ReturnsFalseForInvalidClientOAuth()
+        {
+            // Arrange
+            var brokerServer = new BrokerServer();
+            var oauthEx = new VssOAuthTokenRequestException("Registration abc-123 was not found.") { Error = "invalid_client" };
+
+            // Act & Assert — invalid_client should not be retried
+            Assert.False(brokerServer.ShouldRetryException(oauthEx));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public void ShouldRetryException_ReturnsTrueForOtherOAuthErrors()
+        {
+            // Arrange
+            var brokerServer = new BrokerServer();
+            var oauthEx = new VssOAuthTokenRequestException("Temporary failure") { Error = "server_error" };
+
+            // Act & Assert — other OAuth errors should still be retried
+            Assert.True(brokerServer.ShouldRetryException(oauthEx));
         }
 
         private TestHostContext CreateTestContext([CallerMemberName] String testName = "")


### PR DESCRIPTION
## Summary

Fixes #4191

Two related fixes for ephemeral runners that end up registered with GitHub but unable to pick up jobs, blocking scale set capacity.

### Fix 1: Treat deleted runner registration as non-retryable error

When a runner's registration is garbage-collected by GitHub, the OAuth token exchange fails with `invalid_client` ("Registration was not found"). The runner enters an infinite retry loop because `VssOAuthTokenRequestException` is not classified as non-retryable in either retry layer. This leaves the pod in `Running` status indefinitely — the ARC controller counts it as a live runner and never creates a replacement.

**Changes:**
- `BrokerServer.ShouldRetryException()` — stops the inner 5-retry loop in `RetryRequest()` immediately
- `BrokerMessageListener.IsGetNextMessageExceptionRetriable()` — causes `GetNextMessageAsync()` to throw `NonRetryableException`, so `Program.cs` returns `TerminatedError`

This matches the existing precedent in `CreateSessionAsync()` (line 188), which already treats `invalid_client` as terminal.

### Fix 2: Add idle timeout for ephemeral runners waiting for jobs

Ephemeral runners created via JIT config can end up registered with GitHub but never receive a job (e.g., due to pod recreation causing session conflicts, or the original job being reassigned to another runner). These orphaned runners sit idle indefinitely, blocking a slot in the ARC scale set.

**Changes:**
- `Runner.RunAsync()` — adds a configurable idle timeout (default: 10 minutes) that exits the runner if no job is received after session creation. Uses the existing `Task.WhenAny` pattern already used for auto-update and run-once job completion.
- Configurable via `ACTIONS_RUNNER_IDLE_TIMEOUT_MINUTES` env var (set to 0 to disable). Only applies to ephemeral/run-once runners.

## How we found this

We traced a production incident where jobs targeting an ARC scale set were stuck for 9+ minutes. Cloud Logging revealed:

1. An ephemeral runner (`jgjcv`) had pod stability issues at startup — the original pod disappeared and was recreated
2. The replacement pod hit "A session for this runner already exists" conflicts for ~2 minutes before connecting
3. By then, the job was assigned elsewhere — the runner sat idle "Listening for Jobs" from 09:23 to 10:14 (51 minutes)
4. At 10:14, GitHub garbage-collected the idle registration → "Registration was not found"
5. The runner entered the infinite retry loop (fix 1)
6. The ARC controller saw `running=1, desired=1` and never created a replacement (fix 2 would have caught this at 09:33)

## Test plan

- [x] Build succeeds (`dotnet build Runner.Listener.csproj`)
- [x] L0 test: `GetNextMessage_ThrowsNonRetryableOnInvalidClientOAuth` — verifies `NonRetryableException` without retrying
- [x] L0 test: `ShouldRetryException_ReturnsFalseForInvalidClientOAuth` — verifies `invalid_client` is non-retryable
- [x] L0 test: `ShouldRetryException_ReturnsTrueForOtherOAuthErrors` — verifies other OAuth errors still retry
- [ ] Verify idle timeout exits runner after configured period when no job is received
- [ ] Verify idle timeout does not affect runners that receive a job within the timeout
- [ ] Verify `ACTIONS_RUNNER_IDLE_TIMEOUT_MINUTES=0` disables the timeout