### PR TITLE
fix: dispose IProcessInvoker in Docker/Container/UnixUtil call sites

### DIFF
--- a/src/Runner.Common/Util/UnixUtil.cs
+++ b/src/Runner.Common/Util/UnixUtil.cs
@@ -42,21 +42,24 @@ namespace GitHub.Runner.Common.Util
             string toolPath = WhichUtil.Which(toolName, trace: Trace);
             Trace.Info($"Running {toolPath} {argLine}");
 
-            var processInvoker = HostContext.CreateService<IProcessInvoker>();
-            processInvoker.OutputDataReceived += OnOutputDataReceived;
-            processInvoker.ErrorDataReceived += OnErrorDataReceived;
+            // Dispose invoker per call to release process/CTS resources promptly.
+            using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
+            {
+                processInvoker.OutputDataReceived += OnOutputDataReceived;
+                processInvoker.ErrorDataReceived += OnErrorDataReceived;
 
-            try
-            {
-                using (var cs = new CancellationTokenSource(TimeSpan.FromSeconds(45)))
+                try
                 {
-                    await processInvoker.ExecuteAsync(workingDirectory, toolPath, argLine, null, true, cs.Token);
+                    using (var cs = new CancellationTokenSource(TimeSpan.FromSeconds(45)))
+                    {
+                        await processInvoker.ExecuteAsync(workingDirectory, toolPath, argLine, null, true, cs.Token);
+                    }
                 }
-            }
-            finally
-            {
-                processInvoker.OutputDataReceived -= OnOutputDataReceived;
-                processInvoker.ErrorDataReceived -= OnErrorDataReceived;
+                finally
+                {
+                    processInvoker.OutputDataReceived -= OnOutputDataReceived;
+                    processInvoker.ErrorDataReceived -= OnErrorDataReceived;
+                }
             }
         }
 

--- a/src/Runner.Worker/Container/DockerCommandManager.cs
+++ b/src/Runner.Worker/Container/DockerCommandManager.cs
@@ -309,45 +309,48 @@ namespace GitHub.Runner.Worker.Container
         {
             ArgUtil.NotNull(output, nameof(output));
 
-            string arg = $"exec {options} {containerId} {command}".Trim();
-            context.Command($"{DockerPath} {arg}");
-
-            object outputLock = new();
-            var processInvoker = HostContext.CreateService<IProcessInvoker>();
-            processInvoker.OutputDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
-            {
-                if (!string.IsNullOrEmpty(message.Data))
-                {
-                    lock (outputLock)
-                    {
-                        output.Add(message.Data);
-                    }
-                }
-            };
-
-            processInvoker.ErrorDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
-            {
-                if (!string.IsNullOrEmpty(message.Data))
-                {
-                    lock (outputLock)
-                    {
-                        output.Add(message.Data);
-                    }
-                }
-            };
-
             if (!Constants.Runner.Platform.Equals(Constants.OSPlatform.Linux))
             {
                 throw new NotSupportedException("Container operations are only supported on Linux runners");
             }
-            return await processInvoker.ExecuteAsync(
-                            workingDirectory: HostContext.GetDirectory(WellKnownDirectory.Work),
-                            fileName: DockerPath,
-                            arguments: arg,
-                            environment: null,
-                            requireExitCodeZero: false,
-                            outputEncoding: null,
-                            cancellationToken: CancellationToken.None);
+
+            string arg = $"exec {options} {containerId} {command}".Trim();
+            context.Command($"{DockerPath} {arg}");
+
+            object outputLock = new();
+            using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
+            {
+                processInvoker.OutputDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
+                {
+                    if (!string.IsNullOrEmpty(message.Data))
+                    {
+                        lock (outputLock)
+                        {
+                            output.Add(message.Data);
+                        }
+                    }
+                };
+
+                processInvoker.ErrorDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
+                {
+                    if (!string.IsNullOrEmpty(message.Data))
+                    {
+                        lock (outputLock)
+                        {
+                            output.Add(message.Data);
+                        }
+                    }
+                };
+
+                return await processInvoker.ExecuteAsync(
+                                workingDirectory: HostContext.GetDirectory(WellKnownDirectory.Work),
+                                fileName: DockerPath,
+                                arguments: arg,
+                                environment: null,
+                                requireExitCodeZero: false,
+                                outputEncoding: null,
+                                cancellationToken: CancellationToken.None);
+            }
         }
 
         public async Task<List<string>> DockerInspect(IExecutionContext context, string dockerObject, string options)
