### PR TITLE
Slim runner package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,9 @@ jobs:
     - run: brew install coreutils #needed for shasum util
       if: ${{ matrix.os == 'macOS-latest' }}
       name: Install Dependencies for SHA Calculation (osx)
+
     - run: |
-        file=$(ls)
+        file=$(ls | grep -v slim)
         sha=$(sha256sum $file | awk '{ print $1 }')
         echo "Computed sha256: $sha for $file"
         echo "${{matrix.runtime}}-sha256=$sha" >> $GITHUB_OUTPUT
@@ -281,6 +282,77 @@ jobs:
         upload_url: ${{ steps.createRelease.outputs.upload_url }}
         asset_path: ${{ github.workspace }}/actions-runner-linux-arm64-${{ steps.releaseNote.outputs.version }}.tar.gz
         asset_name: actions-runner-linux-arm64-${{ steps.releaseNote.outputs.version }}.tar.gz
+        asset_content_type: application/octet-stream
+
+    # Upload release assets (slim runner packages)
+    - name: Upload Release Asset (win-x64)
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.createRelease.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/actions-runner-slim-win-x64-${{ steps.releaseNote.outputs.version }}.zip
+        asset_name: actions-runner-slim-win-x64-${{ steps.releaseNote.outputs.version }}.zip
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release Asset (win-arm64)
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.createRelease.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/actions-runner-slim-win-arm64-${{ steps.releaseNote.outputs.version }}.zip
+        asset_name: actions-runner-slim-win-arm64-${{ steps.releaseNote.outputs.version }}.zip
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release Asset (linux-x64)
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.createRelease.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/actions-runner-slim-linux-x64-${{ steps.releaseNote.outputs.version }}.tar.zst
+        asset_name: actions-runner-slim-linux-x64-${{ steps.releaseNote.outputs.version }}.tar.zst
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release Asset (osx-x64)
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.createRelease.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/actions-runner-slim-osx-x64-${{ steps.releaseNote.outputs.version }}.tar.zst
+        asset_name: actions-runner-slim-osx-x64-${{ steps.releaseNote.outputs.version }}.tar.zst
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release Asset (osx-arm64)
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.createRelease.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/actions-runner-slim-osx-arm64-${{ steps.releaseNote.outputs.version }}.tar.zst
+        asset_name: actions-runner-slim-osx-arm64-${{ steps.releaseNote.outputs.version }}.tar.zst
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release Asset (linux-arm)
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.createRelease.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/actions-runner-slim-linux-arm-${{ steps.releaseNote.outputs.version }}.tar.zst
+        asset_name: actions-runner-slim-linux-arm-${{ steps.releaseNote.outputs.version }}.tar.zst
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release Asset (linux-arm64)
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.createRelease.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/actions-runner-slim-linux-arm64-${{ steps.releaseNote.outputs.version }}.tar.zst
+        asset_name: actions-runner-slim-linux-arm64-${{ steps.releaseNote.outputs.version }}.tar.zst
         asset_content_type: application/octet-stream
 
   publish-image:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,8 +291,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.createRelease.outputs.upload_url }}
-        asset_path: ${{ github.workspace }}/actions-runner-slim-win-x64-${{ steps.releaseNote.outputs.version }}.zip
-        asset_name: actions-runner-slim-win-x64-${{ steps.releaseNote.outputs.version }}.zip
+        asset_path: ${{ github.workspace }}/actions-runner-slim-win-x64-${{ steps.releaseNote.outputs.version }}.tar.zst
+        asset_name: actions-runner-slim-win-x64-${{ steps.releaseNote.outputs.version }}.tar.zst
         asset_content_type: application/octet-stream
 
     - name: Upload Release Asset (win-arm64)
@@ -301,8 +301,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.createRelease.outputs.upload_url }}
-        asset_path: ${{ github.workspace }}/actions-runner-slim-win-arm64-${{ steps.releaseNote.outputs.version }}.zip
-        asset_name: actions-runner-slim-win-arm64-${{ steps.releaseNote.outputs.version }}.zip
+        asset_path: ${{ github.workspace }}/actions-runner-slim-win-arm64-${{ steps.releaseNote.outputs.version }}.tar.zst
+        asset_name: actions-runner-slim-win-arm64-${{ steps.releaseNote.outputs.version }}.tar.zst
         asset_content_type: application/octet-stream
 
     - name: Upload Release Asset (linux-x64)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,7 @@ jobs:
         asset_content_type: application/octet-stream
 
     # Upload release assets (slim runner packages)
-    - name: Upload Release Asset (win-x64)
+    - name: Upload Release Asset (slim win-x64)
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -295,7 +295,7 @@ jobs:
         asset_name: actions-runner-slim-win-x64-${{ steps.releaseNote.outputs.version }}.tar.zst
         asset_content_type: application/octet-stream
 
