### PR TITLE
fix: make PagingLogger IDisposable to prevent fd leak on step fault

### DIFF
--- a/src/Runner.Common/Logging.cs
+++ b/src/Runner.Common/Logging.cs
@@ -4,7 +4,7 @@ using System.IO;
 namespace GitHub.Runner.Common
 {
     [ServiceLocator(Default = typeof(PagingLogger))]
-    public interface IPagingLogger : IRunnerService
+    public interface IPagingLogger : IRunnerService, IDisposable
     {
         long TotalLines { get; }
         void Setup(Guid timelineId, Guid timelineRecordId);
@@ -44,6 +44,8 @@ namespace GitHub.Runner.Common
         private string _resultsBlockFolder;
         private int _blockByteCount;
         private int _blockCount;
+
+        private bool _disposed;
 
         public long TotalLines => _totalLines;
 
@@ -163,6 +165,56 @@ namespace GitHub.Runner.Common
                 _resultsBlockData = null;
                 _jobServerQueue.QueueResultsUpload(_timelineRecordId, "ResultsLog", _resultsDataFileName, "Results.Core.Log", deleteSource: true, finalize, firstBlock: _resultsDataFileName.EndsWith(".1"), totalLines: _totalLines);
             }
+        }
+
+        // Best-effort cleanup for fault paths where End() was not reached.
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                // Try normal flush+queue paths first.
+                try { EndPage(); } catch { }
+
+                // Safety net for partially initialized page writer/stream.
+                if (_pageWriter != null)
+                {
+                    try { _pageWriter.Dispose(); } catch { }
+                    _pageWriter = null;
+                    _pageData = null;
+                }
+                else if (_pageData != null)
+                {
+                    try { _pageData.Dispose(); } catch { }
+                    _pageData = null;
+                }
+
+                try { EndBlock(finalize: true); } catch { }
+
+                if (_resultsBlockWriter != null)
+                {
+                    try { _resultsBlockWriter.Dispose(); } catch { }
+                    _resultsBlockWriter = null;
+                    _resultsBlockData = null;
+                }
+                else if (_resultsBlockData != null)
+                {
+                    try { _resultsBlockData.Dispose(); } catch { }
+                    _resultsBlockData = null;
+                }
+            }
+
+            _disposed = true;
         }
     }
 }

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -143,6 +143,7 @@ namespace GitHub.Runner.Worker
         private IssueMatcherConfig[] _matchers;
 
         private IPagingLogger _logger;
+        private bool _ownsLogger;
         private IJobServerQueue _jobServerQueue;
 
         private Guid _mainTimelineId;
@@ -411,6 +412,7 @@ namespace GitHub.Runner.Worker
             else
             {
                 child._logger = HostContext.CreateService<IPagingLogger>();
+                child._ownsLogger = true;
                 child._logger.Setup(_mainTimelineId, recordId);
             }
 
@@ -552,7 +554,14 @@ namespace GitHub.Runner.Worker
                 _cancellationTokenSource?.Dispose();
             }
 
-            _logger.End();
+            try
+            {
+                _logger.End();
+            }
+            finally
+            {
+                DisposeOwnedLogger();
+            }
 
             UpdateGlobalStepsContext();
 
@@ -961,6 +970,7 @@ namespace GitHub.Runner.Worker
 
             // Logger (must be initialized before writing warnings).
             _logger = HostContext.CreateService<IPagingLogger>();
+            _ownsLogger = true;
             _logger.Setup(_mainTimelineId, _record.Id);
 
             // Initialize 'echo on action command success' property, default to false, unless Step_Debug is set
@@ -1275,6 +1285,17 @@ namespace GitHub.Runner.Worker
 
             var newGuid = Guid.NewGuid();
             return CreateChild(newGuid, displayName, newGuid.ToString("N"), null, null, ActionRunStage.Post, intraActionState, _childTimelineRecordOrder - Root.PostJobSteps.Count, siblingScopeName: siblingScopeName);