@@ -361,7 +364,7 @@ namespace GitHub.Runner.Worker.Container
             return DockerUtil.ParseDockerPort(portMappingLines);
         }
 
-        public Task<int> DockerLogin(IExecutionContext context, string configFileDirectory, string registry, string username, string password)
+        public async Task<int> DockerLogin(IExecutionContext context, string configFileDirectory, string registry, string username, string password)
         {
             string args = $"--config {configFileDirectory} login {registry} -u {username} --password-stdin";
             context.Command($"{DockerPath} {args}");
@@ -369,18 +372,19 @@ namespace GitHub.Runner.Worker.Container
             var input = Channel.CreateBounded<string>(new BoundedChannelOptions(1) { SingleReader = true, SingleWriter = true });
             input.Writer.TryWrite(password);
 
-            var processInvoker = HostContext.CreateService<IProcessInvoker>();
-
-            return processInvoker.ExecuteAsync(
-                workingDirectory: context.GetGitHubContext("workspace"),
-                fileName: DockerPath,
-                arguments: args,
-                environment: null,
-                requireExitCodeZero: false,
-                outputEncoding: null,
-                killProcessOnCancel: false,
-                redirectStandardIn: input,
-                cancellationToken: context.CancellationToken);
+            using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
+            {
+                return await processInvoker.ExecuteAsync(
+                    workingDirectory: context.GetGitHubContext("workspace"),
+                    fileName: DockerPath,
+                    arguments: args,
+                    environment: null,
+                    requireExitCodeZero: false,
+                    outputEncoding: null,
+                    killProcessOnCancel: false,
+                    redirectStandardIn: input,
+                    cancellationToken: context.CancellationToken);
+            }
         }
 
         private Task<int> ExecuteDockerCommandAsync(IExecutionContext context, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
@@ -390,59 +394,64 @@ namespace GitHub.Runner.Worker.Container
 
         private async Task<int> ExecuteDockerCommandAsync(IExecutionContext context, string command, string options, IDictionary<string, string> environment, EventHandler<ProcessDataReceivedEventArgs> stdoutDataReceived, EventHandler<ProcessDataReceivedEventArgs> stderrDataReceived, CancellationToken cancellationToken = default(CancellationToken))
         {
-            string arg = $"{command} {options}".Trim();
-            context.Command($"{DockerPath} {arg}");
-
-            var processInvoker = HostContext.CreateService<IProcessInvoker>();
-            processInvoker.OutputDataReceived += stdoutDataReceived;
-            processInvoker.ErrorDataReceived += stderrDataReceived;
-
-
             if (!Constants.Runner.Platform.Equals(Constants.OSPlatform.Linux))
             {
                 throw new NotSupportedException("Container operations are only supported on Linux runners");
             }
-            return await processInvoker.ExecuteAsync(
-                workingDirectory: context.GetGitHubContext("workspace"),
-                fileName: DockerPath,
-                arguments: arg,
-                environment: environment,
-                requireExitCodeZero: false,
-                outputEncoding: null,
-                killProcessOnCancel: false,
-                cancellationToken: cancellationToken);
+
+            string arg = $"{command} {options}".Trim();
+            context.Command($"{DockerPath} {arg}");
+
+            using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
+            {
+                processInvoker.OutputDataReceived += stdoutDataReceived;
+                processInvoker.ErrorDataReceived += stderrDataReceived;
+
+                return await processInvoker.ExecuteAsync(
+                    workingDirectory: context.GetGitHubContext("workspace"),
+                    fileName: DockerPath,
+                    arguments: arg,
+                    environment: environment,
+                    requireExitCodeZero: false,
+                    outputEncoding: null,
+                    killProcessOnCancel: false,
+                    cancellationToken: cancellationToken);
+            }
         }
 
         private async Task<int> ExecuteDockerCommandAsync(IExecutionContext context, string command, string options, string workingDirectory, CancellationToken cancellationToken = default(CancellationToken))
         {
-            string arg = $"{command} {options}".Trim();
-            context.Command($"{DockerPath} {arg}");
-
-            var processInvoker = HostContext.CreateService<IProcessInvoker>();
-            processInvoker.OutputDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
-            {
-                context.Output(message.Data);
-            };
-
-            processInvoker.ErrorDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
-            {
-                context.Output(message.Data);
-            };
-
             if (!Constants.Runner.Platform.Equals(Constants.OSPlatform.Linux))
             {
                 throw new NotSupportedException("Container operations are only supported on Linux runners");
             }
-            return await processInvoker.ExecuteAsync(
-                workingDirectory: workingDirectory ?? context.GetGitHubContext("workspace"),
-                fileName: DockerPath,
-                arguments: arg,
-                environment: null,
-                requireExitCodeZero: false,
-                outputEncoding: null,
-                killProcessOnCancel: false,
-                redirectStandardIn: null,
-                cancellationToken: cancellationToken);
+
+            string arg = $"{command} {options}".Trim();
+            context.Command($"{DockerPath} {arg}");
+
+            using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
+            {
+                processInvoker.OutputDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
+                {
+                    context.Output(message.Data);
+                };
+
+                processInvoker.ErrorDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
+                {
+                    context.Output(message.Data);
+                };
+
+                return await processInvoker.ExecuteAsync(
+                    workingDirectory: workingDirectory ?? context.GetGitHubContext("workspace"),
+                    fileName: DockerPath,
+                    arguments: arg,
+                    environment: null,
+                    requireExitCodeZero: false,
+                    outputEncoding: null,
+                    killProcessOnCancel: false,
+                    redirectStandardIn: null,
+                    cancellationToken: cancellationToken);
+            }
         }
 
         private async Task<List<string>> ExecuteDockerCommandAsync(IExecutionContext context, string command, string options)
@@ -451,32 +460,34 @@ namespace GitHub.Runner.Worker.Container
             context.Command($"{DockerPath} {arg}");
 
             List<string> output = new();
-            var processInvoker = HostContext.CreateService<IProcessInvoker>();
-            processInvoker.OutputDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
+            using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
             {
-                if (!string.IsNullOrEmpty(message.Data))
+                processInvoker.OutputDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
                 {
-                    output.Add(message.Data);
-                    context.Output(message.Data);
-                }
-            };
+                    if (!string.IsNullOrEmpty(message.Data))
+                    {
+                        output.Add(message.Data);
+                        context.Output(message.Data);
+                    }
+                };
 
