### PR TITLE
test: update CommitHash length assertion for SHA-256 support

### DIFF
--- a/src/Test/L0/ConstantGenerationL0.cs
+++ b/src/Test/L0/ConstantGenerationL0.cs
@@ -24,7 +24,10 @@ namespace GitHub.Runner.Common.Tests
                 "osx-arm64"
             };
 
-            Assert.Equal(40, BuildConstants.Source.CommitHash.Length);
+            Assert.True(
+                BuildConstants.Source.CommitHash.Length == 40 || BuildConstants.Source.CommitHash.Length == 64,
+                "CommitHash should be a 40-char SHA-1 or 64-char SHA-256 hex string");
+            Assert.Matches("^[0-9a-f]+$", BuildConstants.Source.CommitHash);
             Assert.True(validPackageNames.Contains(BuildConstants.RunnerPackage.PackageName), $"PackageName should be one of the following '{string.Join(", ", validPackageNames)}', current PackageName is '{BuildConstants.RunnerPackage.PackageName}'");
         }
     }


### PR DESCRIPTION
Update ConstantGenerationL0 test to accept both 40-char (SHA-1) and 64-char (SHA-256) commit hashes. Add hex format validation.

---
*Automated by project-board-agents-plugin via /project-board-agents:lead*
*Board: https://github.com/orgs/github/projects/24272/views/1*
*Item: [P2] Update runner build constant SHA length assertion*