### PR TITLE
feat: Add neutral job conclusion via allow-failure property

### DIFF
--- a/src/Runner.Common/ActionResult.cs
+++ b/src/Runner.Common/ActionResult.cs
@@ -8,6 +8,8 @@
 
         Cancelled = 2,
 
-        Skipped = 3
+        Skipped = 3,
+
+        Neutral = 4
     }
 }

--- a/src/Runner.Common/Util/TaskResultUtil.cs
+++ b/src/Runner.Common/Util/TaskResultUtil.cs
@@ -71,6 +71,8 @@ namespace GitHub.Runner.Common.Util
                     return ActionResult.Cancelled;
                 case TaskResult.Skipped:
                     return ActionResult.Skipped;
+                case TaskResult.Neutral:
+                    return ActionResult.Neutral;
                 default:
                     throw new NotSupportedException(result.ToString());
             }

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -285,6 +285,13 @@ namespace GitHub.Runner.Worker
             jobContext.Debug($"Finishing: {message.JobDisplayName}");
             TaskResult result = jobContext.Complete(taskResult);
 
+            if (result == TaskResult.Failed && ShouldApplyAllowFailure(jobContext, message))
+            {
+                jobContext.Debug("Job failed but allow-failure is set. Reporting as Neutral.");
+                result = TaskResult.Neutral;
+                jobContext.Result = result;
+            }
+
             var jobQueueTelemetry = await ShutdownQueue(throwOnFailure: false);
             // include any job telemetry from the background upload process.
             if (jobQueueTelemetry?.Count > 0)
@@ -358,6 +365,13 @@ namespace GitHub.Runner.Worker
         {
             jobContext.Debug($"Finishing: {message.JobDisplayName}");
             TaskResult result = jobContext.Complete(taskResult);
+
+            if (result == TaskResult.Failed && ShouldApplyAllowFailure(jobContext, message))
+            {
+                jobContext.Debug("Job failed but allow-failure is set. Reporting as Neutral.");
+                result = TaskResult.Neutral;
+                jobContext.Result = result;
+            }
 
             if (_runnerSettings.DisableUpdate == true)
             {
@@ -439,6 +453,23 @@ namespace GitHub.Runner.Worker
 
             // rethrow exceptions from all attempts.
             throw new AggregateException(exceptions);
+        }
+
+        private bool ShouldApplyAllowFailure(IExecutionContext jobContext, Pipelines.AgentJobRequestMessage message)
+        {
+            if (message.AllowFailure)
+            {
+                return true;
+            }
+
+            var allowFailureEnv = Environment.GetEnvironmentVariable("ACTIONS_ALLOW_FAILURE");
+            if (string.Equals(allowFailureEnv, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                jobContext.Debug("allow-failure detected via ACTIONS_ALLOW_FAILURE environment variable.");
+                return true;
+            }
+
+            return false;
         }
 
         private void MaskTelemetrySecrets(List<JobTelemetry> jobTelemetry)

--- a/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
+++ b/src/Sdk/DTPipelines/Pipelines/AgentJobRequestMessage.cs
@@ -261,6 +261,13 @@ namespace GitHub.DistributedTask.Pipelines
         }
 
         [DataMember(EmitDefaultValue = false)]
+        public bool AllowFailure
+        {
+            get;
+            set;
+        }
+
+        [DataMember(EmitDefaultValue = false)]
         public DebuggerTunnelInfo DebuggerTunnel
         {
             get;

--- a/src/Sdk/DTWebApi/WebApi/TaskResult.cs
+++ b/src/Sdk/DTWebApi/WebApi/TaskResult.cs
@@ -22,5 +22,8 @@ namespace GitHub.DistributedTask.WebApi
 
         [EnumMember]
         Abandoned = 5,
+
+        [EnumMember]
+        Neutral = 6,
     }
 }

--- a/src/Test/L0/Util/TaskResultUtilL0.cs
+++ b/src/Test/L0/Util/TaskResultUtilL0.cs
@@ -1,4 +1,5 @@
 ﻿using GitHub.DistributedTask.WebApi;
+using GitHub.Runner.Common;
 using GitHub.Runner.Common.Util;
 using Xunit;
 
@@ -200,6 +201,50 @@ namespace GitHub.Runner.Common.Tests.Util
                 merged = TaskResultUtil.MergeTaskResults(TaskResult.Skipped, TaskResult.Failed);
                 // Actual
                 Assert.Equal(TaskResult.Skipped, merged);
