### PR TITLE
Add support for Ubuntu 26.04 (liblttng-ust1t64, libicu77-80)

### DIFF
--- a/docs/start/envlinux.md
+++ b/docs/start/envlinux.md
@@ -25,11 +25,11 @@ The `installdependencies.sh` script should install all required dependencies on 
 
 Debian based OS (Debian, Ubuntu, Linux Mint)
 
-- liblttng-ust1 or liblttng-ust0
+- liblttng-ust1t64, liblttng-ust1 or liblttng-ust0
 - libkrb5-3
 - zlib1g
 - libssl3t64, libssl3, libssl1.1, libssl1.0.2 or libssl1.0.0
-- libicu76, libicu75, ..., libicu66, libicu65, libicu63, libicu60, libicu57, libicu55, or libicu52
+- libicu80, libicu79, ..., libicu66, libicu65, libicu63, libicu60, libicu57, libicu55, or libicu52
 
 Fedora based OS (Fedora, Red Hat Enterprise Linux, CentOS, Oracle Linux 7)
 

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -94,7 +94,7 @@ then
             fi
         }
 
-        apt_get_with_fallbacks liblttng-ust1 liblttng-ust0
+        apt_get_with_fallbacks liblttng-ust1t64 liblttng-ust1 liblttng-ust0
         if [ $? -ne 0 ]
         then
             echo "'$apt_get' failed with exit code '$?'"
@@ -110,7 +110,7 @@ then
             exit 1
         fi
 
-        apt_get_with_fallbacks libicu76 libicu75 libicu74 libicu73 libicu72 libicu71 libicu70 libicu69 libicu68 libicu67 libicu66 libicu65 libicu63 libicu60 libicu57 libicu55 libicu52
+        apt_get_with_fallbacks libicu80 libicu79 libicu78 libicu77 libicu76 libicu75 libicu74 libicu73 libicu72 libicu71 libicu70 libicu69 libicu68 libicu67 libicu66 libicu65 libicu63 libicu60 libicu57 libicu55 libicu52
         if [ $? -ne 0 ]
         then
             echo "'$apt_get' failed with exit code '$?'"


### PR DESCRIPTION
## Summary

Ubuntu 26.04 LTS (`VERSION_CODENAME=resolute`, "Resolute Raccoon") completes the time_t 64-bit transition for `liblttng-ust` and ships a newer `libicu`. On a fresh 26.04 install the existing `apt_get_with_fallbacks` chains cannot resolve either dependency, so `./bin/installdependencies.sh` aborts with `Can't install dotnet core dependencies.` before the runner can configure.

This PR extends both fallback chains so the script keeps working on 26.04 while remaining a no-op on older releases (the helper silently skips packages that aren't in the apt index).

## What changed

`src/Misc/layoutbin/installdependencies.sh`

| Chain | Before | After |
|---|---|---|
| LTTng | `liblttng-ust1 liblttng-ust0` | `liblttng-ust1t64 liblttng-ust1 liblttng-ust0` |
| ICU | `libicu76 ... libicu52` | `libicu80 libicu79 libicu78 libicu77 libicu76 ... libicu52` |

`docs/start/envlinux.md` — matching dependency list.

## Why these specific names

Verified directly inside `ubuntu:26.04`:

```
$ apt-cache search '^liblttng-ust' | grep -E 'liblttng-ust[0-9]'
liblttng-ust1t64 - LTTng 2.0 Userspace Tracer (tracing libraries)

$ apt-cache search '^libicu[0-9]+$'
libicu78 - International Components for Unicode
```

Adding `libicu77`/`79`/`80` gives runway in case 26.04's archive ICU version changes before GA, and matches the existing pattern of listing several adjacent versions.

## Test plan

- [x] Ran the patched script inside `ubuntu:26.04` on `linux/arm64` — exits with `Finish Install Dependencies`, installs `liblttng-ust1t64 2.14.0-1.1` and `libicu78 78.2-2ubuntu1`
- [x] Same run on `linux/amd64` (via buildx + QEMU) — same result, installs `liblttng-ust1t64:amd64` and `libicu78:amd64`
- [x] Verified the additions are no-ops on older Ubuntu releases — fallbacks fall through harmlessly to the existing `liblttng-ust1` / `libicu74` etc.

## Notes

The `libssl3t64` chain already covers 26.04 (also ships `libssl3t64`). `libkrb5-3` and `zlib1g` package names are unchanged on 26.04. No other changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)