+        }
+
+        private void DisposeOwnedLogger()
+        {
+            if (!_ownsLogger)
+            {
+                return;
+            }
+
+            _logger.Dispose();
+            _ownsLogger = false;
         }
 
         // Sets debug using vars context in case debug variables are not present.

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -411,12 +411,15 @@ namespace GitHub.Runner.Worker
         private async Task<TaskResult> CompleteJobAsync(IJobServer jobServer, IExecutionContext jobContext, Pipelines.AgentJobRequestMessage message, TaskResult? taskResult = null)
         {
             jobContext.Debug($"Finishing: {message.JobDisplayName}");
-            TaskResult result = jobContext.Complete(taskResult);
 
             if (_runnerSettings.DisableUpdate == true)
             {
-                await WarningOutdatedRunnerAsync(jobContext, message, result);
+                // Emit warning before Complete() closes paging logger.
+                TaskResult warningResult = taskResult ?? jobContext.Result ?? TaskResult.Succeeded;
+                await WarningOutdatedRunnerAsync(jobContext, message, warningResult);
             }
+
+            TaskResult result = jobContext.Complete(taskResult);
 
             try
             {

--- a/src/Test/L0/PagingLoggerL0.cs
+++ b/src/Test/L0/PagingLoggerL0.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using System;
 using System.IO;
+using System.Reflection;
 using Xunit;
 
 namespace GitHub.Runner.Common.Tests.Listener
@@ -126,5 +127,215 @@ namespace GitHub.Runner.Common.Tests.Listener
                 CleanLogFolder();
             }
         }