-            processInvoker.ErrorDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
-            {
-                if (!string.IsNullOrEmpty(message.Data))
+                processInvoker.ErrorDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
                 {
-                    context.Output(message.Data);
-                }
-            };
+                    if (!string.IsNullOrEmpty(message.Data))
+                    {
+                        context.Output(message.Data);
+                    }
+                };
 
-            await processInvoker.ExecuteAsync(
-                            workingDirectory: context.GetGitHubContext("workspace"),
-                            fileName: DockerPath,
-                            arguments: arg,
-                            environment: null,
-                            requireExitCodeZero: true,
-                            outputEncoding: null,
-                            cancellationToken: CancellationToken.None);
+                await processInvoker.ExecuteAsync(
+                                workingDirectory: context.GetGitHubContext("workspace"),
+                                fileName: DockerPath,
+                                arguments: arg,
+                                environment: null,
+                                requireExitCodeZero: true,
+                                outputEncoding: null,
+                                cancellationToken: CancellationToken.None);
+            }
 
             return output;
         }

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -362,37 +362,39 @@ namespace GitHub.Runner.Worker
 
             List<string> outputs = new();
             object outputLock = new();
-            var processInvoker = HostContext.CreateService<IProcessInvoker>();
-            processInvoker.OutputDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
+            using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
             {
-                if (!string.IsNullOrEmpty(message.Data))
+                processInvoker.OutputDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
                 {
-                    lock (outputLock)
+                    if (!string.IsNullOrEmpty(message.Data))
                     {
-                        outputs.Add(message.Data);
+                        lock (outputLock)
+                        {
+                            outputs.Add(message.Data);
+                        }
                     }
-                }
-            };
+                };
 
-            processInvoker.ErrorDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
-            {
-                if (!string.IsNullOrEmpty(message.Data))
+                processInvoker.ErrorDataReceived += delegate (object sender, ProcessDataReceivedEventArgs message)
                 {
-                    lock (outputLock)
+                    if (!string.IsNullOrEmpty(message.Data))
                     {
-                        outputs.Add(message.Data);
+                        lock (outputLock)
+                        {
+                            outputs.Add(message.Data);
+                        }
                     }
-                }
-            };
+                };
 