-    - name: Upload Release Asset (win-arm64)
+    - name: Upload Release Asset (slim win-arm64)
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -305,7 +305,7 @@ jobs:
         asset_name: actions-runner-slim-win-arm64-${{ steps.releaseNote.outputs.version }}.tar.zst
         asset_content_type: application/octet-stream
 
-    - name: Upload Release Asset (linux-x64)
+    - name: Upload Release Asset (slim linux-x64)
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -315,7 +315,7 @@ jobs:
         asset_name: actions-runner-slim-linux-x64-${{ steps.releaseNote.outputs.version }}.tar.zst
         asset_content_type: application/octet-stream
 
-    - name: Upload Release Asset (osx-x64)
+    - name: Upload Release Asset (slim osx-x64)
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -325,7 +325,7 @@ jobs:
         asset_name: actions-runner-slim-osx-x64-${{ steps.releaseNote.outputs.version }}.tar.zst
         asset_content_type: application/octet-stream
 
-    - name: Upload Release Asset (osx-arm64)
+    - name: Upload Release Asset (slim osx-arm64)
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -335,7 +335,7 @@ jobs:
         asset_name: actions-runner-slim-osx-arm64-${{ steps.releaseNote.outputs.version }}.tar.zst
         asset_content_type: application/octet-stream
 
-    - name: Upload Release Asset (linux-arm)
+    - name: Upload Release Asset (slim linux-arm)
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -345,7 +345,7 @@ jobs:
         asset_name: actions-runner-slim-linux-arm-${{ steps.releaseNote.outputs.version }}.tar.zst
         asset_content_type: application/octet-stream
 
-    - name: Upload Release Asset (linux-arm64)
+    - name: Upload Release Asset (slim linux-arm64)
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/Runner.Common/HostContext.cs
+++ b/src/Runner.Common/HostContext.cs
@@ -385,9 +385,14 @@ namespace GitHub.Runner.Common
                     break;
 
                 case WellKnownDirectory.Externals:
-                    path = Path.Combine(
-                        GetDirectory(WellKnownDirectory.Root),
-                        Constants.Path.ExternalsDirectory);
+                    path = Environment.GetEnvironmentVariable("RUNNER_EXTERNALSDIRECTORY");
+                    
+                    if (string.IsNullOrEmpty(path))
+                    {
+                        path = Path.Combine(
+                            GetDirectory(WellKnownDirectory.Root),
+                            Constants.Path.ExternalsDirectory);
+                    }
                     break;
 
                 case WellKnownDirectory.Root:

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -200,7 +200,7 @@ function package ()
         $POWERSHELL -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "Add-Type -Assembly \"System.IO.Compression.FileSystem\"; [System.IO.Compression.ZipFile]::CreateFromDirectory(\"${window_path}\", \"${zip_name}\")"
         slim_zip_name="${runner_slim_pkg_name}.zip"
         echo "Creating $slim_zip_name in ${window_path}"
-        Get-ChildItem -Path "${window_path}" -Exclude "externals" | Compress-Archive -DestinationPath "${slim_zip_name}"
+        $POWERSHELL -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "Get-ChildItem -Path \"${window_path}\" -Exclude \"externals\" | Compress-Archive -DestinationPath \"${slim_zip_name}\""
     fi
 
     popd > /dev/null

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -190,7 +190,7 @@ function package ()
         tar -czf "${tar_name}" -C "${LAYOUT_DIR}" .
         slim_tar_name="${runner_slim_pkg_name}.tar.zst"
         echo "Creating $slim_tar_name in ${LAYOUT_DIR}"
-        tar -cf - -C "${LAYOUT_DIR}" --exclude="externals" . | zstd -19 > "${slim_tar_name}"
+        tar -cf "${slim_tar_name}" -C "${LAYOUT_DIR}" --zstd --options zstd:compression-level=19 --exclude="externals" .
     elif [[ ("$CURRENT_PLATFORM" == "windows") ]]; then
         zip_name="${runner_pkg_name}.zip"
         echo "Convert ${LAYOUT_DIR} to Windows style path"
@@ -198,9 +198,9 @@ function package ()
         window_path=${window_path:0:1}:${window_path:1}
         echo "Creating $zip_name in ${window_path}"
         $POWERSHELL -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "Add-Type -Assembly \"System.IO.Compression.FileSystem\"; [System.IO.Compression.ZipFile]::CreateFromDirectory(\"${window_path}\", \"${zip_name}\")"