+
+                //
+                // Neutral is terminal (not overwritten by subsequent results)
+                //
+                // Act.
+                merged = TaskResultUtil.MergeTaskResults(TaskResult.Neutral, TaskResult.Succeeded);
+                // Actual
+                Assert.Equal(TaskResult.Neutral, merged);
+                // Act.
+                merged = TaskResultUtil.MergeTaskResults(TaskResult.Neutral, TaskResult.Failed);
+                // Actual
+                Assert.Equal(TaskResult.Neutral, merged);
+                // Act.
+                merged = TaskResultUtil.MergeTaskResults(null, TaskResult.Neutral);
+                // Actual
+                Assert.Equal(TaskResult.Neutral, merged);
+                // Act.
+                merged = TaskResultUtil.MergeTaskResults(TaskResult.Succeeded, TaskResult.Neutral);
+                // Actual
+                Assert.Equal(TaskResult.Neutral, merged);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void TaskResultNeutralReturnCodeTranslate()
+        {
+            using (TestHostContext hc = new(this))
+            {
+                TaskResult neutral = TaskResultUtil.TranslateFromReturnCode(TaskResultUtil.TranslateToReturnCode(TaskResult.Neutral));
+                Assert.Equal(TaskResult.Neutral, neutral);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void TaskResultNeutralToActionResult()
+        {
+            using (TestHostContext hc = new(this))
+            {
+                ActionResult actionResult = TaskResult.Neutral.ToActionResult();
+                Assert.Equal(ActionResult.Neutral, actionResult);
             }
         }
     }

--- a/src/Test/L0/Worker/JobRunnerL0.cs
+++ b/src/Test/L0/Worker/JobRunnerL0.cs
@@ -175,5 +175,84 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal(TaskResult.Succeeded, _jobEc.Result);
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task AllowFailureConvertsFailedToNeutral()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                _jobExtension.Setup(x => x.InitializeJob(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.AgentJobRequestMessage>()))
+                    .Throws(new Exception());
+
+                var message = GetMessage(JobRequestMessageTypes.RunnerJobRequest);
+                message.AllowFailure = true;
+
+                await _jobRunner.RunAsync(message, _tokenSource.Token);
+
+                Assert.Equal(TaskResult.Neutral, _jobEc.Result);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task AllowFailureDoesNotAffectSucceeded()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var message = GetMessage(JobRequestMessageTypes.RunnerJobRequest);
+                message.AllowFailure = true;
+
+                await _jobRunner.RunAsync(message, _tokenSource.Token);
+
+                Assert.Equal(TaskResult.Succeeded, _jobEc.Result);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task AllowFailureEnvVarConvertsFailedToNeutral()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                _jobExtension.Setup(x => x.InitializeJob(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.AgentJobRequestMessage>()))
+                    .Throws(new Exception());
+
+                var message = GetMessage(JobRequestMessageTypes.RunnerJobRequest);
+
+                Environment.SetEnvironmentVariable("ACTIONS_ALLOW_FAILURE", "true");
+                try
+                {
+                    await _jobRunner.RunAsync(message, _tokenSource.Token);
+                    Assert.Equal(TaskResult.Neutral, _jobEc.Result);
+                }
+                finally
+                {
+                    Environment.SetEnvironmentVariable("ACTIONS_ALLOW_FAILURE", null);
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task AllowFailureWithPipelineAgentJobRequest()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                _jobExtension.Setup(x => x.InitializeJob(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.AgentJobRequestMessage>()))
+                    .Throws(new Exception());
+
+                var message = GetMessage(JobRequestMessageTypes.PipelineAgentJobRequest);
+                message.AllowFailure = true;
+
+                await _jobRunner.RunAsync(message, _tokenSource.Token);
+
+                Assert.Equal(TaskResult.Neutral, _jobEc.Result);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `TaskResult.Neutral` (value 6) and `ActionResult.Neutral` (value 4) enum values
- Adds `AllowFailure` boolean property to `AgentJobRequestMessage`
- When a job fails and `allow-failure` is set, the runner reports `Neutral` instead of `Failed`
- Includes `ACTIONS_ALLOW_FAILURE` env var fallback for testing without server changes
- Adds unit tests covering merge behavior, return code translation, and the override logic

## Why

The Checks API supports a `neutral` conclusion (renders as a grey dash icon), but GitHub Actions provides no way for a job to report it. This means non-critical checks (linting, spell-checking, advisory security scans) must either pass or fail — there's no "warning" state.

This PR implements the runner-side support for a `neutral` conclusion via a job-level `allow-failure` property, similar in spirit to Travis CI's `allow_failures` matrix config. When the server populates `AllowFailure = true` on the job message, the runner converts `Failed` → `Neutral` at job completion time.

Related: #2347

## Server-side requirements (out of scope for this PR)

For end-to-end functionality, the server needs to:
1. Parse `allow-failure: true` from workflow YAML
2. Set `AllowFailure = true` on `AgentJobRequestMessage`
3. Accept `TaskResult.Neutral` (value 6) and map it to Checks API `conclusion: neutral`
4. Treat neutral as non-blocking for downstream `needs:` dependencies

## Design decisions

- **Override location**: `CompleteJobAsync()` after `jobContext.Complete()` — same pattern as other post-completion transforms
- **Neutral is terminal**: `MergeTaskResults()` already handles this correctly since `Neutral = 6 > Failed = 2`, so the existing `if (currentResult > TaskResult.Failed)` guard treats it as terminal
- **Env var fallback**: `ACTIONS_ALLOW_FAILURE=true` allows testing the runner behavior in isolation without server changes

## Test plan

- Unit tests added for:
  - `AllowFailure` message property converts Failed → Neutral
  - `AllowFailure` does not affect Succeeded jobs
  - `ACTIONS_ALLOW_FAILURE` env var fallback works
  - Both `CompleteJobAsync` overloads (IRunServer + IJobServer) are covered
  - `TaskResult.Neutral` round-trips through return code translation
  - `TaskResult.Neutral` maps to `ActionResult.Neutral`
  - Neutral is terminal in merge logic (not overwritten by subsequent results)
- End-to-end testing requires server-side changes (env var fallback demonstrates runner behavior in isolation)

🤖 Generated with [Claude Code](https://claude.ai/code)