### PR TITLE
Not retry and report action download 403.

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1446,6 +1446,11 @@ namespace GitHub.Runner.Worker
                                         // It doesn't make sense to retry in this case, so just stop
                                         throw new ActionNotFoundException(new Uri(downloadUrl), requestId);
                                     }
+                                    else if (response.StatusCode == HttpStatusCode.Forbidden)
+                                    {
+                                        // It doesn't make sense to retry in this case, so just stop
+                                        throw new AccessDeniedException($"Access denied to '{downloadUrl}' ({requestId})");
+                                    }
                                     else
                                     {
                                         // Something else bad happened, let's go to our retry logic
@@ -1467,6 +1472,11 @@ namespace GitHub.Runner.Worker
                         catch (ActionNotFoundException)
                         {
                             Trace.Info($"The action at '{downloadUrl}' does not exist");
+                            throw;
+                        }
+                        catch (AccessDeniedException)
+                        {
+                            Trace.Info($"Access denied to '{downloadUrl}'");
                             throw;
                         }
                         catch (Exception ex) when (retryCount < 2)
@@ -1494,7 +1504,7 @@ namespace GitHub.Runner.Worker
                     }
                 }
             }
-            catch (Exception ex) when (!(ex is OperationCanceledException) && !executionContext.CancellationToken.IsCancellationRequested)
+            catch (Exception ex) when (!(ex is AccessDeniedException) && !(ex is OperationCanceledException) && !executionContext.CancellationToken.IsCancellationRequested)
             {
                 Trace.Error($"Failed to download archive '{downloadUrl}' after {retryCount + 1} attempts.");
                 Trace.Error(ex);


### PR DESCRIPTION
403 most likely client side error with auth or security setting, so retry won't help bypass them.

<img width="2085" height="315" alt="image" src="https://github.com/user-attachments/assets/7d52983d-4865-4ea0-bb9c-19e6412d2895" />