-        slim_zip_name="${runner_slim_pkg_name}.zip"
-        echo "Creating $slim_zip_name in ${window_path}"
-        $POWERSHELL -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "Get-ChildItem -Path \"${window_path}\" -Exclude \"externals\" | Compress-Archive -DestinationPath \"${slim_zip_name}\""
+        slim_tar_name="${runner_slim_pkg_name}.tar.zst"
+        echo "Creating $slim_tar_name in ${window_path}"
+        $POWERSHELL -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "tar -cf \"${slim_tar_name}\" -C \"${window_path}\" --zstd --options zstd:compression-level=19 --exclude=\"externals\" ."
     fi
 
     popd > /dev/null

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -172,6 +172,7 @@ function package ()
     # TODO: We are cross-compiling arm on x64 so we cant exec Runner.Listener. Remove after building on native arm host
     runner_ver=$("${LAYOUT_DIR}/bin/Runner.Listener" --version) || runner_ver=$(cat runnerversion) || failed "version"
     runner_pkg_name="actions-runner-${RUNTIME_ID}-${runner_ver}"
+    runner_slim_pkg_name="actions-runner-slim-${RUNTIME_ID}-${runner_ver}"
 
     heading "Packaging ${runner_pkg_name}"
 
@@ -187,6 +188,9 @@ function package ()
         tar_name="${runner_pkg_name}.tar.gz"
         echo "Creating $tar_name in ${LAYOUT_DIR}"
         tar -czf "${tar_name}" -C "${LAYOUT_DIR}" .
+        slim_tar_name="${runner_slim_pkg_name}.tar.zst"
+        echo "Creating $slim_tar_name in ${LAYOUT_DIR}"
+        tar -cf - -C "${LAYOUT_DIR}" --exclude="externals" . | zstd -19 > "${slim_tar_name}"
     elif [[ ("$CURRENT_PLATFORM" == "windows") ]]; then
         zip_name="${runner_pkg_name}.zip"
         echo "Convert ${LAYOUT_DIR} to Windows style path"
@@ -194,6 +198,9 @@ function package ()
         window_path=${window_path:0:1}:${window_path:1}
         echo "Creating $zip_name in ${window_path}"
         $POWERSHELL -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "Add-Type -Assembly \"System.IO.Compression.FileSystem\"; [System.IO.Compression.ZipFile]::CreateFromDirectory(\"${window_path}\", \"${zip_name}\")"
+        slim_zip_name="${runner_slim_pkg_name}.zip"
+        echo "Creating $slim_zip_name in ${window_path}"
+        Get-ChildItem -Path "${window_path}" -Exclude "externals" | Compress-Archive -DestinationPath "${slim_zip_name}"
     fi
 
     popd > /dev/null

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -184,7 +184,14 @@ function package ()
 
     pushd "$PACKAGE_DIR" > /dev/null
 
-    if [[ ("$CURRENT_PLATFORM" == "linux") || ("$CURRENT_PLATFORM" == "darwin") ]]; then
+    if [[ ("$CURRENT_PLATFORM" == "linux") ]]; then
+        tar_name="${runner_pkg_name}.tar.gz"
+        echo "Creating $tar_name in ${LAYOUT_DIR}"
+        tar -czf "${tar_name}" -C "${LAYOUT_DIR}" .
+        slim_tar_name="${runner_slim_pkg_name}.tar.zst"
+        echo "Creating $slim_tar_name in ${LAYOUT_DIR}"
+        tar -cf "${slim_tar_name}" -C "${LAYOUT_DIR}" --use-compress-program="zstd -19" --exclude="externals" .
+    elif [[ ("$CURRENT_PLATFORM" == "darwin") ]]; then
         tar_name="${runner_pkg_name}.tar.gz"
         echo "Creating $tar_name in ${LAYOUT_DIR}"
         tar -czf "${tar_name}" -C "${LAYOUT_DIR}" .
@@ -200,7 +207,7 @@ function package ()
         $POWERSHELL -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "Add-Type -Assembly \"System.IO.Compression.FileSystem\"; [System.IO.Compression.ZipFile]::CreateFromDirectory(\"${window_path}\", \"${zip_name}\")"
         slim_tar_name="${runner_slim_pkg_name}.tar.zst"
         echo "Creating $slim_tar_name in ${window_path}"
-        $POWERSHELL -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "tar -cf \"${slim_tar_name}\" -C \"${window_path}\" --zstd --options zstd:compression-level=19 --exclude=\"externals\" ."
+        $POWERSHELL -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "\$env:ZSTD_CLEVEL=\"19\"; tar -cf \"${slim_tar_name}\" -C \"${window_path}\" --zstd --exclude=\"externals\" ."
     fi
 
     popd > /dev/null


### PR DESCRIPTION
This PR adds new "slim" flavor of Runner package. It differs from the existing runner package in two ways:
1) `externals` folder containing Node distribution is removed
2) Runner is archived with `zstd` using compression level `19`

When invoking runner `RUNNER_EXTERNALSDIRECTORY` environment variable is expected to point to the directory whose structure matches the `externals` directory of the "full" runner package