-            await processInvoker.ExecuteAsync(
-                            workingDirectory: HostContext.GetDirectory(WellKnownDirectory.Work),
-                            fileName: command,
-                            arguments: arg,
-                            environment: null,
-                            requireExitCodeZero: true,
-                            outputEncoding: null,
-                            cancellationToken: CancellationToken.None);
+                await processInvoker.ExecuteAsync(
+                                workingDirectory: HostContext.GetDirectory(WellKnownDirectory.Work),
+                                fileName: command,
+                                arguments: arg,
+                                environment: null,
+                                requireExitCodeZero: true,
+                                outputEncoding: null,
+                                cancellationToken: CancellationToken.None);
+            }
 
             foreach (var outputLine in outputs)
             {

--- a/src/Test/L0/ProcessInvokerDisposalL0.cs
+++ b/src/Test/L0/ProcessInvokerDisposalL0.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using GitHub.Runner.Sdk;
+using Xunit;
+
+namespace GitHub.Runner.Common.Tests
+{
+    // Verifies CreateService<IProcessInvoker>() call sites dispose per invocation.
+    public sealed class ProcessInvokerDisposalL0
+    {
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void Fix_CreateServiceInUsingBlock_CallsDisposeExactlyOnce()
+        {
+            using (TestHostContext hc = new(this))
+            {
+                var tracker = new DisposalTrackingProcessInvoker();
+                hc.EnqueueInstance<IProcessInvoker>(tracker);
+
+                using (var processInvoker = hc.CreateService<IProcessInvoker>())
+                {
+                    _ = processInvoker;
+                }
+
+                Assert.Equal(1, tracker.DisposeCount);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public async Task Fix_DisposeIsCalledEvenIfExecuteThrows()
+        {
+            using (TestHostContext hc = new(this))
+            {
+                var tracker = new DisposalTrackingProcessInvoker { ThrowOnExecute = true };
+                hc.EnqueueInstance<IProcessInvoker>(tracker);
+
+                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                {
+                    using (var processInvoker = hc.CreateService<IProcessInvoker>())
+                    {
+                        await processInvoker.ExecuteAsync("", "tool", "", null, CancellationToken.None);
+                    }
+                });
+
+                Assert.Equal(1, tracker.DisposeCount);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void Fix_ProcessInvokerWrapperDispose_ReleasesInnerProcessInvoker()
+        {
+            using (TestHostContext hc = new(this))
+            {
+                var wrapper = new ProcessInvokerWrapper();
+                wrapper.Initialize(hc);
+
+                wrapper.Dispose();
+                wrapper.Dispose();
+            }
+        }
+    }
+
+    // Minimal invoker that records Dispose() calls.
+    internal sealed class DisposalTrackingProcessInvoker : IProcessInvoker
+    {
+        public int DisposeCount { get; private set; }
+        public bool ThrowOnExecute { get; set; }
+
+        public void Initialize(IHostContext hostContext) { }
+
+        public event EventHandler<ProcessDataReceivedEventArgs> OutputDataReceived;
+        public event EventHandler<ProcessDataReceivedEventArgs> ErrorDataReceived;
+
+        private Task<int> FailOrReturn() =>
+            ThrowOnExecute ? Task.FromException<int>(new InvalidOperationException("simulated failure")) : Task.FromResult(0);
+
+        // Silence CS0067 "event never used" warnings by nominally attaching/removing.
+        private void _touch()
+        {
+            OutputDataReceived?.Invoke(this, null);
+            ErrorDataReceived?.Invoke(this, null);
+        }
+
+        public Task<int> ExecuteAsync(string workingDirectory, string fileName, string arguments, IDictionary<string, string> environment, CancellationToken cancellationToken) => FailOrReturn();
+        public Task<int> ExecuteAsync(string workingDirectory, string fileName, string arguments, IDictionary<string, string> environment, bool requireExitCodeZero, CancellationToken cancellationToken) => FailOrReturn();
+        public Task<int> ExecuteAsync(string workingDirectory, string fileName, string arguments, IDictionary<string, string> environment, bool requireExitCodeZero, Encoding outputEncoding, CancellationToken cancellationToken) => FailOrReturn();
+        public Task<int> ExecuteAsync(string workingDirectory, string fileName, string arguments, IDictionary<string, string> environment, bool requireExitCodeZero, Encoding outputEncoding, bool killProcessOnCancel, CancellationToken cancellationToken) => FailOrReturn();
+        public Task<int> ExecuteAsync(string workingDirectory, string fileName, string arguments, IDictionary<string, string> environment, bool requireExitCodeZero, Encoding outputEncoding, bool killProcessOnCancel, Channel<string> redirectStandardIn, CancellationToken cancellationToken) => FailOrReturn();
+        public Task<int> ExecuteAsync(string workingDirectory, string fileName, string arguments, IDictionary<string, string> environment, bool requireExitCodeZero, Encoding outputEncoding, bool killProcessOnCancel, Channel<string> redirectStandardIn, bool inheritConsoleHandler, CancellationToken cancellationToken) => FailOrReturn();
+        public Task<int> ExecuteAsync(string workingDirectory, string fileName, string arguments, IDictionary<string, string> environment, bool requireExitCodeZero, Encoding outputEncoding, bool killProcessOnCancel, Channel<string> redirectStandardIn, bool inheritConsoleHandler, bool keepStandardInOpen, CancellationToken cancellationToken) => FailOrReturn();
+        public Task<int> ExecuteAsync(string workingDirectory, string fileName, string arguments, IDictionary<string, string> environment, bool requireExitCodeZero, Encoding outputEncoding, bool killProcessOnCancel, Channel<string> redirectStandardIn, bool inheritConsoleHandler, bool keepStandardInOpen, bool highPriorityProcess, CancellationToken cancellationToken) => FailOrReturn();
+
+        public void Dispose() => DisposeCount++;
+    }
+}

--- a/src/Test/L0/Util/UnixUtilL0.cs
+++ b/src/Test/L0/Util/UnixUtilL0.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using GitHub.Runner.Common.Util;
+using GitHub.Runner.Sdk;
+using Xunit;
+
+namespace GitHub.Runner.Common.Tests.Util
+{
+    // Verifies UnixUtil disposes its per-call process invoker.
+    public sealed class UnixUtilL0
+    {
+#if !OS_WINDOWS
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public async Task ExecAsync_DisposesIProcessInvoker_OnSuccess()
+        {
+            using (TestHostContext hc = new(this))
+            {
+                var tracker = new DisposalTrackingProcessInvoker();
+                hc.EnqueueInstance<IProcessInvoker>(tracker);
+
+                var unix = new UnixUtil();
+                unix.Initialize(hc);
+
+                // Use full path to bypass PATH lookup variance.
+                string toolPath = File.Exists("/bin/true") ? "/bin/true" : "/usr/bin/true";
+                Assert.True(File.Exists(toolPath), $"expected a no-op tool at {toolPath}");
+
+                await unix.ExecAsync(workingDirectory: ".", toolName: toolPath, argLine: "");
+
+                Assert.Equal(1, tracker.DisposeCount);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public async Task ExecAsync_DisposesIProcessInvoker_EvenWhenProcessThrows()
+        {
+            using (TestHostContext hc = new(this))
+            {
+                var tracker = new DisposalTrackingProcessInvoker { ThrowOnExecute = true };
+                hc.EnqueueInstance<IProcessInvoker>(tracker);
+
+                var unix = new UnixUtil();
+                unix.Initialize(hc);
+
+                string toolPath = File.Exists("/bin/true") ? "/bin/true" : "/usr/bin/true";
+
+                await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                    unix.ExecAsync(workingDirectory: ".", toolName: toolPath, argLine: ""));
+
+                Assert.Equal(1, tracker.DisposeCount);
+            }
+        }
+#endif
+    }
+}


### PR DESCRIPTION
## Summary

`IProcessInvoker` instances created via `HostContext.CreateService<IProcessInvoker>()` in a few Docker/container/unix paths were not disposed.  
Because `CreateService` returns a new instance per call, those paths could retain process-related resources longer than needed on long-lived runners.

## What Changed

- Wrapped per-call `IProcessInvoker` usage in `using` scopes in:
  - `src/Runner.Worker/Container/DockerCommandManager.cs`
  - `src/Runner.Worker/ContainerOperationProvider.cs`
  - `src/Runner.Common/Util/UnixUtil.cs`
- Kept existing output/error handler behavior and call semantics intact.
- Added focused L0 coverage in:
  - `src/Test/L0/ProcessInvokerDisposalL0.cs`
  - `src/Test/L0/Util/UnixUtilL0.cs`

## Why This Is Safer

- Ensures invoker disposal is deterministic per invocation.
- Reduces risk of resource retention in hot Docker/container code paths.
- Preserves existing runtime behavior (command execution, output capture, cancellation flow).

## Test Plan

- L0 tests validate disposal on success and exception paths.
- `git diff --check` and IDE lints are clean.
