### PR TITLE
feat: propagate actions dependencies

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -179,7 +179,6 @@ namespace GitHub.Runner.Common
                 public static readonly string EmitCompositeMarkers = "actions_runner_emit_composite_markers";
                 public static readonly string BatchActionResolution = "actions_batch_action_resolution";
                 public static readonly string UseBearerTokenForCodeload = "actions_use_bearer_token_for_codeload";
-                public static readonly string PropagateDependencyPins = "actions_lockfile_propagate_dependencies";
             }
 
             // Node version migration related constants

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -179,6 +179,7 @@ namespace GitHub.Runner.Common
                 public static readonly string EmitCompositeMarkers = "actions_runner_emit_composite_markers";
                 public static readonly string BatchActionResolution = "actions_batch_action_resolution";
                 public static readonly string UseBearerTokenForCodeload = "actions_use_bearer_token_for_codeload";
+                public static readonly string PropagateDependencyPins = "actions_lockfile_propagate_dependencies";
             }
 
             // Node version migration related constants

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -880,6 +880,17 @@ namespace GitHub.Runner.Worker
                 return new Dictionary<string, WebApi.ActionDownloadInfo>();
             }
 
+            var propagateDeps = executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.PropagateDependencyPins) ?? false;
+            IList<string> dependencies = null;
+            if (propagateDeps)
+            {
+                var deps = executionContext.Global.ActionsDependencies;
+                if (deps != null && deps.Count > 0)
+                {
+                    dependencies = deps;
+                }
+            }
+
             // Resolve download info
             var launchServer = HostContext.GetService<ILaunchServer>();
             var jobServer = HostContext.GetService<IJobServer>();
@@ -891,7 +902,7 @@ namespace GitHub.Runner.Worker
                     if (MessageUtil.IsRunServiceJob(executionContext.Global.Variables.Get(Constants.Variables.System.JobRequestType)))
                     {
                         var displayHelpfulActionsDownloadErrors = executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DisplayHelpfulActionsDownloadErrors) ?? false;
-                        actionDownloadInfos = await launchServer.ResolveActionsDownloadInfoAsync(executionContext.Global.Plan.PlanId, executionContext.Root.Id, new WebApi.ActionReferenceList { Actions = actionReferences }, executionContext.CancellationToken, displayHelpfulActionsDownloadErrors);
+                        actionDownloadInfos = await launchServer.ResolveActionsDownloadInfoAsync(executionContext.Global.Plan.PlanId, executionContext.Root.Id, new WebApi.ActionReferenceList { Actions = actionReferences, Dependencies = dependencies }, executionContext.CancellationToken, displayHelpfulActionsDownloadErrors);
                     }
                     else
                     {

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -880,16 +880,10 @@ namespace GitHub.Runner.Worker
                 return new Dictionary<string, WebApi.ActionDownloadInfo>();
             }
 
-            var propagateDeps = executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.PropagateDependencyPins) ?? false;
-            IList<string> dependencies = null;
-            if (propagateDeps)
-            {
-                var deps = executionContext.Global.ActionsDependencies;
-                if (deps != null && deps.Count > 0)
-                {
-                    dependencies = deps;
-                }
-            }
+            // Pass lockfile dependencies to Launch when present, so it can
+            // perform ref-scoped policy matching with the original refs.
+            var deps = executionContext.Global.ActionsDependencies;
+            IList<string> dependencies = (deps != null && deps.Count > 0) ? deps : null;
 
             // Resolve download info
             var launchServer = HostContext.GetService<ILaunchServer>();

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -875,6 +875,9 @@ namespace GitHub.Runner.Worker
             // File table
             Global.FileTable = new List<String>(message.FileTable ?? new string[0]);
 
+            // Workflow dependencies (lockfile pins)
+            Global.ActionsDependencies = message.ActionsDependencies;
+
             // What type of job request is running (i.e. Run Service vs. pipelines)
             Global.Variables.Set(Constants.Variables.System.JobRequestType, message.MessageType);
 

--- a/src/Runner.Worker/GlobalContext.cs
+++ b/src/Runner.Worker/GlobalContext.cs
@@ -38,5 +38,6 @@ namespace GitHub.Runner.Worker
         public HashSet<string> DeprecatedNode20Actions { get; set; }
         public HashSet<string> UpgradedToNode24Actions { get; set; }
         public HashSet<string> Arm32Node20Actions { get; set; }