+
+        // Dispose without End() should flush/queue partial content.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void Dispose_AfterPartialWrite_FlushesAndClosesFiles()
+        {
+            CleanLogFolder();
+
+            try
+            {
+                using (var hc = new TestHostContext(this))
+                {
+                    var pagingLogger = new PagingLogger();
+                    hc.SetSingleton<IJobServerQueue>(_jobServerQueue.Object);
+                    pagingLogger.Initialize(hc);
+                    Guid timeLineId = Guid.NewGuid();
+                    Guid timeLineRecordId = Guid.NewGuid();
+
+                    string queuedPagePath = null;
+                    _jobServerQueue
+                        .Setup(x => x.QueueFileUpload(timeLineId, timeLineRecordId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), true))
+                        .Callback((Guid _, Guid _, string _, string _, string path, bool _) => queuedPagePath = path);
+
+                    string queuedBlockPath = null;
+                    _jobServerQueue
+                        .Setup(x => x.QueueResultsUpload(timeLineRecordId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), true, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<long>()))
+                        .Callback((Guid _, string _, string path, string _, bool _, bool _, bool _, long _) => queuedBlockPath = path);
+
+                    // Act: write once, then dispose without End().
+                    pagingLogger.Setup(timeLineId, timeLineRecordId);
+                    pagingLogger.Write(LogData);
+                    pagingLogger.Dispose();
+
+                    Assert.False(string.IsNullOrEmpty(queuedPagePath), "Dispose should have queued the partial page for upload.");
+                    Assert.False(string.IsNullOrEmpty(queuedBlockPath), "Dispose should have queued the partial block for upload with finalize=true.");
+
+                    // Verify flushed content reached queued files.
+                    Assert.Contains(LogData, File.ReadAllText(queuedPagePath));
+                    Assert.Contains(LogData, File.ReadAllText(queuedBlockPath));
+
+                    // Cleanup files created outside the normal callback path.
+                    File.Delete(queuedPagePath);
+                    File.Delete(queuedBlockPath);
+                }
+            }
+            finally
+            {
+                CleanLogFolder();
+            }
+        }
+
+        // Dispose should be idempotent.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void Dispose_IsIdempotent()
+        {
+            CleanLogFolder();
+
+            try
+            {
+                using (var hc = new TestHostContext(this))
+                {
+                    var pagingLogger = new PagingLogger();
+                    hc.SetSingleton<IJobServerQueue>(_jobServerQueue.Object);
+                    pagingLogger.Initialize(hc);
+                    Guid timeLineId = Guid.NewGuid();
+                    Guid timeLineRecordId = Guid.NewGuid();
+
+                    int queueFileUploadCount = 0;
+                    int queueResultsUploadCount = 0;
+                    _jobServerQueue
+                        .Setup(x => x.QueueFileUpload(timeLineId, timeLineRecordId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), true))
+                        .Callback(() => queueFileUploadCount++);
+                    _jobServerQueue
+                        .Setup(x => x.QueueResultsUpload(timeLineRecordId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), true, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<long>()))
+                        .Callback(() => queueResultsUploadCount++);
+
+                    pagingLogger.Setup(timeLineId, timeLineRecordId);
+                    pagingLogger.Write(LogData);
+                    pagingLogger.Dispose();
+                    pagingLogger.Dispose();
+
+                    Assert.Equal(1, queueFileUploadCount);
+                    Assert.Equal(1, queueResultsUploadCount);
+                }
+            }
+            finally
+            {
+                CleanLogFolder();
+            }
+        }
+
+        // Dispose after End() should be a no-op.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void Dispose_AfterEnd_IsNoOp()
+        {
+            CleanLogFolder();
+
+            try
+            {
+                using (var hc = new TestHostContext(this))
+                {
+                    var pagingLogger = new PagingLogger();
+                    hc.SetSingleton<IJobServerQueue>(_jobServerQueue.Object);
+                    pagingLogger.Initialize(hc);
+                    Guid timeLineId = Guid.NewGuid();
+                    Guid timeLineRecordId = Guid.NewGuid();
+
+                    int queueCount = 0;
+                    _jobServerQueue
+                        .Setup(x => x.QueueFileUpload(timeLineId, timeLineRecordId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), true))
+                        .Callback(() => queueCount++);
+
+                    pagingLogger.Setup(timeLineId, timeLineRecordId);
+                    pagingLogger.Write(LogData);
+                    pagingLogger.End();
+                    int afterEnd = queueCount;
+
+                    pagingLogger.Dispose();
+
+                    Assert.Equal(afterEnd, queueCount);
+                }
+            }
+            finally
+            {
+                CleanLogFolder();
+            }
+        }
+
+        // Dispose before Write() should not queue uploads.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void Dispose_BeforeAnyWrite_DoesNotThrow()
+        {
+            CleanLogFolder();
+
+            try
+            {
+                using (var hc = new TestHostContext(this))
+                {
+                    var pagingLogger = new PagingLogger();
+                    hc.SetSingleton<IJobServerQueue>(_jobServerQueue.Object);
+                    pagingLogger.Initialize(hc);
+
+                    int queueCount = 0;
+                    _jobServerQueue
+                        .Setup(x => x.QueueFileUpload(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                        .Callback(() => queueCount++);
+
+                    pagingLogger.Setup(Guid.NewGuid(), Guid.NewGuid());
+                    pagingLogger.Dispose();
+
+                    Assert.Equal(0, queueCount);
+                }
+            }
+            finally
+            {
+                CleanLogFolder();
+            }
+        }
+
+        // Safety net: close orphaned _pageData when _pageWriter was never assigned.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void Dispose_ReleasesOrphanedFileStream_WhenWriterWasNeverAssigned()
+        {
+            CleanLogFolder();
+
+            try
+            {
+                using (var hc = new TestHostContext(this))
+                {
+                    var pagingLogger = new PagingLogger();
+                    hc.SetSingleton<IJobServerQueue>(_jobServerQueue.Object);
+                    pagingLogger.Initialize(hc);
+                    pagingLogger.Setup(Guid.NewGuid(), Guid.NewGuid());
+
+                    // Force partial-init state: _pageData set, _pageWriter null.
+                    var pagesFolder = Path.Combine(hc.GetDirectory(WellKnownDirectory.Diag), PagingLogger.PagingFolder);
+                    Directory.CreateDirectory(pagesFolder);
+                    var orphanPath = Path.Combine(pagesFolder, $"orphan-{Guid.NewGuid():N}.log");
+                    var orphanStream = new FileStream(orphanPath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+                    typeof(PagingLogger)
+                        .GetField("_pageData", BindingFlags.NonPublic | BindingFlags.Instance)
+                        .SetValue(pagingLogger, orphanStream);
+
+                    pagingLogger.Dispose();
+
+                    var closedStream = (FileStream)typeof(PagingLogger)
+                        .GetField("_pageData", BindingFlags.NonPublic | BindingFlags.Instance)
+                        .GetValue(pagingLogger);
+                    Assert.Null(closedStream);
+
+                    Assert.True(orphanStream.SafeFileHandle.IsClosed, "Dispose should have closed the orphaned FileStream's handle.");
+                    File.Delete(orphanPath);
+                }
+            }
+            finally
+            {
+                CleanLogFolder();
+            }
+        }
+
     }
 }

--- a/src/Test/L0/Worker/ExecutionContextL0.cs
+++ b/src/Test/L0/Worker/ExecutionContextL0.cs
@@ -1310,6 +1310,121 @@ namespace GitHub.Runner.Common.Tests.Worker
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Complete_DisposesOwnedJobLogger()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var jobRequest = CreateJobRequestMessage();
+                var pagingLogger = new Mock<IPagingLogger>();
+                var jobServerQueue = new Mock<IJobServerQueue>();
+                jobServerQueue.Setup(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.IsAny<TimelineRecord>()));
+
+                hc.EnqueueInstance(pagingLogger.Object);
+                hc.SetSingleton(jobServerQueue.Object);
+
+                var ec = new Runner.Worker.ExecutionContext();
+                ec.Initialize(hc);
+                ec.InitializeJob(jobRequest, CancellationToken.None);
+
+                ec.Complete();
+
+                pagingLogger.Verify(x => x.End(), Times.Once);
+                pagingLogger.Verify(x => x.Dispose(), Times.Once);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Complete_DisposesOwnedChildLogger()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var jobRequest = CreateJobRequestMessage();
+                var jobLogger = new Mock<IPagingLogger>();
+                var childLogger = new Mock<IPagingLogger>();
+                var jobServerQueue = new Mock<IJobServerQueue>();
+                jobServerQueue.Setup(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.IsAny<TimelineRecord>()));
+
+                hc.EnqueueInstance(jobLogger.Object);
+                hc.EnqueueInstance(childLogger.Object);
+                hc.SetSingleton(jobServerQueue.Object);
+
+                var ec = new Runner.Worker.ExecutionContext();
+                ec.Initialize(hc);
+                ec.InitializeJob(jobRequest, CancellationToken.None);
+
+                var child = ec.CreateChild(Guid.NewGuid(), "step", "step", null, "step", ActionRunStage.Main);
+                child.Complete();
+
+                childLogger.Verify(x => x.End(), Times.Once);
+                childLogger.Verify(x => x.Dispose(), Times.Once);
+                jobLogger.Verify(x => x.Dispose(), Times.Never);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Complete_DoesNotDisposeSharedEmbeddedLogger()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var jobRequest = CreateJobRequestMessage();
+                var pagingLogger = new Mock<IPagingLogger>();
+                var jobServerQueue = new Mock<IJobServerQueue>();
+                jobServerQueue.Setup(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.IsAny<TimelineRecord>()));
+
+                hc.EnqueueInstance(pagingLogger.Object);
+                hc.SetSingleton(jobServerQueue.Object);
+
+                var ec = new Runner.Worker.ExecutionContext();
+                ec.Initialize(hc);
+                ec.InitializeJob(jobRequest, CancellationToken.None);
+
+                var embedded = ec.CreateEmbeddedChild("scope", "__embedded", Guid.NewGuid(), ActionRunStage.Main);
+                embedded.Complete();
+
+                pagingLogger.Verify(x => x.End(), Times.Once);
+                pagingLogger.Verify(x => x.Dispose(), Times.Never);
+            }
+        }
+
+        private Pipelines.AgentJobRequestMessage CreateJobRequestMessage()
+        {
+            var jobRequest = new Pipelines.AgentJobRequestMessage(
+                new TaskOrchestrationPlanReference(),
+                new TimelineReference(),
+                Guid.NewGuid(),
+                "some job name",
+                "some job name",
+                null,
+                null,
+                null,
+                new Dictionary<string, VariableValue>(),
+                new List<MaskHint>(),
+                new Pipelines.JobResources(),
+                new Pipelines.ContextData.DictionaryContextData(),
+                new Pipelines.WorkspaceOptions(),
+                new List<Pipelines.ActionStep>(),
+                null,
+                null,
+                null,
+                null,
+                null);
+            jobRequest.Resources.Repositories.Add(new Pipelines.RepositoryResource()
+            {
+                Alias = Pipelines.PipelineConstants.SelfAlias,
+                Id = "github",
+                Version = "sha1"
+            });
+            jobRequest.ContextData["github"] = new Pipelines.ContextData.DictionaryContextData();
+            return jobRequest;
+        }
+
         private bool ExpressionValuesAssertEqual(DictionaryContextData expect, DictionaryContextData actual)
         {
             foreach (var key in expect.Keys.ToList())


### PR DESCRIPTION
## Summary

`PagingLogger` can lose partial step logs and hold file handles open when a step faults before `ExecutionContext.Complete()` reaches `_logger.End()`.

This PR makes logger lifetime explicit: owned `PagingLogger` instances are disposed when an `ExecutionContext` completes, while shared embedded loggers are not double-disposed.

## What Changed

- Keep `PagingLogger` disposable behavior and focused disposal tests in `src/Test/L0/PagingLoggerL0.cs`.
- Add ownership tracking in `src/Runner.Worker/ExecutionContext.cs`:
  - mark loggers created via `HostContext.CreateService<IPagingLogger>()` as owned
  - dispose owned loggers in `Complete()` via `finally`
  - avoid disposing shared embedded loggers
- Add `ExecutionContext` L0 tests in `src/Test/L0/Worker/ExecutionContextL0.cs` to verify:
  - owned job logger is disposed
  - owned child logger is disposed
  - shared embedded logger is not disposed
- Trim low-signal/diagnostic-only F4 tests to keep the suite focused and maintainable.

## Why This Is Safer

- Prevents leaked file handles from owned loggers on non-happy paths.
- Reduces risk of missing partial logs by ensuring disposal runs deterministically when contexts complete.
- Preserves existing shared-logger behavior for embedded execution contexts.

## Test Plan

- Existing L0 `PagingLogger` disposal behavior tests pass in unit test environment.
- New L0 `ExecutionContext` ownership tests cover the production ownership path.
- `git diff --check` and IDE lints are clean.