+        public IList<String> ActionsDependencies { get; set; }
     }
 }

--- a/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
+++ b/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
@@ -268,6 +268,21 @@ namespace GitHub.DistributedTask.Pipelines
         }
 
         /// <summary>
+        /// Gets the workflow-level action dependencies (lockfile entries)
+        /// </summary>
+        public IList<String> ActionsDependencies
+        {
+            get
+            {
+                if (m_actionsDependencies == null)
+                {
+                    m_actionsDependencies = new List<String>();
+                }
+                return m_actionsDependencies;
+            }
+        }
+
+        /// <summary>
         /// Gets the collection of variables associated with the current context.
         /// </summary>
         public IDictionary<String, VariableValue> Variables
@@ -441,6 +456,11 @@ namespace GitHub.DistributedTask.Pipelines
                 m_variables = null;
             }
 
+            if (m_actionsDependencies?.Count == 0)
+            {
+                m_actionsDependencies = null;
+            }
+
             // todo: remove after feature-flag DistributedTask.EvaluateContainerOnRunner is enabled everywhere
             if (!string.IsNullOrEmpty(m_jobContainerResourceAlias))
             {
@@ -465,6 +485,9 @@ namespace GitHub.DistributedTask.Pipelines
 
         [DataMember(Name = "Variables", EmitDefaultValue = false)]
         private IDictionary<String, VariableValue> m_variables;
+
+        [DataMember(Name = "dependencies", EmitDefaultValue = false)]
+        private List<String> m_actionsDependencies;
 
         // todo: remove after feature-flag DistributedTask.EvaluateContainerOnRunner is enabled everywhere
         [DataMember(Name = "JobSidecarContainers", EmitDefaultValue = false)]

--- a/src/Sdk/DTWebApi/WebApi/ActionReferenceList.cs
+++ b/src/Sdk/DTWebApi/WebApi/ActionReferenceList.cs
@@ -12,5 +12,12 @@ namespace GitHub.DistributedTask.WebApi
             get;
             set;
         }
+
+        [DataMember(EmitDefaultValue = false)]
+        public IList<string> Dependencies
+        {
+            get;
+            set;
+        }
     }
 }

--- a/src/Sdk/WebApi/WebApi/LaunchContracts.cs
+++ b/src/Sdk/WebApi/WebApi/LaunchContracts.cs
@@ -22,6 +22,9 @@ namespace GitHub.Services.Launch.Contracts
     {
         [DataMember(EmitDefaultValue = false, Name = "actions")]
         public IList<ActionReferenceRequest> Actions { get; set; }
+
+        [DataMember(EmitDefaultValue = false, Name = "actions_dependencies")]
+        public IList<string> ActionsDependencies { get; set; }
     }
 
     [DataContract]

--- a/src/Sdk/WebApi/WebApi/LaunchHttpClient.cs
+++ b/src/Sdk/WebApi/WebApi/LaunchHttpClient.cs
@@ -97,7 +97,8 @@ namespace GitHub.Services.Launch.Client
         {
             return new ActionReferenceRequestList
             {
-                Actions = actionReferenceList.Actions?.Select(ToGitHubData).ToList()
+                Actions = actionReferenceList.Actions?.Select(ToGitHubData).ToList(),
+                ActionsDependencies = actionReferenceList.Dependencies
             };
         }
 

--- a/src/Test/L0/Sdk/RSWebApi/AgentJobRequestMessageL0.cs
+++ b/src/Test/L0/Sdk/RSWebApi/AgentJobRequestMessageL0.cs
@@ -119,6 +119,48 @@ public sealed class AgentJobRequestMessageL0
         Assert.Null(recoveredMessage.DebuggerTunnel);
     }
 
+    [Fact]
+    [Trait("Level", "L0")]
+    [Trait("Category", "Common")]
+    public void VerifyActionsDependenciesDeserialization_WithDependencies()
+    {
+        // Arrange
+        var serializer = new DataContractJsonSerializer(typeof(AgentJobRequestMessage));
+        string json = DoubleQuotify("{'dependencies': ['actions/checkout@v4:sha256-abc123', 'actions/setup-node@v4:sha256-def456']}");
+
+        // Act
+        using var stream = new MemoryStream();
+        stream.Write(Encoding.UTF8.GetBytes(json));
+        stream.Position = 0;
+        var recoveredMessage = serializer.ReadObject(stream) as AgentJobRequestMessage;
+
+        // Assert
+        Assert.NotNull(recoveredMessage);
+        Assert.Equal(2, recoveredMessage.ActionsDependencies.Count);
+        Assert.Equal("actions/checkout@v4:sha256-abc123", recoveredMessage.ActionsDependencies[0]);
+        Assert.Equal("actions/setup-node@v4:sha256-def456", recoveredMessage.ActionsDependencies[1]);
+    }
+
+    [Fact]
+    [Trait("Level", "L0")]
+    [Trait("Category", "Common")]
+    public void VerifyActionsDependenciesDeserialization_DefaultsToEmpty()
+    {
+        // Arrange
+        var serializer = new DataContractJsonSerializer(typeof(AgentJobRequestMessage));
+        string json = DoubleQuotify("{'messageType': 'PipelineAgentJobRequest'}");
+
+        // Act
+        using var stream = new MemoryStream();
+        stream.Write(Encoding.UTF8.GetBytes(json));
+        stream.Position = 0;
+        var recoveredMessage = serializer.ReadObject(stream) as AgentJobRequestMessage;
+
+        // Assert
+        Assert.NotNull(recoveredMessage);
+        Assert.Empty(recoveredMessage.ActionsDependencies);
+    }
+
     private static string DoubleQuotify(string text)
     {
         return text.Replace('\'', '"');

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -3283,5 +3283,141 @@ runs:
                 Directory.Delete(_workFolder, recursive: true);
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task GetDownloadInfoAsync_PropagatesDependencies_WhenPresent()
+        {
+            try
+            {
+                // Arrange
+                Setup();
+
+                // Set RunServiceJob so we hit the Launch path
+                _ec.Object.Global.Variables.Set(Constants.Variables.System.JobRequestType, "RunnerJobRequest");
+
+                // Populate lockfile dependencies
+                _ec.Object.Global.ActionsDependencies = new List<string>
+                {
+                    "github.com/actions/checkout@v4:sha256-abc123",
+                    "github.com/actions/setup-node@v4:sha256-def456"
+                };
+
+                // Capture the ActionReferenceList passed to Launch
+                ActionReferenceList capturedList = null;
+                _launchServer
+                    .Setup(x => x.ResolveActionsDownloadInfoAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ActionReferenceList>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+                    .Callback<Guid, Guid, ActionReferenceList, CancellationToken, bool>((planId, jobId, list, ct, display) => capturedList = list)
+                    .Returns((Guid planId, Guid jobId, ActionReferenceList actions, CancellationToken ct, bool display) =>
+                    {
+                        var result = new ActionDownloadInfoCollection { Actions = new Dictionary<string, ActionDownloadInfo>() };
+                        foreach (var action in actions.Actions)
+                        {
+                            var key = $"{action.NameWithOwner}@{action.Ref}";
+                            result.Actions[key] = new ActionDownloadInfo
+                            {
+                                NameWithOwner = action.NameWithOwner,
+                                Ref = action.Ref,
+                                ResolvedNameWithOwner = action.NameWithOwner,
+                                ResolvedSha = $"{action.Ref}-sha",
+                                TarballUrl = $"https://api.github.com/repos/{action.NameWithOwner}/tarball/{action.Ref}",
+                                ZipballUrl = $"https://api.github.com/repos/{action.NameWithOwner}/zipball/{action.Ref}",
+                            };
+                        }
+                        return Task.FromResult(result);
+                    });
+
+                var actionStep = new Pipelines.ActionStep()
+                {
+                    Name = "action",
+                    Id = Guid.NewGuid(),
+                    Reference = new Pipelines.RepositoryPathReference()
+                    {
+                        Name = "actions/checkout",
+                        Ref = "v4",
+                        RepositoryType = "GitHub"
+                    }
+                };
+
+                // Act
+                var result = await _actionManager.PrepareActionsAsync(_ec.Object, new List<Pipelines.JobStep> { actionStep }, default);
+
+                // Assert
+                Assert.NotNull(capturedList);
+                Assert.NotNull(capturedList.Dependencies);
+                Assert.Equal(2, capturedList.Dependencies.Count);
+                Assert.Equal("github.com/actions/checkout@v4:sha256-abc123", capturedList.Dependencies[0]);
+                Assert.Equal("github.com/actions/setup-node@v4:sha256-def456", capturedList.Dependencies[1]);
+            }
+            finally
+            {
+                Teardown();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task GetDownloadInfoAsync_OmitsDependencies_WhenEmpty()
+        {
+            try
+            {
+                // Arrange
+                Setup();
+
+                // Set RunServiceJob so we hit the Launch path
+                _ec.Object.Global.Variables.Set(Constants.Variables.System.JobRequestType, "RunnerJobRequest");
+
+                // No dependencies set (default empty list from GlobalContext)
+
+                // Capture the ActionReferenceList passed to Launch
+                ActionReferenceList capturedList = null;
+                _launchServer
+                    .Setup(x => x.ResolveActionsDownloadInfoAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ActionReferenceList>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+                    .Callback<Guid, Guid, ActionReferenceList, CancellationToken, bool>((planId, jobId, list, ct, display) => capturedList = list)
+                    .Returns((Guid planId, Guid jobId, ActionReferenceList actions, CancellationToken ct, bool display) =>
+                    {
+                        var result = new ActionDownloadInfoCollection { Actions = new Dictionary<string, ActionDownloadInfo>() };
+                        foreach (var action in actions.Actions)
+                        {
+                            var key = $"{action.NameWithOwner}@{action.Ref}";
+                            result.Actions[key] = new ActionDownloadInfo
+                            {
+                                NameWithOwner = action.NameWithOwner,
+                                Ref = action.Ref,
+                                ResolvedNameWithOwner = action.NameWithOwner,
+                                ResolvedSha = $"{action.Ref}-sha",
+                                TarballUrl = $"https://api.github.com/repos/{action.NameWithOwner}/tarball/{action.Ref}",
+                                ZipballUrl = $"https://api.github.com/repos/{action.NameWithOwner}/zipball/{action.Ref}",
+                            };
+                        }
+                        return Task.FromResult(result);
+                    });
+
+                var actionStep = new Pipelines.ActionStep()
+                {
+                    Name = "action",
+                    Id = Guid.NewGuid(),
+                    Reference = new Pipelines.RepositoryPathReference()
+                    {
+                        Name = "actions/checkout",
+                        Ref = "v4",
+                        RepositoryType = "GitHub"
+                    }
+                };
+
+                // Act
+                var result = await _actionManager.PrepareActionsAsync(_ec.Object, new List<Pipelines.JobStep> { actionStep }, default);
+
+                // Assert
+                Assert.NotNull(capturedList);
+                Assert.Null(capturedList.Dependencies);
+            }
+            finally
+            {
+                Teardown();
+            }
+        }
     }
 }

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -3164,7 +3164,7 @@ runs:
             _ec.Setup(x => x.Global).Returns(new GlobalContext());
             _ec.Setup(x => x.CancellationToken).Returns(_ecTokenSource.Token);
             _ec.Setup(x => x.Root).Returns(new GitHub.Runner.Worker.ExecutionContext());
-            var variables = new Dictionary<string, VariableValue>() {};
+            var variables = new Dictionary<string, VariableValue>();
             _ec.Object.Global.Variables = new Variables(_hc, variables);
             _ec.Setup(x => x.ExpressionValues).Returns(new DictionaryContextData());
             _ec.Setup(x => x.ExpressionFunctions).Returns(new List<IFunctionInfo>());

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -3164,7 +3164,7 @@ runs:
             _ec.Setup(x => x.Global).Returns(new GlobalContext());
             _ec.Setup(x => x.CancellationToken).Returns(_ecTokenSource.Token);
             _ec.Setup(x => x.Root).Returns(new GitHub.Runner.Worker.ExecutionContext());
-            var variables = new Dictionary<string, VariableValue>();
+            var variables = new Dictionary<string, VariableValue>() {};
             _ec.Object.Global.Variables = new Variables(_hc, variables);
             _ec.Setup(x => x.ExpressionValues).Returns(new DictionaryContextData());
             _ec.Setup(x => x.ExpressionFunctions).Returns(new List<IFunctionInfo>());


### PR DESCRIPTION
Propagate the actions dependencies into the actions resolution call.

We technically don't need to recurse in order to resolve all the actions dependencies with a well-formed pinned job and could reduce the round trips for resolution. I will leave this to another PR.

ref https://github.com/github/actions-dispatch/issues/559