### PR TITLE
DAP: add JobExecutionView model + renderer

### DIFF
--- a/src/Runner.Worker/Dap/JobExecutionView.cs
+++ b/src/Runner.Worker/Dap/JobExecutionView.cs
@@ -125,20 +125,25 @@ namespace GitHub.Runner.Worker.Dap
         }
 
         /// <summary>
-        /// Append a new entry. If <paramref name="stepIdentity"/> is non-null,
-        /// registers the IStep -> line mapping for later lookup. If
-        /// <paramref name="matchKey"/> is non-null, the entry is registered
-        /// as an unclaimed placeholder that a future
-        /// <see cref="TryClaim(string, IStep)"/> call can bind to a real
-        /// IStep (used by the predictive Post-step path). Re-renders the
-        /// YAML and updates the start-line table.
+        /// Append a new entry. Exactly one of <paramref name="stepIdentity"/>
+        /// or <paramref name="matchKey"/> may be non-null (or both may be
+        /// null for a static entry that needs no line lookup):
+        ///   - <paramref name="stepIdentity"/> non-null: registers the
+        ///     IStep→line mapping immediately. Use when the real
+        ///     <see cref="IStep"/> is known at append time.
+        ///   - <paramref name="matchKey"/> non-null: registers an unclaimed
+        ///     placeholder that a later <see cref="TryClaim"/> binds to a
+        ///     real <see cref="IStep"/>.
+        /// Re-renders the YAML and updates the start-line table.
         /// </summary>
         /// <returns>1-based line number of the newly-appended entry's <c>- step:</c> key.</returns>
         public int Append(JobExecutionViewEntry entry, IStep stepIdentity = null, string matchKey = null)
         {
-            if (entry == null)
+            ArgUtil.NotNull(entry, nameof(entry));
+            if (stepIdentity != null && matchKey != null)
             {
-                throw new ArgumentNullException(nameof(entry));
+                throw new ArgumentException(
+                    "Append cannot register both a step identity and a placeholder match key on the same entry; pass at most one.");
             }
 
             lock (_lock)

--- a/src/Runner.Worker/Dap/JobExecutionView.cs
+++ b/src/Runner.Worker/Dap/JobExecutionView.cs
@@ -10,9 +10,21 @@ namespace GitHub.Runner.Worker.Dap
     /// and provides O(1) lookup from <see cref="IStep"/> identity to the current line
     /// in the rendered YAML where that step's <c>- step:</c> key appears.
     ///
-    /// Append-only growth model: post-steps are discovered lazily during execution
-    /// and appended. Setup/pre/main entry line numbers are stable across appends —
-    /// only the synthetic Cleanup boundary (which is not tracked here) shifts.
+    /// Each <see cref="Append"/> can register the entry in one of three modes:
+    ///   - With a non-null <c>stepIdentity</c>: registers the IStep→line mapping
+    ///     immediately. Used for entries whose real <see cref="IStep"/> is already
+    ///     known at append time.
+    ///   - With a non-null <c>matchKey</c>: registers an unclaimed placeholder
+    ///     that a later <see cref="TryClaim"/> binds to a real <see cref="IStep"/>.
+    ///     Used for entries whose <see cref="IStep"/> is materialized later. A
+    ///     placeholder that is never claimed simply stays in the view and is never
+    ///     paused on — the IStep→line mapping is only populated on claim.
+    ///   - With neither: a static entry that needs no line lookup.
+    ///
+    /// <see cref="Append"/> and <see cref="AppendRange"/> never remove or reorder
+    /// existing entries. <see cref="TryClaim"/> does not re-render. The IStep→line
+    /// mapping is rebuilt on every render, so lookups stay accurate even if a later
+    /// Append happens to shift previously-emitted entries.
     /// </summary>
     internal sealed class JobExecutionView
     {
@@ -190,46 +202,6 @@ namespace GitHub.Runner.Worker.Dap
                 _stepIdentities[index] = stepIdentity;
                 _lineByStep[stepIdentity] = _entryStartLines[index];
                 return _entryStartLines[index];
-            }
-        }
-
-        /// <summary>
-        /// Mark a previously-appended unclaimed placeholder as skipped. Used
-        /// when the predicting Main step never runs (skipped by <c>if:</c>),
-        /// so its predicted Post-step placeholder should not appear as a
-        /// step that will execute. Re-renders the view (inline comment only
-        /// — subsequent entry line numbers stay stable).
-        /// </summary>
-        /// <returns>
-        /// true if a matching unclaimed placeholder was marked; false when
-        /// no placeholder exists for <paramref name="matchKey"/>, or the
-        /// placeholder has already been claimed (claim wins).
-        /// </returns>
-        public bool TryMarkSkipped(string matchKey)
-        {
-            ArgUtil.NotNull(matchKey, nameof(matchKey));
-
-            lock (_lock)
-            {
-                if (!_unclaimedByKey.TryGetValue(matchKey, out int index))
-                {
-                    return false;
-                }
-                // Defensive: only mark if it's still an unclaimed placeholder.
-                if (_stepIdentities[index] != null)
-                {
-                    return false;
-                }
-
-                if (_entries[index].IsSkipped)
-                {
-                    // Idempotent — already marked.
-                    return true;
-                }
-                _entries[index].IsSkipped = true;
-                _unclaimedByKey.Remove(matchKey);
-                Render();
-                return true;
             }
         }
 

--- a/src/Runner.Worker/Dap/JobExecutionView.cs
+++ b/src/Runner.Worker/Dap/JobExecutionView.cs
@@ -1,0 +1,299 @@
+﻿using System;
+using System.Collections.Generic;
+using GitHub.Runner.Sdk;
+
+namespace GitHub.Runner.Worker.Dap
+{
+    /// <summary>
+    /// Stateful, append-only container that wraps <see cref="JobExecutionViewRenderer"/>
+    /// for runtime use. Maintains a mutable list of entries, caches the rendered YAML,
+    /// and provides O(1) lookup from <see cref="IStep"/> identity to the current line
+    /// in the rendered YAML where that step's <c>- step:</c> key appears.
+    ///
+    /// Append-only growth model: post-steps are discovered lazily during execution
+    /// and appended. Setup/pre/main entry line numbers are stable across appends —
+    /// only the synthetic Cleanup boundary (which is not tracked here) shifts.
+    /// </summary>
+    internal sealed class JobExecutionView
+    {
+        private readonly object _lock = new();
+        private readonly string _jobId;
+        private readonly List<JobExecutionViewEntry> _entries = new();
+        private readonly List<IStep> _stepIdentities = new();
+        private readonly Dictionary<IStep, int> _lineByStep =
+            new(ReferenceEqualityComparer.Instance);
+        // Map matchKey -> entry index for placeholders awaiting a future
+        // TryClaim. Removed when claimed.
+        private readonly Dictionary<string, int> _unclaimedByKey =
+            new(StringComparer.Ordinal);
+        private string _yaml;
+        private IReadOnlyList<int> _entryStartLines = Array.Empty<int>();
+
+        public JobExecutionView(string jobId)
+        {
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("jobId must not be null or whitespace.", nameof(jobId));
+            }
+
+            _jobId = jobId;
+            Render();
+        }
+
+        public string JobId
+        {
+            get { return _jobId; }
+        }
+
+        /// <summary>
+        /// Currently rendered YAML. Always reflects all entries appended so far,
+        /// plus the synthetic Setup header and Cleanup footer emitted by the renderer.
+        /// </summary>
+        public string Yaml
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _yaml;
+                }
+            }
+        }
+
+        /// <summary>Number of entries (excludes synthetic Setup/Cleanup boundaries).</summary>
+        public int EntryCount
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _entries.Count;
+                }
+            }
+        }
+
+        /// <summary>
+        /// 1-based line where entry <paramref name="entryIndex"/>'s <c>- step:</c> key
+        /// currently appears in <see cref="Yaml"/>.
+        /// </summary>
+        public int GetLine(int entryIndex)
+        {
+            lock (_lock)
+            {
+                if (entryIndex < 0 || entryIndex >= _entries.Count)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(entryIndex));
+                }
+
+                return _entryStartLines[entryIndex];
+            }
+        }
+
+        /// <summary>
+        /// 1-based line for the entry whose <see cref="IStep"/> reference identity
+        /// matches <paramref name="step"/>. Returns null if <paramref name="step"/>
+        /// is null or has not been registered.
+        /// </summary>
+        public int? TryGetLineForStep(IStep step)
+        {
+            if (step == null)
+            {
+                return null;
+            }
+
+            lock (_lock)
+            {
+                if (_lineByStep.TryGetValue(step, out var line))
+                {
+                    return line;
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Append a new entry. If <paramref name="stepIdentity"/> is non-null,
+        /// registers the IStep -> line mapping for later lookup. If
+        /// <paramref name="matchKey"/> is non-null, the entry is registered
+        /// as an unclaimed placeholder that a future
+        /// <see cref="TryClaim(string, IStep)"/> call can bind to a real
+        /// IStep (used by the predictive Post-step path). Re-renders the
+        /// YAML and updates the start-line table.
+        /// </summary>
+        /// <returns>1-based line number of the newly-appended entry's <c>- step:</c> key.</returns>
+        public int Append(JobExecutionViewEntry entry, IStep stepIdentity = null, string matchKey = null)
+        {
+            if (entry == null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+
+            lock (_lock)
+            {
+                if (stepIdentity != null && _lineByStep.ContainsKey(stepIdentity))
+                {
+                    throw new InvalidOperationException("step already registered in execution view");
+                }
+                if (matchKey != null && _unclaimedByKey.ContainsKey(matchKey))
+                {
+                    throw new InvalidOperationException($"matchKey already registered: {matchKey}");
+                }
+
+                _entries.Add(entry);
+                _stepIdentities.Add(stepIdentity);
+                Render();
+
+                int index = _entries.Count - 1;
+                if (matchKey != null)
+                {
+                    _unclaimedByKey[matchKey] = index;
+                }
+                return _entryStartLines[index];
+            }
+        }
+
+        /// <summary>
+        /// Bind a previously-appended placeholder entry (registered via
+        /// <see cref="Append(JobExecutionViewEntry, IStep, string)"/> with
+        /// a non-null <c>matchKey</c>) to a real <see cref="IStep"/>.
+        /// Returns the 1-based line of the now-claimed entry on success.
+        /// Returns null when no unclaimed placeholder exists for
+        /// <paramref name="matchKey"/>, OR when <paramref name="stepIdentity"/>
+        /// is already registered for a different entry (defensive).
+        /// Does not re-render: claim only updates the IStep -> line index.
+        /// </summary>
+        public int? TryClaim(string matchKey, IStep stepIdentity)
+        {
+            if (matchKey == null)
+            {
+                throw new ArgumentNullException(nameof(matchKey));
+            }
+            if (stepIdentity == null)
+            {
+                throw new ArgumentNullException(nameof(stepIdentity));
+            }
+
+            lock (_lock)
+            {
+                if (!_unclaimedByKey.TryGetValue(matchKey, out int index))
+                {
+                    return null;
+                }
+                if (_lineByStep.ContainsKey(stepIdentity))
+                {
+                    // Bail rather than double-register the step.
+                    return null;
+                }
+
+                _unclaimedByKey.Remove(matchKey);
+                _stepIdentities[index] = stepIdentity;
+                _lineByStep[stepIdentity] = _entryStartLines[index];
+                return _entryStartLines[index];
+            }
+        }
+
+        /// <summary>
+        /// Mark a previously-appended unclaimed placeholder as skipped. Used
+        /// when the predicting Main step never runs (skipped by <c>if:</c>),
+        /// so its predicted Post-step placeholder should not appear as a
+        /// step that will execute. Re-renders the view (inline comment only
+        /// — subsequent entry line numbers stay stable).
+        /// </summary>
+        /// <returns>
+        /// true if a matching unclaimed placeholder was marked; false when
+        /// no placeholder exists for <paramref name="matchKey"/>, or the
+        /// placeholder has already been claimed (claim wins).
+        /// </returns>
+        public bool TryMarkSkipped(string matchKey)
+        {
+            ArgUtil.NotNull(matchKey, nameof(matchKey));
+
+            lock (_lock)
+            {
+                if (!_unclaimedByKey.TryGetValue(matchKey, out int index))
+                {
+                    return false;
+                }
+                // Defensive: only mark if it's still an unclaimed placeholder.
+                if (_stepIdentities[index] != null)
+                {
+                    return false;
+                }
+
+                if (_entries[index].IsSkipped)
+                {
+                    // Idempotent — already marked.
+                    return true;
+                }
+                _entries[index].IsSkipped = true;
+                _unclaimedByKey.Remove(matchKey);
+                Render();
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Bulk-append for the initial population. Equivalent to calling
+        /// <see cref="Append"/> once per pair, but renders only once at the end.
+        /// State is left unchanged if any input is invalid.
+        /// </summary>
+        public void AppendRange(IEnumerable<(JobExecutionViewEntry entry, IStep stepIdentity)> items)
+        {
+            ArgUtil.NotNull(items, nameof(items));
+
+            // Materialize first so we don't enumerate twice.
+            var materialized = new List<(JobExecutionViewEntry entry, IStep stepIdentity)>(items);
+            for (int i = 0; i < materialized.Count; i++)
+            {
+                if (materialized[i].entry == null)
+                {
+                    throw new ArgumentException($"items[{i}].entry is null.", nameof(items));
+                }
+            }
+
+            lock (_lock)
+            {
+                // Validate no duplicates within the input or with existing identities,
+                // before mutating state.
+                var seen = new HashSet<IStep>(ReferenceEqualityComparer.Instance);
+                foreach (var (_, stepIdentity) in materialized)
+                {
+                    if (stepIdentity == null)
+                    {
+                        continue;
+                    }
+                    if (_lineByStep.ContainsKey(stepIdentity) || !seen.Add(stepIdentity))
+                    {
+                        throw new InvalidOperationException("step already registered in execution view");
+                    }
+                }
+
+                foreach (var (entry, stepIdentity) in materialized)
+                {
+                    _entries.Add(entry);
+                    _stepIdentities.Add(stepIdentity);
+                }
+                Render();
+            }
+        }
+
+        // Caller MUST hold _lock (constructor's call is safe — no concurrent access yet).
+        private void Render()
+        {
+            var result = JobExecutionViewRenderer.Render(_jobId, _entries.AsReadOnly());
+            _yaml = result.Yaml;
+            _entryStartLines = result.EntryStartLines;
+
+            _lineByStep.Clear();
+            for (int i = 0; i < _stepIdentities.Count; i++)
+            {
+                var step = _stepIdentities[i];
+                if (step != null)
+                {
+                    _lineByStep[step] = _entryStartLines[i];
+                }
+            }
+        }
+    }
+}

--- a/src/Runner.Worker/Dap/JobExecutionViewRenderer.cs
+++ b/src/Runner.Worker/Dap/JobExecutionViewRenderer.cs
@@ -88,15 +88,6 @@ namespace GitHub.Runner.Worker.Dap
         public string WithYaml { get; }
         public string Shell { get; }
         public string WorkingDirectory { get; }
-
-        /// <summary>
-        /// Set when the corresponding step was skipped (e.g. predicted Post
-        /// placeholder for a Main step that never executed because its
-        /// <c>if:</c> evaluated false). Rendered as an inline YAML comment
-        /// on the entry's <c>- step:</c> line so subsequent entry line
-        /// numbers stay stable.
-        /// </summary>
-        public bool IsSkipped { get; internal set; }
     }
 
     /// <summary>
@@ -213,11 +204,6 @@ namespace GitHub.Runner.Worker.Dap
                 startLines[i] = newlinesEmitted + 1;
 
                 sb.Append("  - step: ").Append(FormatScalar(entry.DisplayName));
-                if (entry.IsSkipped)
-                {
-                    // Inline comment — keeps following entry line numbers stable.
-                    sb.Append("  # (skipped — main step did not execute)");
-                }
                 sb.Append('\n');
                 newlinesEmitted++;
 

--- a/src/Runner.Worker/Dap/JobExecutionViewRenderer.cs
+++ b/src/Runner.Worker/Dap/JobExecutionViewRenderer.cs
@@ -366,7 +366,14 @@ namespace GitHub.Runner.Worker.Dap
             emitter.Emit(new StreamEnd());
 
             string raw = sw.ToString();
+            // Strip YAML document markers. Emitter elides these for most
+            // scalars but emits "--- " (with space) for some edge cases
+            // (e.g. empty strings). Defensively handle "---\n" too.
             if (raw.StartsWith("--- ", StringComparison.Ordinal))
+            {
+                raw = raw.Substring(4);
+            }
+            else if (raw.StartsWith("---\n", StringComparison.Ordinal))
             {
                 raw = raw.Substring(4);
             }

--- a/src/Runner.Worker/Dap/JobExecutionViewRenderer.cs
+++ b/src/Runner.Worker/Dap/JobExecutionViewRenderer.cs
@@ -367,6 +367,11 @@ namespace GitHub.Runner.Worker.Dap
             }
 
             using var sw = new StringWriter(CultureInfo.InvariantCulture);
+            // Force LF line breaks; YamlDotNet's Emitter calls WriteLine,
+            // which would otherwise produce CRLF on Windows and break
+            // both our document-end stripping below and downstream
+            // consumers that assume a single line-break convention.
+            sw.NewLine = "\n";
             var emitter = new Emitter(sw);
             emitter.Emit(new StreamStart());
             emitter.Emit(new DocumentStart(null, null, true));

--- a/src/Runner.Worker/Dap/JobExecutionViewRenderer.cs
+++ b/src/Runner.Worker/Dap/JobExecutionViewRenderer.cs
@@ -1,0 +1,391 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using GitHub.Runner.Sdk;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace GitHub.Runner.Worker.Dap
+{
+    /// <summary>
+    /// Phase a step occupies in the runner's flat execution sequence.
+    /// Setup and Cleanup are NOT modeled here — they are synthetic
+    /// boundaries hard-coded by <see cref="JobExecutionViewRenderer"/>
+    /// and cannot be constructed by callers.
+    /// </summary>
+    internal enum JobExecutionPhase
+    {
+        Pre,
+        Main,
+        Post,
+    }
+
+    /// <summary>
+    /// One step in the rendered execution view. Pure data; no link to
+    /// any worker type. Phase 2 will translate runner step objects
+    /// into instances of this record.
+    /// </summary>
+    internal sealed class JobExecutionViewEntry
+    {
+        public JobExecutionViewEntry(
+            JobExecutionPhase phase,
+            string displayName,
+            string uses = null,
+            string run = null,
+            string sourcePath = null,
+            int sourceLine = 0,
+            string id = null,
+            string @if = null,
+            string continueOnError = null,
+            string timeoutMinutes = null,
+            string envYaml = null,
+            string withYaml = null,
+            string shell = null,
+            string workingDirectory = null)
+        {
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                throw new ArgumentException("displayName must not be null or whitespace.", nameof(displayName));
+            }
+            if (sourcePath != null && sourceLine < 1)
+            {
+                throw new ArgumentException(
+                    "sourceLine must be >= 1 when sourcePath is provided.",
+                    nameof(sourceLine));
+            }
+
+            Phase = phase;
+            DisplayName = displayName;
+            Uses = uses;
+            Run = run;
+            SourcePath = sourcePath;
+            SourceLine = sourceLine;
+            Id = id;
+            If = @if;
+            ContinueOnError = continueOnError;
+            TimeoutMinutes = timeoutMinutes;
+            EnvYaml = envYaml;
+            WithYaml = withYaml;
+            Shell = shell;
+            WorkingDirectory = workingDirectory;
+        }
+
+        public JobExecutionPhase Phase { get; }
+        public string DisplayName { get; }
+        public string Uses { get; }
+        public string Run { get; }
+        public string SourcePath { get; }
+        public int SourceLine { get; }
+        public string Id { get; }
+        public string If { get; }
+        public string ContinueOnError { get; }
+        public string TimeoutMinutes { get; }
+        // Pre-serialized YAML fragment, already indented for embedding
+        // under the entry's `env:` key (6-space child indent).
+        public string EnvYaml { get; }
+        public string WithYaml { get; }
+        public string Shell { get; }
+        public string WorkingDirectory { get; }
+
+        /// <summary>
+        /// Set when the corresponding step was skipped (e.g. predicted Post
+        /// placeholder for a Main step that never executed because its
+        /// <c>if:</c> evaluated false). Rendered as an inline YAML comment
+        /// on the entry's <c>- step:</c> line so subsequent entry line
+        /// numbers stay stable.
+        /// </summary>
+        public bool IsSkipped { get; internal set; }
+    }
+
+    /// <summary>
+    /// Output of <see cref="JobExecutionViewRenderer.Render"/>: the YAML
+    /// document plus a parallel array of 1-based line numbers, one per
+    /// input entry, where each entry's <c>- step:</c> key appears.
+    /// Synthetic Setup/Cleanup boundaries are not tracked here.
+    /// </summary>
+    internal readonly struct RenderResult
+    {
+        public RenderResult(string yaml, IReadOnlyList<int> entryStartLines)
+        {
+            Yaml = yaml;
+            EntryStartLines = entryStartLines;
+        }
+
+        public string Yaml { get; }
+        public IReadOnlyList<int> EntryStartLines { get; }
+    }
+
+    /// <summary>
+    /// Renders a job's execution-view YAML. Pure function; no I/O,
+    /// no logging, no static state. Output format and Setup/Cleanup
+    /// boundaries are fixed; callers cannot influence them.
+    ///
+    /// Output is structured as phase-keyed top-level sections:
+    /// <c>setup:</c>, <c>pre:</c>, <c>main:</c>, <c>post:</c>, <c>cleanup:</c>.
+    /// <c>setup:</c> and <c>cleanup:</c> always render; <c>pre:</c>,
+    /// <c>main:</c>, <c>post:</c> only render when they contain at least
+    /// one entry.
+    /// </summary>
+    internal static class JobExecutionViewRenderer
+    {
+        public static RenderResult Render(string jobId, IReadOnlyList<JobExecutionViewEntry> entries)
+        {
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("jobId must not be null or whitespace.", nameof(jobId));
+            }
+            ArgUtil.NotNull(entries, nameof(entries));
+
+            // Pre-validate non-null entries before any output, so partial
+            // state is never observed by callers.
+            for (int i = 0; i < entries.Count; i++)
+            {
+                if (entries[i] == null)
+                {
+                    throw new ArgumentException($"entries[{i}] is null.", nameof(entries));
+                }
+            }
+
+            var sb = new StringBuilder();
+            var startLines = new int[entries.Count];
+            int newlinesEmitted = 0;
+
+            // Header (3 lines).
+            sb.Append("# Job: ").Append(FormatScalar(jobId)).Append('\n');
+            sb.Append("# Runner execution plan — read-only.\n");
+            sb.Append('\n');
+            newlinesEmitted += 3;
+
+            // setup: section — always present.
+            sb.Append("setup:\n");
+            sb.Append("  - step: Setup job\n");
+            newlinesEmitted += 2;
+
+            // Render phase sections in fixed order. Each emits a leading
+            // blank line separator before its header.
+            EmitPhaseSection(sb, "pre", JobExecutionPhase.Pre, entries, startLines, ref newlinesEmitted);
+            EmitPhaseSection(sb, "main", JobExecutionPhase.Main, entries, startLines, ref newlinesEmitted);
+            EmitPhaseSection(sb, "post", JobExecutionPhase.Post, entries, startLines, ref newlinesEmitted);
+
+            // cleanup: section — always present, preceded by a blank line.
+            sb.Append('\n');
+            sb.Append("cleanup:\n");
+            sb.Append("  - step: Complete job\n");
+
+            return new RenderResult(sb.ToString(), Array.AsReadOnly(startLines));
+        }
+
+        private static void EmitPhaseSection(
+            StringBuilder sb,
+            string sectionName,
+            JobExecutionPhase phase,
+            IReadOnlyList<JobExecutionViewEntry> entries,
+            int[] startLines,
+            ref int newlinesEmitted)
+        {
+            // Skip the section entirely if no entries belong to this phase.
+            bool any = false;
+            for (int i = 0; i < entries.Count; i++)
+            {
+                if (entries[i].Phase == phase) { any = true; break; }
+            }
+            if (!any)
+            {
+                return;
+            }
+
+            // Blank line separator + section header.
+            sb.Append('\n');
+            sb.Append(sectionName).Append(":\n");
+            newlinesEmitted += 2;
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                var entry = entries[i];
+                if (entry.Phase != phase)
+                {
+                    continue;
+                }
+
+                // 1-based line of the `- step:` key for this entry.
+                startLines[i] = newlinesEmitted + 1;
+
+                sb.Append("  - step: ").Append(FormatScalar(entry.DisplayName));
+                if (entry.IsSkipped)
+                {
+                    // Inline comment — keeps following entry line numbers stable.
+                    sb.Append("  # (skipped — main step did not execute)");
+                }
+                sb.Append('\n');
+                newlinesEmitted++;
+
+                switch (phase)
+                {
+                    case JobExecutionPhase.Pre:
+                    case JobExecutionPhase.Post:
+                        if (!string.IsNullOrEmpty(entry.Uses))
+                        {
+                            sb.Append("    action: ").Append(FormatScalar(entry.Uses)).Append('\n');
+                            newlinesEmitted++;
+                        }
+                        // No source: annotation for pre/post.
+                        break;
+
+                    case JobExecutionPhase.Main:
+                        if (!string.IsNullOrEmpty(entry.Id))
+                        {
+                            sb.Append("    id: ").Append(FormatScalar(entry.Id)).Append('\n');
+                            newlinesEmitted++;
+                        }
+                        if (!string.IsNullOrEmpty(entry.Uses))
+                        {
+                            sb.Append("    uses: ").Append(FormatScalar(entry.Uses)).Append('\n');
+                            newlinesEmitted++;
+                        }
+                        if (!string.IsNullOrEmpty(entry.Run))
+                        {
+                            if (entry.Run.IndexOf('\n') < 0)
+                            {
+                                sb.Append("    run: ").Append(FormatScalar(entry.Run)).Append('\n');
+                                newlinesEmitted++;
+                            }
+                            else
+                            {
+                                sb.Append("    run: |\n");
+                                newlinesEmitted++;
+                                newlinesEmitted += AppendIndentedBlock(sb, entry.Run, "      ");
+                            }
+                        }
+                        if (!string.IsNullOrEmpty(entry.If))
+                        {
+                            sb.Append("    if: ").Append(FormatScalar(entry.If)).Append('\n');
+                            newlinesEmitted++;
+                        }
+                        if (!string.IsNullOrEmpty(entry.ContinueOnError))
+                        {
+                            sb.Append("    continue-on-error: ").Append(entry.ContinueOnError).Append('\n');
+                            newlinesEmitted++;
+                        }
+                        if (!string.IsNullOrEmpty(entry.TimeoutMinutes))
+                        {
+                            sb.Append("    timeout-minutes: ").Append(entry.TimeoutMinutes).Append('\n');
+                            newlinesEmitted++;
+                        }
+                        if (!string.IsNullOrEmpty(entry.EnvYaml))
+                        {
+                            sb.Append("    env:\n");
+                            newlinesEmitted++;
+                            sb.Append(entry.EnvYaml).Append('\n');
+                            newlinesEmitted += CountChar(entry.EnvYaml, '\n') + 1;
+                        }
+                        if (!string.IsNullOrEmpty(entry.WithYaml))
+                        {
+                            sb.Append("    with:\n");
+                            newlinesEmitted++;
+                            sb.Append(entry.WithYaml).Append('\n');
+                            newlinesEmitted += CountChar(entry.WithYaml, '\n') + 1;
+                        }
+                        if (!string.IsNullOrEmpty(entry.Shell))
+                        {
+                            sb.Append("    shell: ").Append(FormatScalar(entry.Shell)).Append('\n');
+                            newlinesEmitted++;
+                        }
+                        if (!string.IsNullOrEmpty(entry.WorkingDirectory))
+                        {
+                            sb.Append("    working-directory: ").Append(FormatScalar(entry.WorkingDirectory)).Append('\n');
+                            newlinesEmitted++;
+                        }
+                        if (entry.SourcePath != null)
+                        {
+                            sb.Append("    source: ")
+                              .Append(entry.SourcePath)
+                              .Append(':')
+                              .Append(entry.SourceLine.ToString(CultureInfo.InvariantCulture))
+                              .Append('\n');
+                            newlinesEmitted++;
+                        }
+                        break;
+                }
+            }
+        }
+
+        private static int AppendIndentedBlock(StringBuilder sb, string text, string indent)
+        {
+            int newlines = 0;
+            int i = 0;
+            while (i < text.Length)
+            {
+                int end = text.IndexOf('\n', i);
+                int lineEnd = end < 0 ? text.Length : end;
+                int trimEnd = lineEnd;
+                if (trimEnd > i && text[trimEnd - 1] == '\r')
+                {
+                    trimEnd--;
+                }
+                if (trimEnd > i)
+                {
+                    sb.Append(indent);
+                    sb.Append(text, i, trimEnd - i);
+                }
+                sb.Append('\n');
+                newlines++;
+                if (end < 0)
+                {
+                    break;
+                }
+                i = end + 1;
+            }
+            return newlines;
+        }
+
+        private static int CountChar(string s, char c)
+        {
+            int n = 0;
+            for (int i = 0; i < s.Length; i++)
+            {
+                if (s[i] == c) n++;
+            }
+            return n;
+        }
+
+        /// <summary>
+        /// Formats a single string as a YAML 1.x flow scalar, delegating
+        /// quoting/escaping decisions to YamlDotNet. This avoids maintaining
+        /// our own escape table for every YAML-significant character: we
+        /// just emit the value through the YAML library and use whichever
+        /// scalar style (plain, single-quoted, double-quoted) it picks.
+        /// A new <see cref="Emitter"/> is created per call, so the helper
+        /// is safe to invoke concurrently.
+        /// </summary>
+        internal static string FormatScalar(string value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            using var sw = new StringWriter(CultureInfo.InvariantCulture);
+            var emitter = new Emitter(sw);
+            emitter.Emit(new StreamStart());
+            emitter.Emit(new DocumentStart(null, null, true));
+            emitter.Emit(new Scalar(null, null, value, ScalarStyle.Any, true, true));
+            emitter.Emit(new DocumentEnd(true));
+            emitter.Emit(new StreamEnd());
+
+            string raw = sw.ToString();
+            if (raw.StartsWith("--- ", StringComparison.Ordinal))
+            {
+                raw = raw.Substring(4);
+            }
+            raw = raw.TrimEnd('\n');
+            const string DocEndMarker = "\n...";
+            if (raw.EndsWith(DocEndMarker, StringComparison.Ordinal))
+            {
+                raw = raw.Substring(0, raw.Length - DocEndMarker.Length);
+            }
+            return raw.TrimEnd('\n');
+        }
+    }
+}

--- a/src/Runner.Worker/Dap/StepEntryTranslator.cs
+++ b/src/Runner.Worker/Dap/StepEntryTranslator.cs
@@ -16,12 +16,14 @@ namespace GitHub.Runner.Worker.Dap
     internal static class StepEntryTranslator
     {
         // Run-step internals carried on ActionStep.Inputs that are NOT
-        // user-authored `with:` entries.
+        // user-authored `with:` entries. The runner stores these under
+        // the keys defined in PipelineConstants.ScriptStepInputs, NOT
+        // their kebab-case workflow-YAML spellings.
         private static readonly HashSet<string> RunStepInternalKeys = new(StringComparer.Ordinal)
         {
-            "script",
-            "shell",
-            "working-directory",
+            PipelineConstants.ScriptStepInputs.Script,
+            PipelineConstants.ScriptStepInputs.Shell,
+            PipelineConstants.ScriptStepInputs.WorkingDirectory,
         };
 
         /// <summary>
@@ -116,11 +118,11 @@ namespace GitHub.Runner.Worker.Dap
                     var inputs = action.Inputs as MappingToken;
                     if (inputs != null)
                     {
-                        if (TryGetMapValue(inputs, "script", out var scriptTok) && scriptTok != null)
+                        if (TryGetMapValue(inputs, PipelineConstants.ScriptStepInputs.Script, out var scriptTok) && scriptTok != null)
                         {
                             run = scriptTok.ToString();
                         }
-                        if (TryGetMapValue(inputs, "shell", out var shellTok) && shellTok != null)
+                        if (TryGetMapValue(inputs, PipelineConstants.ScriptStepInputs.Shell, out var shellTok) && shellTok != null)
                         {
                             string shellText = shellTok.ToString();
                             if (!string.IsNullOrEmpty(shellText))
@@ -128,7 +130,7 @@ namespace GitHub.Runner.Worker.Dap
                                 shell = shellText;
                             }
                         }
-                        if (TryGetMapValue(inputs, "working-directory", out var wdTok) && wdTok != null)
+                        if (TryGetMapValue(inputs, PipelineConstants.ScriptStepInputs.WorkingDirectory, out var wdTok) && wdTok != null)
                         {
                             string wdText = wdTok.ToString();
                             if (!string.IsNullOrEmpty(wdText))

--- a/src/Runner.Worker/Dap/StepEntryTranslator.cs
+++ b/src/Runner.Worker/Dap/StepEntryTranslator.cs
@@ -1,0 +1,238 @@
+﻿using System;
+using System.Collections.Generic;
+using GitHub.DistributedTask.ObjectTemplating.Tokens;
+using GitHub.DistributedTask.Pipelines;
+using GitHub.Runner.Sdk;
+
+namespace GitHub.Runner.Worker.Dap
+{
+    /// <summary>
+    /// Translates runner <see cref="IStep"/> instances into pure-data
+    /// <see cref="JobExecutionViewEntry"/> records used by the DAP debugger
+    /// execution view. Filters out runner-internal steps (e.g.
+    /// <see cref="JobExtensionRunner"/>) so the rendered view only shows
+    /// user-visible workflow steps.
+    /// </summary>
+    internal static class StepEntryTranslator
+    {
+        // Run-step internals carried on ActionStep.Inputs that are NOT
+        // user-authored `with:` entries.
+        private static readonly HashSet<string> RunStepInternalKeys = new(StringComparer.Ordinal)
+        {
+            "script",
+            "shell",
+            "working-directory",
+        };
+
+        /// <summary>
+        /// Translate an IStep into a JobExecutionViewEntry.
+        /// </summary>
+        /// <param name="step">The IStep to translate. Must not be null.</param>
+        /// <returns>
+        /// A JobExecutionViewEntry, or null if the step is not user-visible
+        /// (JobExtensionRunner and any other non-IActionRunner IStep impls).
+        /// </returns>
+        public static JobExecutionViewEntry TryTranslate(IStep step)
+        {
+            ArgUtil.NotNull(step, nameof(step));
+
+            if (step is JobExtensionRunner)
+            {
+                return null;
+            }
+
+            if (step is not IActionRunner actionRunner)
+            {
+                return null;
+            }
+
+            var phase = actionRunner.Stage switch
+            {
+                ActionRunStage.Pre => JobExecutionPhase.Pre,
+                ActionRunStage.Post => JobExecutionPhase.Post,
+                _ => JobExecutionPhase.Main,
+            };
+
+            string displayName = actionRunner.DisplayName;
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                displayName = "run";
+            }
+
+            string uses = null;
+            string run = null;
+            string id = null;
+            string ifCond = null;
+            string continueOnError = null;
+            string timeoutMinutes = null;
+            string envYaml = null;
+            string withYaml = null;
+            string shell = null;
+            string workingDirectory = null;
+
+            var action = actionRunner.Action;
+            var reference = action?.Reference;
+            bool isScript = reference?.Type == ActionSourceType.Script;
+
+            if (reference != null && !isScript)
+            {
+                uses = FormatActionReference(reference);
+            }
+
+            // Only the user-visible Main entry surfaces authored params.
+            // Pre/Post stay minimal (step + action) — they reference the
+            // same Action as the Main entry, and duplicating params adds
+            // noise without information.
+            if (phase == JobExecutionPhase.Main && action != null)
+            {
+                id = FilterAuthoredId(action.ContextName);
+
+                if (!string.IsNullOrEmpty(action.Condition))
+                {
+                    ifCond = action.Condition;
+                }
+
+                if (action.ContinueOnError != null)
+                {
+                    continueOnError = TemplateTokenYamlAdapter.Serialize(action.ContinueOnError, indentSpaces: 0);
+                }
+                if (action.TimeoutInMinutes != null)
+                {
+                    timeoutMinutes = TemplateTokenYamlAdapter.Serialize(action.TimeoutInMinutes, indentSpaces: 0);
+                }
+
+                if (action.Environment is MappingToken envMap && envMap.Count > 0)
+                {
+                    envYaml = TemplateTokenYamlAdapter.Serialize(envMap, indentSpaces: 6);
+                }
+                else if (action.Environment != null && !(action.Environment is MappingToken))
+                {
+                    // Unusual but possible: env: ${{ ... }} expression form.
+                    envYaml = TemplateTokenYamlAdapter.Serialize(action.Environment, indentSpaces: 6);
+                }
+
+                if (isScript)
+                {
+                    var inputs = action.Inputs as MappingToken;
+                    if (inputs != null)
+                    {
+                        if (TryGetMapValue(inputs, "script", out var scriptTok) && scriptTok != null)
+                        {
+                            run = scriptTok.ToString();
+                        }
+                        if (TryGetMapValue(inputs, "shell", out var shellTok) && shellTok != null)
+                        {
+                            string shellText = shellTok.ToString();
+                            if (!string.IsNullOrEmpty(shellText))
+                            {
+                                shell = shellText;
+                            }
+                        }
+                        if (TryGetMapValue(inputs, "working-directory", out var wdTok) && wdTok != null)
+                        {
+                            string wdText = wdTok.ToString();
+                            if (!string.IsNullOrEmpty(wdText))
+                            {
+                                workingDirectory = wdText;
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    // Action step: surface `with:` entries, filtering any
+                    // run-step internal keys defensively.
+                    if (action.Inputs is MappingToken withMap && withMap.Count > 0)
+                    {
+                        var filtered = FilterMapping(withMap, RunStepInternalKeys);
+                        if (filtered != null && filtered.Count > 0)
+                        {
+                            withYaml = TemplateTokenYamlAdapter.Serialize(filtered, indentSpaces: 6);
+                        }
+                    }
+                }
+            }
+
+            // Source annotation (SourcePath/SourceLine) requires a public
+            // seam onto TemplateToken position info — not wired yet.
+            return new JobExecutionViewEntry(
+                phase: phase,
+                displayName: displayName,
+                uses: uses,
+                run: run,
+                sourcePath: null,
+                sourceLine: 0,
+                id: id,
+                @if: ifCond,
+                continueOnError: continueOnError,
+                timeoutMinutes: timeoutMinutes,
+                envYaml: envYaml,
+                withYaml: withYaml,
+                shell: shell,
+                workingDirectory: workingDirectory);
+        }
+
+        /// <summary>
+        /// Auto-generated step IDs are noise in the view: filter them out.
+        /// The runner's convention (see ExecutionContext) is that auto-
+        /// generated context names start with <c>__</c>. Only user-authored
+        /// IDs survive the filter.
+        /// </summary>
+        internal static string FilterAuthoredId(string contextName)
+        {
+            if (string.IsNullOrWhiteSpace(contextName))
+            {
+                return null;
+            }
+            if (contextName.StartsWith("__", StringComparison.Ordinal))
+            {
+                return null;
+            }
+            return contextName;
+        }
+
+        private static bool TryGetMapValue(MappingToken map, string key, out TemplateToken value)
+        {
+            foreach (var pair in map)
+            {
+                if (pair.Key is StringToken s && string.Equals(s.Value, key, StringComparison.Ordinal))
+                {
+                    value = pair.Value;
+                    return true;
+                }
+            }
+            value = null;
+            return false;
+        }
+
+        private static MappingToken FilterMapping(MappingToken source, HashSet<string> excludeKeys)
+        {
+            var copy = new MappingToken(source.FileId, source.Line, source.Column);
+            foreach (var pair in source)
+            {
+                if (pair.Key is StringToken sk && excludeKeys.Contains(sk.Value))
+                {
+                    continue;
+                }
+                copy.Add(pair);
+            }
+            return copy;
+        }
+
+        internal static string FormatActionReference(ActionStepDefinitionReference reference)
+        {
+            switch (reference)
+            {
+                case RepositoryPathReference repo:
+                    var path = string.IsNullOrEmpty(repo.Path) ? string.Empty : $"/{repo.Path}";
+                    return string.IsNullOrEmpty(repo.Ref)
+                        ? $"{repo.Name}{path}"
+                        : $"{repo.Name}{path}@{repo.Ref}";
+                case ContainerRegistryReference container:
+                    return container.Image;
+                default:
+                    return reference.ToString();
+            }
+        }
+    }
+}

--- a/src/Runner.Worker/Dap/TemplateTokenYamlAdapter.cs
+++ b/src/Runner.Worker/Dap/TemplateTokenYamlAdapter.cs
@@ -107,8 +107,17 @@ namespace GitHub.Runner.Worker.Dap
             adapter.WriteEnd();
 
             string raw = sw.ToString();
-            // Strip YAML document markers ("--- " prefix and "\n..." suffix).
+            // Strip YAML document markers. The Emitter most commonly elides
+            // these for our use (DocumentStart isImplicit=true), but emits
+            // them for some scalar edge cases (e.g. empty strings) and may
+            // emit them on their own line for collection roots under some
+            // settings. Strip both shapes defensively so callers never see
+            // a leaked marker leak into the embedded fragment.
             if (raw.StartsWith("--- ", StringComparison.Ordinal))
+            {
+                raw = raw.Substring(4);
+            }
+            else if (raw.StartsWith("---\n", StringComparison.Ordinal))
             {
                 raw = raw.Substring(4);
             }

--- a/src/Runner.Worker/Dap/TemplateTokenYamlAdapter.cs
+++ b/src/Runner.Worker/Dap/TemplateTokenYamlAdapter.cs
@@ -95,6 +95,11 @@ namespace GitHub.Runner.Worker.Dap
             }
 
             using var sw = new StringWriter(CultureInfo.InvariantCulture);
+            // Force LF line breaks; YamlDotNet's Emitter calls WriteLine,
+            // which would otherwise produce CRLF on Windows and corrupt
+            // both the document-end stripping below and the per-line
+            // indentation pass that follows.
+            sw.NewLine = "\n";
             var emitter = new Emitter(sw);
             var adapter = new TemplateTokenYamlAdapter(emitter);
             adapter.WriteStart();

--- a/src/Runner.Worker/Dap/TemplateTokenYamlAdapter.cs
+++ b/src/Runner.Worker/Dap/TemplateTokenYamlAdapter.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using GitHub.DistributedTask.ObjectTemplating;
+using GitHub.DistributedTask.ObjectTemplating.Tokens;
+using GitHub.Runner.Sdk;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace GitHub.Runner.Worker.Dap
+{
+    /// <summary>
+    /// Adapts a YamlDotNet <see cref="IEmitter"/> as a DT
+    /// <see cref="IObjectWriter"/> so a <see cref="TemplateToken"/> DOM
+    /// can be serialized back to YAML preserving its pre-evaluation form
+    /// (basic <c>${{ }}</c> expressions are written through verbatim).
+    ///
+    /// Used by the DAP execution view to surface user-authored step
+    /// parameters (<c>env:</c>, <c>with:</c>, <c>run:</c>, ...) without
+    /// any expression substitution.
+    /// </summary>
+    internal sealed class TemplateTokenYamlAdapter : IObjectWriter
+    {
+        private readonly IEmitter _emitter;
+
+        public TemplateTokenYamlAdapter(IEmitter emitter)
+        {
+            ArgUtil.NotNull(emitter, nameof(emitter));
+            _emitter = emitter;
+        }
+
+        public void WriteStart()
+        {
+            _emitter.Emit(new StreamStart());
+            _emitter.Emit(new DocumentStart(null, null, true));
+        }
+
+        public void WriteEnd()
+        {
+            _emitter.Emit(new DocumentEnd(true));
+            _emitter.Emit(new StreamEnd());
+        }
+
+        public void WriteNull() =>
+            _emitter.Emit(new Scalar(null, null, "null", ScalarStyle.Plain, true, false));
+
+        public void WriteBoolean(bool value) =>
+            _emitter.Emit(new Scalar(null, null, value ? "true" : "false", ScalarStyle.Plain, true, false));
+
+        public void WriteNumber(double value) =>
+            _emitter.Emit(new Scalar(null, null, value.ToString("R", CultureInfo.InvariantCulture), ScalarStyle.Plain, true, false));
+
+        public void WriteString(string value)
+        {
+            if (value == null)
+            {
+                WriteNull();
+                return;
+            }
+            // Multi-line strings render as block literal so embedded
+            // newlines survive the YAML round trip.
+            var style = value.IndexOf('\n') >= 0 ? ScalarStyle.Literal : ScalarStyle.Any;
+            _emitter.Emit(new Scalar(null, null, value, style, true, true));
+        }
+
+        public void WriteSequenceStart() =>
+            _emitter.Emit(new SequenceStart(null, null, true, SequenceStyle.Any));
+
+        public void WriteSequenceEnd() =>
+            _emitter.Emit(new SequenceEnd());
+
+        public void WriteMappingStart() =>
+            _emitter.Emit(new MappingStart(null, null, true, MappingStyle.Any));
+
+        public void WriteMappingEnd() =>
+            _emitter.Emit(new MappingEnd());
+
+        /// <summary>
+        /// Serialize a TemplateToken to a YAML fragment ready to embed
+        /// under a parent key. Each non-empty line is prefixed by
+        /// <paramref name="indentSpaces"/> spaces. Trailing newlines and
+        /// the YAML stream start/document markers are stripped, so the
+        /// caller controls line breaks.
+        /// </summary>
+        /// <remarks>
+        /// Empty mappings render as <c>{}</c> and empty sequences as
+        /// <c>[]</c> via YamlDotNet's flow style fallback for empty
+        /// collections.
+        /// </remarks>
+        internal static string Serialize(TemplateToken token, int indentSpaces)
+        {
+            if (indentSpaces < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(indentSpaces));
+            }
+
+            using var sw = new StringWriter(CultureInfo.InvariantCulture);
+            var emitter = new Emitter(sw);
+            var adapter = new TemplateTokenYamlAdapter(emitter);
+            TemplateWriter.Write(adapter, token);
+
+            string raw = sw.ToString();
+            // Strip YAML document markers ("--- " prefix and "\n..." suffix).
+            if (raw.StartsWith("--- ", StringComparison.Ordinal))
+            {
+                raw = raw.Substring(4);
+            }
+            const string DocEndMarker = "\n...";
+            if (raw.EndsWith(DocEndMarker + "\n", StringComparison.Ordinal))
+            {
+                raw = raw.Substring(0, raw.Length - DocEndMarker.Length - 1);
+            }
+            else if (raw.EndsWith(DocEndMarker, StringComparison.Ordinal))
+            {
+                raw = raw.Substring(0, raw.Length - DocEndMarker.Length);
+            }
+            raw = raw.TrimEnd('\n');
+
+            if (indentSpaces == 0)
+            {
+                return raw;
+            }
+
+            // Re-indent every non-empty line. Empty lines remain empty
+            // so YAML block-literal blank lines stay valid.
+            var pad = new string(' ', indentSpaces);
+            var sb = new System.Text.StringBuilder(raw.Length + indentSpaces * 4);
+            int i = 0;
+            while (i < raw.Length)
+            {
+                int end = raw.IndexOf('\n', i);
+                int lineEnd = end < 0 ? raw.Length : end;
+                if (lineEnd > i)
+                {
+                    sb.Append(pad);
+                    sb.Append(raw, i, lineEnd - i);
+                }
+                if (end < 0)
+                {
+                    break;
+                }
+                sb.Append('\n');
+                i = end + 1;
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Runner.Worker/Dap/TemplateTokenYamlAdapter.cs
+++ b/src/Runner.Worker/Dap/TemplateTokenYamlAdapter.cs
@@ -97,7 +97,9 @@ namespace GitHub.Runner.Worker.Dap
             using var sw = new StringWriter(CultureInfo.InvariantCulture);
             var emitter = new Emitter(sw);
             var adapter = new TemplateTokenYamlAdapter(emitter);
-            TemplateWriter.Write(adapter, token);
+            adapter.WriteStart();
+            WriteToken(adapter, token);
+            adapter.WriteEnd();
 
             string raw = sw.ToString();
             // Strip YAML document markers ("--- " prefix and "\n..." suffix).
@@ -143,6 +145,65 @@ namespace GitHub.Runner.Worker.Dap
                 i = end + 1;
             }
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Mirrors <see cref="TemplateWriter"/>'s recursive walk, with one
+        /// behavioural change: <see cref="BasicExpressionToken"/> is emitted
+        /// via <c>ToDisplayString()</c> instead of <c>ToString()</c>.
+        /// </summary>
+        /// <remarks>
+        /// The workflow parser tokenizes a mixed scalar like
+        /// <c>${{ runner.os }}-primes</c> as a single
+        /// <see cref="BasicExpressionToken"/> whose internal expression is
+        /// <c>format('{0}-primes', runner.os)</c>. <c>ToString()</c> emits
+        /// the normalized form verbatim; <c>ToDisplayString()</c> reverses
+        /// the <c>format(...)</c> rewrite so the user sees the original
+        /// authored form. Other token kinds delegate to the same writer
+        /// calls <see cref="TemplateWriter"/> would make.
+        /// </remarks>
+        private static void WriteToken(IObjectWriter writer, TemplateToken token)
+        {
+            switch (token?.Type ?? TokenType.Null)
+            {
+                case TokenType.Null:
+                    writer.WriteNull();
+                    break;
+                case TokenType.Boolean:
+                    writer.WriteBoolean(((BooleanToken)token).Value);
+                    break;
+                case TokenType.Number:
+                    writer.WriteNumber(((NumberToken)token).Value);
+                    break;
+                case TokenType.String:
+                    writer.WriteString(token.ToString());
+                    break;
+                case TokenType.BasicExpression:
+                    writer.WriteString(((BasicExpressionToken)token).ToDisplayString());
+                    break;
+                case TokenType.InsertExpression:
+                    writer.WriteString(token.ToString());
+                    break;
+                case TokenType.Mapping:
+                    writer.WriteMappingStart();
+                    foreach (var pair in (MappingToken)token)
+                    {
+                        WriteToken(writer, pair.Key);
+                        WriteToken(writer, pair.Value);
+                    }
+                    writer.WriteMappingEnd();
+                    break;
+                case TokenType.Sequence:
+                    writer.WriteSequenceStart();
+                    foreach (var item in (SequenceToken)token)
+                    {
+                        WriteToken(writer, item);
+                    }
+                    writer.WriteSequenceEnd();
+                    break;
+                default:
+                    throw new NotSupportedException($"Unexpected token type '{token.GetType()}'.");
+            }
         }
     }
 }

--- a/src/Test/L0/Worker/JobExecutionViewL0.cs
+++ b/src/Test/L0/Worker/JobExecutionViewL0.cs
@@ -422,5 +422,21 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Contains(line.Value, entryLines);
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Append_RejectsBothStepIdentityAndMatchKey()
+        {
+            // Allowing both would orphan the IStep→line mapping the moment
+            // TryClaim overwrites _stepIdentities[index] for a different
+            // step, so the API rejects the combination at append time.
+            var view = new JobExecutionView("j");
+            var entry = new JobExecutionViewEntry(JobExecutionPhase.Post, "Post X", uses: "actions/x@v1");
+            Assert.Throws<ArgumentException>(() =>
+                view.Append(entry, stepIdentity: NewStep("real"), matchKey: "k1"));
+            // State unchanged.
+            Assert.Equal(0, view.EntryCount);
+        }
     }
 }

--- a/src/Test/L0/Worker/JobExecutionViewL0.cs
+++ b/src/Test/L0/Worker/JobExecutionViewL0.cs
@@ -422,46 +422,5 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Contains(line.Value, entryLines);
             }
         }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Worker")]
-        public void TryMarkSkipped_MarksUnclaimedPlaceholder()
-        {
-            var view = new JobExecutionView("j");
-            var postEntry = new JobExecutionViewEntry(JobExecutionPhase.Post, "Post X", uses: "actions/x@v1");
-            view.Append(postEntry, stepIdentity: null, matchKey: "k1");
-
-            Assert.True(view.TryMarkSkipped("k1"));
-            Assert.True(postEntry.IsSkipped);
-            Assert.Contains("(skipped — main step did not execute)", view.Yaml);
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Worker")]
-        public void TryMarkSkipped_ReturnsFalseForUnknownKey()
-        {
-            var view = new JobExecutionView("j");
-            Assert.False(view.TryMarkSkipped("nope"));
-            Assert.DoesNotContain("(skipped", view.Yaml);
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Worker")]
-        public void TryMarkSkipped_ReturnsFalseForClaimedPlaceholder()
-        {
-            var view = new JobExecutionView("j");
-            var postEntry = new JobExecutionViewEntry(JobExecutionPhase.Post, "Post X", uses: "actions/x@v1");
-            view.Append(postEntry, stepIdentity: null, matchKey: "k1");
-
-            var step = NewStep("real-post");
-            Assert.NotNull(view.TryClaim("k1", step));
-
-            // Already claimed — must not mark as skipped.
-            Assert.False(view.TryMarkSkipped("k1"));
-            Assert.False(postEntry.IsSkipped);
-        }
     }
 }

--- a/src/Test/L0/Worker/JobExecutionViewL0.cs
+++ b/src/Test/L0/Worker/JobExecutionViewL0.cs
@@ -1,0 +1,467 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GitHub.Runner.Worker;
+using GitHub.Runner.Worker.Dap;
+using Moq;
+using Xunit;
+
+namespace GitHub.Runner.Common.Tests.Worker
+{
+    public sealed class JobExecutionViewL0
+    {
+        private static JobExecutionViewEntry MainEntry(string name)
+        {
+            return new JobExecutionViewEntry(JobExecutionPhase.Main, name, run: name);
+        }
+
+        private static IStep NewStep(string displayName = "step")
+        {
+            var mock = new Mock<IStep>();
+            mock.Setup(s => s.DisplayName).Returns(displayName);
+            return mock.Object;
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Constructor_RendersEmptyView()
+        {
+            var view = new JobExecutionView("my-job");
+
+            Assert.Equal(0, view.EntryCount);
+            Assert.Contains("# Job: my-job", view.Yaml);
+            Assert.Contains("- step: Setup job", view.Yaml);
+            Assert.Contains("- step: Complete job", view.Yaml);
+
+            // Only the two synthetic boundaries appear.
+            int stepCount = view.Yaml.Split("- step: ").Length - 1;
+            Assert.Equal(2, stepCount);
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Constructor_ThrowsOnInvalidJobId(string jobId)
+        {
+            Assert.Throws<ArgumentException>(() => new JobExecutionView(jobId));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Append_IncrementsEntryCount()
+        {
+            var view = new JobExecutionView("j");
+
+            int line0 = view.Append(MainEntry("a"));
+            int line1 = view.Append(MainEntry("b"));
+            int line2 = view.Append(MainEntry("c"));
+
+            Assert.Equal(3, view.EntryCount);
+            Assert.True(line0 < line1);
+            Assert.True(line1 < line2);
+            Assert.Equal(line0, view.GetLine(0));
+            Assert.Equal(line1, view.GetLine(1));
+            Assert.Equal(line2, view.GetLine(2));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Append_PreservesPriorEntryLines()
+        {
+            var view = new JobExecutionView("j");
+
+            int l0 = view.Append(MainEntry("a"));
+            int l1 = view.Append(MainEntry("b"));
+            int l2 = view.Append(MainEntry("c"));
+
+            view.Append(MainEntry("d"));
+            Assert.Equal(l0, view.GetLine(0));
+            Assert.Equal(l1, view.GetLine(1));
+            Assert.Equal(l2, view.GetLine(2));
+
+            view.Append(MainEntry("e"));
+            Assert.Equal(l0, view.GetLine(0));
+            Assert.Equal(l1, view.GetLine(1));
+            Assert.Equal(l2, view.GetLine(2));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Append_RegistersStepIdentity()
+        {
+            var view = new JobExecutionView("j");
+            var step = NewStep();
+
+            int line = view.Append(MainEntry("a"), step);
+
+            Assert.Equal(line, view.GetLine(0));
+            Assert.Equal(line, view.TryGetLineForStep(step));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Append_NullStepIdentity_StillAppends()
+        {
+            var view = new JobExecutionView("j");
+
+            view.Append(MainEntry("a"), stepIdentity: null);
+
+            Assert.Equal(1, view.EntryCount);
+            Assert.Null(view.TryGetLineForStep(null));
+            Assert.Contains("- step: a", view.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Append_DuplicateStepIdentity_Throws()
+        {
+            var view = new JobExecutionView("j");
+            var step = NewStep();
+
+            view.Append(MainEntry("a"), step);
+            Assert.Throws<InvalidOperationException>(() => view.Append(MainEntry("b"), step));
+
+            // State preserved: only the first entry is present.
+            Assert.Equal(1, view.EntryCount);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Append_NullEntry_Throws()
+        {
+            var view = new JobExecutionView("j");
+            Assert.Throws<ArgumentNullException>(() => view.Append(null));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void AppendRange_AppendsAllAndRendersOnce()
+        {
+            var view = new JobExecutionView("j");
+            var steps = Enumerable.Range(0, 5).Select(i => NewStep("s" + i)).ToList();
+            var items = steps
+                .Select((s, i) => (entry: MainEntry("e" + i), stepIdentity: s))
+                .ToList();
+
+            view.AppendRange(items);
+
+            Assert.Equal(5, view.EntryCount);
+            for (int i = 0; i < 5; i++)
+            {
+                int line = view.GetLine(i);
+                Assert.Equal(line, view.TryGetLineForStep(steps[i]));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void AppendRange_RejectsDuplicateInInput()
+        {
+            var view = new JobExecutionView("j");
+            var dup = NewStep();
+            var items = new List<(JobExecutionViewEntry, IStep)>
+            {
+                (MainEntry("a"), dup),
+                (MainEntry("b"), dup),
+            };
+
+            Assert.Throws<InvalidOperationException>(() => view.AppendRange(items));
+            Assert.Equal(0, view.EntryCount);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void AppendRange_RejectsOverlapWithExisting()
+        {
+            var view = new JobExecutionView("j");
+            var step = NewStep();
+            view.Append(MainEntry("a"), step);
+
+            var items = new List<(JobExecutionViewEntry, IStep)>
+            {
+                (MainEntry("b"), step),
+            };
+
+            Assert.Throws<InvalidOperationException>(() => view.AppendRange(items));
+            Assert.Equal(1, view.EntryCount);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void AppendRange_NullItems_Throws()
+        {
+            var view = new JobExecutionView("j");
+            Assert.Throws<ArgumentNullException>(() => view.AppendRange(null));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void TryGetLineForStep_NullStep_ReturnsNull()
+        {
+            var view = new JobExecutionView("j");
+            Assert.Null(view.TryGetLineForStep(null));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void TryGetLineForStep_UnknownStep_ReturnsNull()
+        {
+            var view = new JobExecutionView("j");
+            var step = NewStep();
+            Assert.Null(view.TryGetLineForStep(step));
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData(-1)]
+        [InlineData(2)]
+        public void GetLine_OutOfRange_Throws(int index)
+        {
+            var view = new JobExecutionView("j");
+            view.Append(MainEntry("a"));
+            view.Append(MainEntry("b"));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => view.GetLine(index));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Yaml_UpdatesAfterAppend()
+        {
+            var view = new JobExecutionView("j");
+            view.Append(MainEntry("first"));
+            string before = view.Yaml;
+            Assert.Contains("- step: first", before);
+
+            view.Append(MainEntry("second"));
+            string after = view.Yaml;
+
+            Assert.Contains("- step: first", after);
+            Assert.Contains("- step: second", after);
+            Assert.NotEqual(before, after);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Yaml_AlwaysEndsWithCleanupBoundary()
+        {
+            var view = new JobExecutionView("j");
+            Assert.EndsWith("cleanup:\n  - step: Complete job\n", view.Yaml);
+
+            view.Append(MainEntry("a"));
+            Assert.EndsWith("cleanup:\n  - step: Complete job\n", view.Yaml);
+
+            view.Append(MainEntry("b"));
+            view.Append(MainEntry("c"));
+            Assert.EndsWith("cleanup:\n  - step: Complete job\n", view.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Append_WithMatchKey_TracksUnclaimed()
+        {
+            var view = new JobExecutionView("j");
+
+            int line = view.Append(MainEntry("placeholder"), stepIdentity: null, matchKey: "k1");
+
+            var step = NewStep("real");
+            int? claimed = view.TryClaim("k1", step);
+            Assert.Equal(line, claimed);
+            Assert.Equal(line, view.TryGetLineForStep(step));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void TryClaim_UnknownKey_ReturnsNull()
+        {
+            var view = new JobExecutionView("j");
+            view.Append(MainEntry("a"), stepIdentity: null, matchKey: "k1");
+
+            Assert.Null(view.TryClaim("nope", NewStep()));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void TryClaim_AlreadyClaimed_ReturnsNull()
+        {
+            var view = new JobExecutionView("j");
+            view.Append(MainEntry("a"), stepIdentity: null, matchKey: "k1");
+
+            var first = NewStep("first");
+            Assert.NotNull(view.TryClaim("k1", first));
+
+            var second = NewStep("second");
+            Assert.Null(view.TryClaim("k1", second));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void TryClaim_StepAlreadyRegistered_ReturnsNull()
+        {
+            var view = new JobExecutionView("j");
+            var step = NewStep();
+            // Step is registered for the first entry.
+            view.Append(MainEntry("a"), step);
+            // A placeholder is registered for the second entry.
+            view.Append(MainEntry("b"), stepIdentity: null, matchKey: "k1");
+
+            // Trying to claim the placeholder with the already-registered
+            // step must return null (defensive — would otherwise double-bind).
+            Assert.Null(view.TryClaim("k1", step));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Append_DuplicateMatchKey_Throws()
+        {
+            var view = new JobExecutionView("j");
+            view.Append(MainEntry("a"), stepIdentity: null, matchKey: "k1");
+
+            Assert.Throws<InvalidOperationException>(
+                () => view.Append(MainEntry("b"), stepIdentity: null, matchKey: "k1"));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Append_MatchKeyNull_BehavesLikeOldOverload()
+        {
+            var view = new JobExecutionView("j");
+            var step = NewStep();
+
+            int line = view.Append(MainEntry("a"), step);
+
+            Assert.Equal(line, view.GetLine(0));
+            Assert.Equal(line, view.TryGetLineForStep(step));
+            // TryClaim with any key must return null since no matchKey was registered.
+            Assert.Null(view.TryClaim("anything", NewStep()));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void TryClaim_AfterClaim_TryGetLineForStepResolves()
+        {
+            var view = new JobExecutionView("j");
+            int line = view.Append(MainEntry("placeholder"), stepIdentity: null, matchKey: "k1");
+
+            var step = NewStep();
+            Assert.Equal(line, view.TryClaim("k1", step));
+            Assert.Equal(line, view.TryGetLineForStep(step));
+
+            // And a later Append doesn't lose the claim (Render rebuilds
+            // the IStep -> line map from the persisted identities).
+            view.Append(MainEntry("b"));
+            Assert.Equal(line, view.TryGetLineForStep(step));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void TryClaim_NullArgs_Throws()
+        {
+            var view = new JobExecutionView("j");
+            Assert.Throws<ArgumentNullException>(() => view.TryClaim(null, NewStep()));
+            Assert.Throws<ArgumentNullException>(() => view.TryClaim("k", null));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task ConcurrentAppends_DontCorruptState()
+        {
+            var view = new JobExecutionView("j");
+            const int N = 50;
+            var steps = Enumerable.Range(0, N).Select(i => NewStep("s" + i)).ToList();
+            var returnedLines = new ConcurrentBag<int>();
+
+            var tasks = Enumerable.Range(0, N).Select(i => Task.Run(() =>
+            {
+                int line = view.Append(MainEntry("e" + i), steps[i]);
+                returnedLines.Add(line);
+            })).ToArray();
+
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(N, view.EntryCount);
+            Assert.Equal(N, returnedLines.Distinct().Count());
+
+            // Every step identity resolves to some line in [0, N).
+            var entryLines = Enumerable.Range(0, N).Select(view.GetLine).ToHashSet();
+            Assert.Equal(N, entryLines.Count);
+            foreach (var step in steps)
+            {
+                int? line = view.TryGetLineForStep(step);
+                Assert.NotNull(line);
+                Assert.Contains(line.Value, entryLines);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void TryMarkSkipped_MarksUnclaimedPlaceholder()
+        {
+            var view = new JobExecutionView("j");
+            var postEntry = new JobExecutionViewEntry(JobExecutionPhase.Post, "Post X", uses: "actions/x@v1");
+            view.Append(postEntry, stepIdentity: null, matchKey: "k1");
+
+            Assert.True(view.TryMarkSkipped("k1"));
+            Assert.True(postEntry.IsSkipped);
+            Assert.Contains("(skipped — main step did not execute)", view.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void TryMarkSkipped_ReturnsFalseForUnknownKey()
+        {
+            var view = new JobExecutionView("j");
+            Assert.False(view.TryMarkSkipped("nope"));
+            Assert.DoesNotContain("(skipped", view.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void TryMarkSkipped_ReturnsFalseForClaimedPlaceholder()
+        {
+            var view = new JobExecutionView("j");
+            var postEntry = new JobExecutionViewEntry(JobExecutionPhase.Post, "Post X", uses: "actions/x@v1");
+            view.Append(postEntry, stepIdentity: null, matchKey: "k1");
+
+            var step = NewStep("real-post");
+            Assert.NotNull(view.TryClaim("k1", step));
+
+            // Already claimed — must not mark as skipped.
+            Assert.False(view.TryMarkSkipped("k1"));
+            Assert.False(postEntry.IsSkipped);
+        }
+    }
+}

--- a/src/Test/L0/Worker/JobExecutionViewRendererL0.cs
+++ b/src/Test/L0/Worker/JobExecutionViewRendererL0.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using GitHub.Runner.Worker.Dap;
 using Xunit;
 

--- a/src/Test/L0/Worker/JobExecutionViewRendererL0.cs
+++ b/src/Test/L0/Worker/JobExecutionViewRendererL0.cs
@@ -585,38 +585,6 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public void Render_EmitsSkippedAnnotationForMarkedEntry()
-        {
-            var entry = new JobExecutionViewEntry(JobExecutionPhase.Post, "Post X", uses: "actions/x@v1");
-            entry.IsSkipped = true;
-
-            var result = JobExecutionViewRenderer.Render("j", new[] { entry });
-
-            // Annotation is inline on the `- step:` line so subsequent
-            // entry line numbers stay stable.
-            Assert.Contains("- step: Post X  # (skipped — main step did not execute)\n", result.Yaml);
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Worker")]
-        public void Render_SkippedAnnotation_DoesNotShiftSubsequentLines()
-        {
-            var skipped = new JobExecutionViewEntry(JobExecutionPhase.Post, "Post A", uses: "actions/a@v1");
-            var following = new JobExecutionViewEntry(JobExecutionPhase.Post, "Post B", uses: "actions/b@v1");
-
-            var unmarked = JobExecutionViewRenderer.Render("j", new[] { skipped, following });
-            skipped.IsSkipped = true;
-            var marked = JobExecutionViewRenderer.Render("j", new[] { skipped, following });
-
-            // Following entry's start line must not move when the prior
-            // entry gets an inline skipped annotation.
-            Assert.Equal(unmarked.EntryStartLines[1], marked.EntryStartLines[1]);
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Worker")]
         public void Render_AlwaysUsesLfLineBreaks()
         {
             // Regression: YamlDotNet's Emitter calls WriteLine, which on

--- a/src/Test/L0/Worker/JobExecutionViewRendererL0.cs
+++ b/src/Test/L0/Worker/JobExecutionViewRendererL0.cs
@@ -613,5 +613,31 @@ namespace GitHub.Runner.Common.Tests.Worker
             // entry gets an inline skipped annotation.
             Assert.Equal(unmarked.EntryStartLines[1], marked.EntryStartLines[1]);
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_AlwaysUsesLfLineBreaks()
+        {
+            // Regression: YamlDotNet's Emitter calls WriteLine, which on
+            // Windows produces CRLF (the host's Environment.NewLine).
+            // FormatScalar / TemplateTokenYamlAdapter.Serialize must force
+            // LF so the rendered view round-trips regardless of platform.
+            var entry = new JobExecutionViewEntry(JobExecutionPhase.Main, "with: colon", id: "step-1", uses: "actions/checkout@v4");
+            var result = JobExecutionViewRenderer.Render("job-1", new[] { entry });
+            Assert.DoesNotContain("\r", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void FormatScalar_AlwaysUsesLfLineBreaks()
+        {
+            // Direct check on FormatScalar to guard against future refactors
+            // that bypass the full Render path but still emit through
+            // YamlDotNet.
+            Assert.DoesNotContain("\r", JobExecutionViewRenderer.FormatScalar("with: colon"));
+            Assert.DoesNotContain("\r", JobExecutionViewRenderer.FormatScalar("hello"));
+        }
     }
 }

--- a/src/Test/L0/Worker/JobExecutionViewRendererL0.cs
+++ b/src/Test/L0/Worker/JobExecutionViewRendererL0.cs
@@ -1,0 +1,617 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GitHub.Runner.Worker.Dap;
+using Xunit;
+
+namespace GitHub.Runner.Common.Tests.Worker
+{
+    public sealed class JobExecutionViewRendererL0
+    {
+        // Verbatim expected YAML for the design doc's "Worked example".
+        // The render output is structured as phase-keyed top-level sections;
+        // there is no per-entry `phase:` field. The setup: and cleanup:
+        // sections always render; pre:/main:/post: render only when
+        // they contain at least one entry. The Main entries surface
+        // user-authored step parameters pre-evaluation (no expression
+        // substitution); Pre/Post entries stay minimal.
+        private const string ExpectedWorkedExampleYaml =
+            "# Job: build\n" +
+            "# Runner execution plan — read-only.\n" +
+            "\n" +
+            "setup:\n" +
+            "  - step: Setup job\n" +
+            "\n" +
+            "pre:\n" +
+            "  - step: Pre actions/checkout@v4\n" +
+            "    action: actions/checkout@v4\n" +
+            "  - step: Pre actions/cache@v5\n" +
+            "    action: actions/cache@v5\n" +
+            "\n" +
+            "main:\n" +
+            "  - step: actions/checkout@v4\n" +
+            "    uses: actions/checkout@v4\n" +
+            "    source: .github/workflows/ci.yml:10\n" +
+            "  - step: Cache Primes\n" +
+            "    id: cache-primes\n" +
+            "    uses: actions/cache@v5\n" +
+            "    with:\n" +
+            "      path: prime-numbers\n" +
+            "      key: ${{ runner.os }}-primes\n" +
+            "    source: .github/workflows/ci.yml:12\n" +
+            "  - step: Run tests\n" +
+            "    id: test\n" +
+            "    run: |\n" +
+            "      echo starting\n" +
+            "      npm test\n" +
+            "    if: ${{ github.event_name == 'push' }}\n" +
+            "    env:\n" +
+            "      NODE_ENV: production\n" +
+            "    shell: bash\n" +
+            "    working-directory: ./api\n" +
+            "    source: .github/workflows/ci.yml:18\n" +
+            "  - step: npm ci\n" +
+            "    run: npm ci\n" +
+            "    source: .github/workflows/ci.yml:28\n" +
+            "\n" +
+            "post:\n" +
+            "  - step: Post actions/cache@v5\n" +
+            "    action: actions/cache@v5\n" +
+            "  - step: Post actions/checkout@v4\n" +
+            "    action: actions/checkout@v4\n" +
+            "\n" +
+            "cleanup:\n" +
+            "  - step: Complete job\n";
+
+        private static List<JobExecutionViewEntry> WorkedExampleEntries()
+        {
+            return new List<JobExecutionViewEntry>
+            {
+                new JobExecutionViewEntry(JobExecutionPhase.Pre, "Pre actions/checkout@v4", uses: "actions/checkout@v4"),
+                new JobExecutionViewEntry(JobExecutionPhase.Pre, "Pre actions/cache@v5", uses: "actions/cache@v5"),
+                new JobExecutionViewEntry(JobExecutionPhase.Main, "actions/checkout@v4", uses: "actions/checkout@v4", sourcePath: ".github/workflows/ci.yml", sourceLine: 10),
+                new JobExecutionViewEntry(
+                    JobExecutionPhase.Main,
+                    "Cache Primes",
+                    uses: "actions/cache@v5",
+                    id: "cache-primes",
+                    withYaml: "      path: prime-numbers\n      key: ${{ runner.os }}-primes",
+                    sourcePath: ".github/workflows/ci.yml",
+                    sourceLine: 12),
+                new JobExecutionViewEntry(
+                    JobExecutionPhase.Main,
+                    "Run tests",
+                    run: "echo starting\nnpm test",
+                    id: "test",
+                    @if: "${{ github.event_name == 'push' }}",
+                    envYaml: "      NODE_ENV: production",
+                    shell: "bash",
+                    workingDirectory: "./api",
+                    sourcePath: ".github/workflows/ci.yml",
+                    sourceLine: 18),
+                new JobExecutionViewEntry(JobExecutionPhase.Main, "npm ci", run: "npm ci", sourcePath: ".github/workflows/ci.yml", sourceLine: 28),
+                new JobExecutionViewEntry(JobExecutionPhase.Post, "Post actions/cache@v5", uses: "actions/cache@v5"),
+                new JobExecutionViewEntry(JobExecutionPhase.Post, "Post actions/checkout@v4", uses: "actions/checkout@v4"),
+            };
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_MatchesDesignDocWorkedExample()
+        {
+            var entries = WorkedExampleEntries();
+
+            var result = JobExecutionViewRenderer.Render("build", entries);
+
+            Assert.Equal(ExpectedWorkedExampleYaml, result.Yaml);
+            Assert.Equal(8, result.EntryStartLines.Count);
+            var lines = result.Yaml.Split('\n');
+            for (int i = 0; i < entries.Count; i++)
+            {
+                Assert.StartsWith("  - step: ", lines[result.EntryStartLines[i] - 1]);
+                Assert.Contains(entries[i].DisplayName, lines[result.EntryStartLines[i] - 1]);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_AlwaysEmitsSetupAndCleanup()
+        {
+            var result = JobExecutionViewRenderer.Render("job-1", new List<JobExecutionViewEntry>());
+
+            const string expected =
+                "# Job: job-1\n" +
+                "# Runner execution plan — read-only.\n" +
+                "\n" +
+                "setup:\n" +
+                "  - step: Setup job\n" +
+                "\n" +
+                "cleanup:\n" +
+                "  - step: Complete job\n";
+            Assert.Equal(expected, result.Yaml);
+            Assert.Empty(result.EntryStartLines);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_OmitsEmptyOptionalSections()
+        {
+            // Only a Main entry — pre:/post: must not appear.
+            var result = JobExecutionViewRenderer.Render("j", new[]
+            {
+                new JobExecutionViewEntry(JobExecutionPhase.Main, "echo", run: "echo hello"),
+            });
+
+            Assert.Contains("setup:\n", result.Yaml);
+            Assert.Contains("main:\n", result.Yaml);
+            Assert.Contains("cleanup:\n", result.Yaml);
+            Assert.DoesNotContain("\npre:\n", result.Yaml);
+            Assert.DoesNotContain("\npost:\n", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_EmitsPhaseSectionsInFixedOrder()
+        {
+            // Input order [Post, Pre, Main] should still render as setup → pre → main → post → cleanup.
+            var entries = new[]
+            {
+                new JobExecutionViewEntry(JobExecutionPhase.Post, "post-a", uses: "a/b@v1"),
+                new JobExecutionViewEntry(JobExecutionPhase.Pre, "pre-a", uses: "a/b@v1"),
+                new JobExecutionViewEntry(JobExecutionPhase.Main, "main-a", uses: "a/b@v1"),
+            };
+
+            var result = JobExecutionViewRenderer.Render("j", entries);
+            string yaml = result.Yaml;
+
+            int setupIdx = yaml.IndexOf("setup:\n", StringComparison.Ordinal);
+            int preIdx = yaml.IndexOf("\npre:\n", StringComparison.Ordinal);
+            int mainIdx = yaml.IndexOf("\nmain:\n", StringComparison.Ordinal);
+            int postIdx = yaml.IndexOf("\npost:\n", StringComparison.Ordinal);
+            int cleanupIdx = yaml.IndexOf("\ncleanup:\n", StringComparison.Ordinal);
+            Assert.True(setupIdx >= 0 && preIdx > setupIdx && mainIdx > preIdx && postIdx > mainIdx && cleanupIdx > postIdx,
+                $"section ordering wrong: setup={setupIdx} pre={preIdx} main={mainIdx} post={postIdx} cleanup={cleanupIdx}");
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_StartLinesAlignWithInputOrder()
+        {
+            // Input order is [Pre, Main, Post]; output order is also pre/main/post,
+            // but startLines must be indexed by INPUT position, not by section.
+            var entries = new[]
+            {
+                new JobExecutionViewEntry(JobExecutionPhase.Pre, "pre-x", uses: "x/y@v1"),     // index 0
+                new JobExecutionViewEntry(JobExecutionPhase.Main, "main-x", uses: "x/y@v1"),    // index 1
+                new JobExecutionViewEntry(JobExecutionPhase.Post, "post-x", uses: "x/y@v1"),    // index 2
+            };
+
+            var result = JobExecutionViewRenderer.Render("j", entries);
+            var lines = result.Yaml.Split('\n');
+
+            Assert.StartsWith("  - step: pre-x", lines[result.EntryStartLines[0] - 1]);
+            Assert.StartsWith("  - step: main-x", lines[result.EntryStartLines[1] - 1]);
+            Assert.StartsWith("  - step: post-x", lines[result.EntryStartLines[2] - 1]);
+            // And input-order ordering of start lines is strictly increasing
+            // when phases are in declaration order matching the section order.
+            Assert.True(result.EntryStartLines[0] < result.EntryStartLines[1]);
+            Assert.True(result.EntryStartLines[1] < result.EntryStartLines[2]);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_StartLinesFollowInputOrderEvenWhenPhasesAreInterleaved()
+        {
+            // Input order is [Main A, Pre B, Main C]: pre section will render
+            // first (Pre B) and main second (Main A then Main C). startLines
+            // must still be indexed by input order.
+            var entries = new[]
+            {
+                new JobExecutionViewEntry(JobExecutionPhase.Main, "main-a", uses: "a@v1"),  // index 0 — renders in main section
+                new JobExecutionViewEntry(JobExecutionPhase.Pre, "pre-b", uses: "b@v1"),    // index 1 — renders in pre section
+                new JobExecutionViewEntry(JobExecutionPhase.Main, "main-c", uses: "c@v1"),  // index 2 — renders in main section
+            };
+
+            var result = JobExecutionViewRenderer.Render("j", entries);
+            var lines = result.Yaml.Split('\n');
+
+            Assert.StartsWith("  - step: main-a", lines[result.EntryStartLines[0] - 1]);
+            Assert.StartsWith("  - step: pre-b", lines[result.EntryStartLines[1] - 1]);
+            Assert.StartsWith("  - step: main-c", lines[result.EntryStartLines[2] - 1]);
+            // The pre section comes before main: input-index-1 entry's line is
+            // before input-index-0 entry's line.
+            Assert.True(result.EntryStartLines[1] < result.EntryStartLines[0]);
+            Assert.True(result.EntryStartLines[0] < result.EntryStartLines[2]);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_EntryStartLinesPointAtStepKeys()
+        {
+            var entries = WorkedExampleEntries();
+            var result = JobExecutionViewRenderer.Render("build", entries);
+            var lines = result.Yaml.Split('\n');
+
+            for (int i = 0; i < result.EntryStartLines.Count; i++)
+            {
+                int oneBased = result.EntryStartLines[i];
+                Assert.True(oneBased >= 1 && oneBased <= lines.Length, $"start line {oneBased} out of range");
+                Assert.StartsWith("  - step: ", lines[oneBased - 1]);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_EntryStartLinesExcludeSetupAndCleanup()
+        {
+            var entries = WorkedExampleEntries();
+            var result = JobExecutionViewRenderer.Render("build", entries);
+            var lines = result.Yaml.Split('\n');
+
+            int setupLine = -1, cleanupLine = -1;
+            for (int i = 0; i < lines.Length; i++)
+            {
+                if (lines[i] == "  - step: Setup job") setupLine = i + 1;
+                if (lines[i] == "  - step: Complete job") cleanupLine = i + 1;
+            }
+            Assert.True(setupLine > 0 && cleanupLine > 0, "Setup/Cleanup lines must exist");
+            Assert.DoesNotContain(setupLine, result.EntryStartLines);
+            Assert.DoesNotContain(cleanupLine, result.EntryStartLines);
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData("hello")]
+        [InlineData("with: colon")]
+        [InlineData("with#hash")]
+        [InlineData(" leading")]
+        [InlineData("trailing ")]
+        [InlineData("a\"b")]
+        [InlineData("a\\b")]
+        [InlineData("@at")]
+        [InlineData("*star")]
+        public void Render_QuotesSpecialChars(string displayName)
+        {
+            // Round-trip the rendered YAML through YamlDotNet's deserializer
+            // and assert the parsed step's display name matches the input.
+            // This decouples the test from any specific quoting style.
+            var entry = new JobExecutionViewEntry(JobExecutionPhase.Main, displayName);
+            var result = JobExecutionViewRenderer.Render("j", new[] { entry });
+
+            var deserializer = new YamlDotNet.Serialization.DeserializerBuilder().Build();
+            var doc = deserializer.Deserialize<Dictionary<string, List<Dictionary<string, object>>>>(result.Yaml);
+            Assert.NotNull(doc);
+            Assert.True(doc.ContainsKey("main"), "rendered YAML missing top-level 'main' key");
+            var mainSteps = doc["main"];
+            Assert.Single(mainSteps);
+            Assert.Equal(displayName, mainSteps[0]["step"] as string);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_EmitsSourceAnnotationForMainStep()
+        {
+            var entry = new JobExecutionViewEntry(
+                JobExecutionPhase.Main,
+                "npm ci",
+                run: "npm ci",
+                sourcePath: ".github/workflows/ci.yml",
+                sourceLine: 42);
+
+            var result = JobExecutionViewRenderer.Render("j", new[] { entry });
+
+            Assert.Contains("    source: .github/workflows/ci.yml:42\n", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_OmitsSourceAnnotationForPreAndPost()
+        {
+            var pre = new JobExecutionViewEntry(
+                JobExecutionPhase.Pre,
+                "Pre actions/checkout@v4",
+                uses: "actions/checkout@v4",
+                sourcePath: ".github/workflows/ci.yml",
+                sourceLine: 9);
+            var post = new JobExecutionViewEntry(
+                JobExecutionPhase.Post,
+                "Post actions/checkout@v4",
+                uses: "actions/checkout@v4",
+                sourcePath: ".github/workflows/ci.yml",
+                sourceLine: 9);
+
+            var result = JobExecutionViewRenderer.Render("j", new[] { pre, post });
+
+            Assert.DoesNotContain("source:", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_EmitsMultilineRunAsBlockScalar()
+        {
+            var entry = new JobExecutionViewEntry(
+                JobExecutionPhase.Main,
+                "multi",
+                run: "echo a\necho b\necho c");
+
+            var result = JobExecutionViewRenderer.Render("j", new[] { entry });
+
+            Assert.Contains("    run: |\n", result.Yaml);
+            Assert.Contains("      echo a\n", result.Yaml);
+            Assert.Contains("      echo b\n", result.Yaml);
+            Assert.Contains("      echo c\n", result.Yaml);
+            Assert.DoesNotContain("truncated", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_EmitsAllUserAuthoredParamsForActionStep()
+        {
+            var entry = new JobExecutionViewEntry(
+                JobExecutionPhase.Main,
+                "Run action",
+                uses: "actions/cache@v5",
+                id: "cache-primes",
+                @if: "${{ github.event_name == 'push' }}",
+                continueOnError: "true",
+                timeoutMinutes: "10",
+                envYaml: "      NODE_ENV: production",
+                withYaml: "      path: prime-numbers\n      key: ${{ runner.os }}-primes",
+                sourcePath: "ci.yml",
+                sourceLine: 5);
+
+            var result = JobExecutionViewRenderer.Render("j", new[] { entry });
+
+            Assert.Contains("    id: cache-primes\n", result.Yaml);
+            Assert.Contains("    uses: actions/cache@v5\n", result.Yaml);
+            Assert.Contains("    continue-on-error: true\n", result.Yaml);
+            Assert.Contains("    timeout-minutes: 10\n", result.Yaml);
+            Assert.Contains("    env:\n      NODE_ENV: production\n", result.Yaml);
+            Assert.Contains("    with:\n      path: prime-numbers\n      key: ${{ runner.os }}-primes\n", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_EmitsRunStepWithShellAndWorkingDirectory()
+        {
+            var entry = new JobExecutionViewEntry(
+                JobExecutionPhase.Main,
+                "Run tests",
+                run: "echo starting\nnpm test",
+                id: "test",
+                shell: "bash",
+                workingDirectory: "./api");
+
+            var result = JobExecutionViewRenderer.Render("j", new[] { entry });
+
+            Assert.Contains("    run: |\n      echo starting\n      npm test\n", result.Yaml);
+            Assert.Contains("    shell: bash\n", result.Yaml);
+            Assert.Contains("    working-directory: ./api\n", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_PreservesExpressionsInRenderedYaml()
+        {
+            var entry = new JobExecutionViewEntry(
+                JobExecutionPhase.Main,
+                "Cache",
+                uses: "actions/cache@v5",
+                withYaml: "      key: ${{ runner.os }}-primes");
+
+            var result = JobExecutionViewRenderer.Render("j", new[] { entry });
+
+            // Expressions render exactly as authored — no evaluation.
+            Assert.Contains("${{ runner.os }}-primes", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_PrePostStepsRemainMinimal()
+        {
+            // Even if a pre/post entry carries user-param fields (it shouldn't
+            // in production, but the renderer must defensively drop them),
+            // only step: + action: render for these phases.
+            var pre = new JobExecutionViewEntry(
+                JobExecutionPhase.Pre,
+                "Pre actions/cache@v5",
+                uses: "actions/cache@v5",
+                id: "should-not-appear",
+                envYaml: "      X: y",
+                withYaml: "      key: nope");
+            var post = new JobExecutionViewEntry(
+                JobExecutionPhase.Post,
+                "Post actions/cache@v5",
+                uses: "actions/cache@v5",
+                id: "should-not-appear",
+                envYaml: "      X: y");
+
+            var result = JobExecutionViewRenderer.Render("j", new[] { pre, post });
+
+            Assert.DoesNotContain("id:", result.Yaml);
+            Assert.DoesNotContain("env:", result.Yaml);
+            Assert.DoesNotContain("with:", result.Yaml);
+            Assert.DoesNotContain("should-not-appear", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_FieldOrderIsStable()
+        {
+            var entry = new JobExecutionViewEntry(
+                JobExecutionPhase.Main,
+                "Everything",
+                uses: "actions/cache@v5",
+                id: "x",
+                @if: "always()",
+                continueOnError: "false",
+                timeoutMinutes: "5",
+                envYaml: "      A: 1",
+                withYaml: "      key: k",
+                sourcePath: "ci.yml",
+                sourceLine: 1);
+
+            var result = JobExecutionViewRenderer.Render("j", new[] { entry });
+            var y = result.Yaml;
+            int iStep = y.IndexOf("    - step: ", StringComparison.Ordinal) >= 0
+                ? y.IndexOf("- step:", StringComparison.Ordinal) : y.IndexOf("- step:", StringComparison.Ordinal);
+            int iId = y.IndexOf("    id:", StringComparison.Ordinal);
+            int iUses = y.IndexOf("    uses:", StringComparison.Ordinal);
+            int iIf = y.IndexOf("    if:", StringComparison.Ordinal);
+            int iCoe = y.IndexOf("    continue-on-error:", StringComparison.Ordinal);
+            int iTm = y.IndexOf("    timeout-minutes:", StringComparison.Ordinal);
+            int iEnv = y.IndexOf("    env:", StringComparison.Ordinal);
+            int iWith = y.IndexOf("    with:", StringComparison.Ordinal);
+            int iSrc = y.IndexOf("    source:", StringComparison.Ordinal);
+            Assert.True(iId < iUses && iUses < iIf && iIf < iCoe && iCoe < iTm && iTm < iEnv && iEnv < iWith && iWith < iSrc,
+                $"order wrong: id={iId} uses={iUses} if={iIf} coe={iCoe} tm={iTm} env={iEnv} with={iWith} src={iSrc}");
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_OmitsEmptyOptionalFields()
+        {
+            var entry = new JobExecutionViewEntry(
+                JobExecutionPhase.Main,
+                "bare",
+                uses: "a/b@v1");
+
+            var result = JobExecutionViewRenderer.Render("j", new[] { entry });
+            Assert.DoesNotContain("    id:", result.Yaml);
+            Assert.DoesNotContain("    if:", result.Yaml);
+            Assert.DoesNotContain("    continue-on-error:", result.Yaml);
+            Assert.DoesNotContain("    timeout-minutes:", result.Yaml);
+            Assert.DoesNotContain("    env:", result.Yaml);
+            Assert.DoesNotContain("    with:", result.Yaml);
+            Assert.DoesNotContain("    shell:", result.Yaml);
+            Assert.DoesNotContain("    working-directory:", result.Yaml);
+            Assert.DoesNotContain("    source:", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_HandlesEmptyEntries()
+        {
+            var result = JobExecutionViewRenderer.Render("j", new List<JobExecutionViewEntry>());
+
+            Assert.Empty(result.EntryStartLines);
+            Assert.Contains("  - step: Setup job\n", result.Yaml);
+            Assert.Contains("  - step: Complete job\n", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_NoPerEntryPhaseField()
+        {
+            // The phase: <value> per-entry field is gone — the section
+            // header is the phase indicator. Guard against accidental
+            // regressions.
+            var result = JobExecutionViewRenderer.Render("build", WorkedExampleEntries());
+            Assert.DoesNotContain("phase:", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_ThrowsOnNullJobId()
+        {
+            Assert.Throws<ArgumentException>(
+                () => JobExecutionViewRenderer.Render(null, new List<JobExecutionViewEntry>()));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_ThrowsOnWhitespaceJobId()
+        {
+            Assert.Throws<ArgumentException>(
+                () => JobExecutionViewRenderer.Render("   ", new List<JobExecutionViewEntry>()));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_ThrowsOnNullEntries()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => JobExecutionViewRenderer.Render("j", null));
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData(null, 1)]
+        [InlineData("", 1)]
+        [InlineData("   ", 1)]
+        public void Entry_Constructor_RejectsBadDisplayName(string displayName, int sourceLine)
+        {
+            Assert.Throws<ArgumentException>(
+                () => new JobExecutionViewEntry(JobExecutionPhase.Main, displayName, sourceLine: sourceLine));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Entry_Constructor_RejectsZeroLineWhenSourcePathSet()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new JobExecutionViewEntry(
+                    JobExecutionPhase.Main,
+                    "ok",
+                    sourcePath: "ci.yml",
+                    sourceLine: 0));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_EmitsSkippedAnnotationForMarkedEntry()
+        {
+            var entry = new JobExecutionViewEntry(JobExecutionPhase.Post, "Post X", uses: "actions/x@v1");
+            entry.IsSkipped = true;
+
+            var result = JobExecutionViewRenderer.Render("j", new[] { entry });
+
+            // Annotation is inline on the `- step:` line so subsequent
+            // entry line numbers stay stable.
+            Assert.Contains("- step: Post X  # (skipped — main step did not execute)\n", result.Yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Render_SkippedAnnotation_DoesNotShiftSubsequentLines()
+        {
+            var skipped = new JobExecutionViewEntry(JobExecutionPhase.Post, "Post A", uses: "actions/a@v1");
+            var following = new JobExecutionViewEntry(JobExecutionPhase.Post, "Post B", uses: "actions/b@v1");
+
+            var unmarked = JobExecutionViewRenderer.Render("j", new[] { skipped, following });
+            skipped.IsSkipped = true;
+            var marked = JobExecutionViewRenderer.Render("j", new[] { skipped, following });
+
+            // Following entry's start line must not move when the prior
+            // entry gets an inline skipped annotation.
+            Assert.Equal(unmarked.EntryStartLines[1], marked.EntryStartLines[1]);
+        }
+    }
+}

--- a/src/Test/L0/Worker/StepEntryTranslatorL0.cs
+++ b/src/Test/L0/Worker/StepEntryTranslatorL0.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using GitHub.DistributedTask.ObjectTemplating.Tokens;
 using GitHub.DistributedTask.Pipelines;
 using GitHub.Runner.Worker;
@@ -244,13 +243,17 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void Translate_RunStep_ExtractsShellAndWorkingDirectory()
         {
+            // The runner stores run-step inputs under the keys defined in
+            // PipelineConstants.ScriptStepInputs (camelCase), NOT their
+            // kebab-case workflow-YAML spellings — see
+            // ActionManifestManagerWrapper:244.
             var action = new ActionStep
             {
                 Reference = new ScriptReference(),
                 Inputs = Map(
-                    ("script", Str("npm test")),
-                    ("shell", Str("bash")),
-                    ("working-directory", Str("./api"))),
+                    (PipelineConstants.ScriptStepInputs.Script, Str("npm test")),
+                    (PipelineConstants.ScriptStepInputs.Shell, Str("bash")),
+                    (PipelineConstants.ScriptStepInputs.WorkingDirectory, Str("./api"))),
             };
             var mock = NewActionRunnerMock(ActionRunStage.Main, "Run", new ScriptReference(), action);
 
@@ -276,9 +279,9 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Reference = reference,
                 Inputs = Map(
                     ("mode", Str("ci")),
-                    ("script", Str("leak")),
-                    ("shell", Str("leak")),
-                    ("working-directory", Str("leak"))),
+                    (PipelineConstants.ScriptStepInputs.Script, Str("leak")),
+                    (PipelineConstants.ScriptStepInputs.Shell, Str("leak")),
+                    (PipelineConstants.ScriptStepInputs.WorkingDirectory, Str("leak"))),
             };
             var mock = NewActionRunnerMock(ActionRunStage.Main, "Run", reference, action);
 
@@ -288,9 +291,9 @@ namespace GitHub.Runner.Common.Tests.Worker
             Assert.NotNull(entry.WithYaml);
             Assert.Contains("mode: ci", entry.WithYaml);
             Assert.DoesNotContain("leak", entry.WithYaml);
-            Assert.DoesNotContain("script", entry.WithYaml);
-            Assert.DoesNotContain("shell", entry.WithYaml);
-            Assert.DoesNotContain("working-directory", entry.WithYaml);
+            Assert.DoesNotContain(PipelineConstants.ScriptStepInputs.Script, entry.WithYaml);
+            Assert.DoesNotContain(PipelineConstants.ScriptStepInputs.Shell, entry.WithYaml);
+            Assert.DoesNotContain(PipelineConstants.ScriptStepInputs.WorkingDirectory, entry.WithYaml);
         }
 
         [Fact]

--- a/src/Test/L0/Worker/StepEntryTranslatorL0.cs
+++ b/src/Test/L0/Worker/StepEntryTranslatorL0.cs
@@ -1,0 +1,425 @@
+﻿using System;
+using System.Collections.Generic;
+using GitHub.DistributedTask.ObjectTemplating.Tokens;
+using GitHub.DistributedTask.Pipelines;
+using GitHub.Runner.Worker;
+using GitHub.Runner.Worker.Dap;
+using Moq;
+using Xunit;
+
+namespace GitHub.Runner.Common.Tests.Worker
+{
+    public sealed class StepEntryTranslatorL0
+    {
+        private static StringToken Str(string s) => new(null, null, null, s);
+
+        private static MappingToken Map(params (string Key, TemplateToken Value)[] pairs)
+        {
+            var m = new MappingToken(null, null, null);
+            foreach (var (k, v) in pairs)
+            {
+                m.Add(Str(k), v);
+            }
+            return m;
+        }
+
+        private static Mock<IActionRunner> NewActionRunnerMock(
+            ActionRunStage stage,
+            string displayName,
+            ActionStepDefinitionReference reference,
+            ActionStep actionOverride = null)
+        {
+            var mock = new Mock<IActionRunner>();
+            mock.SetupGet(x => x.Stage).Returns(stage);
+            mock.SetupGet(x => x.DisplayName).Returns(displayName);
+            mock.SetupGet(x => x.Action).Returns(actionOverride ?? new ActionStep
+            {
+                Reference = reference,
+            });
+            return mock;
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_NullStep_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                StepEntryTranslator.TryTranslate(null));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_JobExtensionRunner_ReturnsNull()
+        {
+            var step = new JobExtensionRunner(
+                runAsync: (_, __) => System.Threading.Tasks.Task.CompletedTask,
+                condition: null,
+                displayName: "Set up job",
+                data: null);
+
+            Assert.Null(StepEntryTranslator.TryTranslate(step));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_OtherIStepType_ReturnsNull()
+        {
+            var mock = new Mock<IStep>();
+            mock.SetupGet(x => x.DisplayName).Returns("custom");
+
+            Assert.Null(StepEntryTranslator.TryTranslate(mock.Object));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionRunnerPre_ReturnsPreEntry()
+        {
+            var reference = new RepositoryPathReference
+            {
+                Name = "actions/checkout",
+                Ref = "v4",
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Pre, "Pre Run actions/checkout@v4", reference);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Equal(JobExecutionPhase.Pre, entry.Phase);
+            Assert.Equal("Pre Run actions/checkout@v4", entry.DisplayName);
+            Assert.Equal("actions/checkout@v4", entry.Uses);
+            Assert.Null(entry.Run);
+            Assert.Null(entry.SourcePath);
+            Assert.Equal(0, entry.SourceLine);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionRunnerMain_ReturnsMainEntryWithUses()
+        {
+            var reference = new RepositoryPathReference
+            {
+                Name = "actions/setup-node",
+                Path = "subdir",
+                Ref = "v3",
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Run actions/setup-node@v3", reference);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Equal(JobExecutionPhase.Main, entry.Phase);
+            Assert.Equal("actions/setup-node/subdir@v3", entry.Uses);
+            Assert.Null(entry.Run);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionRunnerMain_ScriptReference_LeavesUsesNull()
+        {
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Run echo hi", new ScriptReference());
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Equal(JobExecutionPhase.Main, entry.Phase);
+            Assert.Null(entry.Uses);
+            Assert.Null(entry.Run);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionRunnerMain_ContainerReference_UsesImage()
+        {
+            var reference = new ContainerRegistryReference { Image = "alpine:3.18" };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Run alpine", reference);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Equal("alpine:3.18", entry.Uses);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionRunnerPost_ReturnsPostEntry()
+        {
+            var reference = new RepositoryPathReference { Name = "actions/cache", Ref = "v3" };
+            var mock = NewActionRunnerMock(ActionRunStage.Post, "Post Run actions/cache@v3", reference);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Equal(JobExecutionPhase.Post, entry.Phase);
+            Assert.Equal("Post Run actions/cache@v3", entry.DisplayName);
+            Assert.Equal("actions/cache@v3", entry.Uses);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionRunner_NullAction_LeavesUsesNull()
+        {
+            var mock = new Mock<IActionRunner>();
+            mock.SetupGet(x => x.Stage).Returns(ActionRunStage.Main);
+            mock.SetupGet(x => x.DisplayName).Returns("anonymous");
+            mock.SetupGet(x => x.Action).Returns((ActionStep)null);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Equal("anonymous", entry.DisplayName);
+            Assert.Null(entry.Uses);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionStep_ExtractsWith()
+        {
+            var reference = new RepositoryPathReference { Name = "actions/cache", Ref = "v5" };
+            var action = new ActionStep
+            {
+                Reference = reference,
+                Inputs = Map(("path", Str("prime-numbers")), ("key", Str("k"))),
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Cache", reference, action);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.NotNull(entry.WithYaml);
+            Assert.Contains("path: prime-numbers", entry.WithYaml);
+            Assert.Contains("key: k", entry.WithYaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionStep_PreservesExpressionInWith()
+        {
+            var reference = new RepositoryPathReference { Name = "actions/cache", Ref = "v5" };
+            var action = new ActionStep
+            {
+                Reference = reference,
+                Inputs = Map(("key", Str("${{ runner.os }}-primes"))),
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Cache", reference, action);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Contains("${{ runner.os }}-primes", entry.WithYaml);
+            Assert.DoesNotContain("Linux", entry.WithYaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_RunStep_ExtractsScript()
+        {
+            var action = new ActionStep
+            {
+                Reference = new ScriptReference(),
+                Inputs = Map(("script", Str("echo hi"))),
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Run echo", new ScriptReference(), action);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Null(entry.Uses);
+            Assert.Equal("echo hi", entry.Run);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_RunStep_ExtractsShellAndWorkingDirectory()
+        {
+            var action = new ActionStep
+            {
+                Reference = new ScriptReference(),
+                Inputs = Map(
+                    ("script", Str("npm test")),
+                    ("shell", Str("bash")),
+                    ("working-directory", Str("./api"))),
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Run", new ScriptReference(), action);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Equal("npm test", entry.Run);
+            Assert.Equal("bash", entry.Shell);
+            Assert.Equal("./api", entry.WorkingDirectory);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionStep_FiltersRunStepKeysFromWith()
+        {
+            // Defensive: an action step's Inputs should not contain
+            // run-step internal keys, but if it did, they must not
+            // surface in the with: rendering.
+            var reference = new RepositoryPathReference { Name = "a/b", Ref = "v1" };
+            var action = new ActionStep
+            {
+                Reference = reference,
+                Inputs = Map(
+                    ("mode", Str("ci")),
+                    ("script", Str("leak")),
+                    ("shell", Str("leak")),
+                    ("working-directory", Str("leak"))),
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Run", reference, action);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.NotNull(entry.WithYaml);
+            Assert.Contains("mode: ci", entry.WithYaml);
+            Assert.DoesNotContain("leak", entry.WithYaml);
+            Assert.DoesNotContain("script", entry.WithYaml);
+            Assert.DoesNotContain("shell", entry.WithYaml);
+            Assert.DoesNotContain("working-directory", entry.WithYaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionStep_OmitsEmptyEnv()
+        {
+            var reference = new RepositoryPathReference { Name = "a/b", Ref = "v1" };
+            var action = new ActionStep
+            {
+                Reference = reference,
+                Environment = new MappingToken(null, null, null),
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Run", reference, action);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Null(entry.EnvYaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionStep_ExtractsEnv()
+        {
+            var reference = new RepositoryPathReference { Name = "a/b", Ref = "v1" };
+            var action = new ActionStep
+            {
+                Reference = reference,
+                Environment = Map(("NODE_ENV", Str("production"))),
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Run", reference, action);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.NotNull(entry.EnvYaml);
+            Assert.Contains("NODE_ENV: production", entry.EnvYaml);
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("__1")]
+        [InlineData("__123")]
+        public void Translate_FiltersAutoGeneratedId(string contextName)
+        {
+            var reference = new RepositoryPathReference { Name = "a/b", Ref = "v1" };
+            var action = new ActionStep
+            {
+                Reference = reference,
+                ContextName = contextName,
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Run", reference, action);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Null(entry.Id);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_PreservesUserId()
+        {
+            var reference = new RepositoryPathReference { Name = "a/b", Ref = "v1" };
+            var action = new ActionStep
+            {
+                Reference = reference,
+                ContextName = "cache-primes",
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Cache", reference, action);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Equal("cache-primes", entry.Id);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_ActionStep_ExtractsCondition()
+        {
+            var reference = new RepositoryPathReference { Name = "a/b", Ref = "v1" };
+            var action = new ActionStep
+            {
+                Reference = reference,
+                Condition = "always()",
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Main, "Run", reference, action);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Equal("always()", entry.If);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Translate_PreEntry_OmitsUserParams()
+        {
+            // Pre entries stay minimal — they reference the same Action as
+            // Main, and duplicating params adds noise.
+            var reference = new RepositoryPathReference { Name = "a/b", Ref = "v1" };
+            var action = new ActionStep
+            {
+                Reference = reference,
+                ContextName = "user-id",
+                Condition = "always()",
+                Environment = Map(("X", Str("y"))),
+                Inputs = Map(("k", Str("v"))),
+            };
+            var mock = NewActionRunnerMock(ActionRunStage.Pre, "Pre a/b@v1", reference, action);
+
+            var entry = StepEntryTranslator.TryTranslate(mock.Object);
+
+            Assert.NotNull(entry);
+            Assert.Equal(JobExecutionPhase.Pre, entry.Phase);
+            Assert.Null(entry.Id);
+            Assert.Null(entry.If);
+            Assert.Null(entry.EnvYaml);
+            Assert.Null(entry.WithYaml);
+        }
+    }
+}

--- a/src/Test/L0/Worker/TemplateTokenYamlAdapterL0.cs
+++ b/src/Test/L0/Worker/TemplateTokenYamlAdapterL0.cs
@@ -170,5 +170,22 @@ namespace GitHub.Runner.Common.Tests.Worker
             string yaml = TemplateTokenYamlAdapter.Serialize(token, 0);
             Assert.False(yaml.EndsWith("\n"));
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_AlwaysUsesLfLineBreaks()
+        {
+            // Regression: YamlDotNet's Emitter calls WriteLine, which on
+            // Windows produces CRLF (the host's Environment.NewLine).
+            // Serialize must force LF so the rendered view round-trips
+            // regardless of platform.
+            var map = new MappingToken(null, null, null);
+            map.Add(Str("k1"), Str("v1"));
+            map.Add(Str("k2"), Num(2));
+            map.Add(Str("k3"), Bool(true));
+            string yaml = TemplateTokenYamlAdapter.Serialize(map, indentSpaces: 2);
+            Assert.DoesNotContain("\r", yaml);
+        }
     }
 }

--- a/src/Test/L0/Worker/TemplateTokenYamlAdapterL0.cs
+++ b/src/Test/L0/Worker/TemplateTokenYamlAdapterL0.cs
@@ -1,0 +1,155 @@
+﻿using GitHub.DistributedTask.ObjectTemplating.Tokens;
+using GitHub.Runner.Worker.Dap;
+using Xunit;
+
+namespace GitHub.Runner.Common.Tests.Worker
+{
+    public sealed class TemplateTokenYamlAdapterL0
+    {
+        private static StringToken Str(string s) => new(null, null, null, s);
+        private static BooleanToken Bool(bool b) => new(null, null, null, b);
+        private static NumberToken Num(double n) => new(null, null, null, n);
+        private static BasicExpressionToken Expr(string s) => new(null, null, null, s);
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_StringScalar()
+        {
+            Assert.Equal("hello", TemplateTokenYamlAdapter.Serialize(Str("hello"), 0));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_BooleanScalar()
+        {
+            Assert.Equal("true", TemplateTokenYamlAdapter.Serialize(Bool(true), 0));
+            Assert.Equal("false", TemplateTokenYamlAdapter.Serialize(Bool(false), 0));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_NumberScalar()
+        {
+            Assert.Equal("10", TemplateTokenYamlAdapter.Serialize(Num(10), 0));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_NullToken_RendersAsNull()
+        {
+            Assert.Equal("null", TemplateTokenYamlAdapter.Serialize(null, 0));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_PreservesBasicExpression()
+        {
+            var token = Expr("runner.os");
+            string yaml = TemplateTokenYamlAdapter.Serialize(token, 0);
+            Assert.Contains("${{ runner.os }}", yaml);
+            Assert.DoesNotContain("Linux", yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_PreservesCompositeExpressionInStringToken()
+        {
+            // Composite strings like `${{ runner.os }}-primes` are parsed
+            // as a StringToken whose value is exactly that literal. The
+            // adapter must round-trip the literal unchanged.
+            var token = Str("${{ runner.os }}-primes");
+            string yaml = TemplateTokenYamlAdapter.Serialize(token, 0);
+            Assert.Contains("${{ runner.os }}-primes", yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_NestedMapping()
+        {
+            var inner = new MappingToken(null, null, null);
+            inner.Add(Str("b"), Num(1));
+            inner.Add(Str("c"), Expr("x"));
+            var outer = new MappingToken(null, null, null);
+            outer.Add(Str("a"), inner);
+
+            string yaml = TemplateTokenYamlAdapter.Serialize(outer, 0);
+
+            Assert.Contains("a:", yaml);
+            Assert.Contains("b: 1", yaml);
+            Assert.Contains("c: ${{ x }}", yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_EmptyMapping()
+        {
+            var token = new MappingToken(null, null, null);
+            string yaml = TemplateTokenYamlAdapter.Serialize(token, 0);
+            Assert.Equal("{}", yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_EmptySequence()
+        {
+            var token = new SequenceToken(null, null, null);
+            string yaml = TemplateTokenYamlAdapter.Serialize(token, 0);
+            Assert.Equal("[]", yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_MultilineString_UsesBlockScalar()
+        {
+            var token = Str("line1\nline2\nline3");
+            string yaml = TemplateTokenYamlAdapter.Serialize(token, 0);
+            // Block-literal indicator `|` appears for multi-line scalars.
+            Assert.Contains("|", yaml);
+            Assert.Contains("line1", yaml);
+            Assert.Contains("line2", yaml);
+            Assert.Contains("line3", yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_IndentLevel_PrefixesNonEmptyLines()
+        {
+            var map = new MappingToken(null, null, null);
+            map.Add(Str("k1"), Str("v1"));
+            map.Add(Str("k2"), Str("v2"));
+
+            string yaml = TemplateTokenYamlAdapter.Serialize(map, indentSpaces: 4);
+
+            foreach (var line in yaml.Split('\n'))
+            {
+                if (line.Length > 0)
+                {
+                    Assert.StartsWith("    ", line);
+                }
+            }
+            Assert.Contains("k1: v1", yaml);
+            Assert.Contains("k2: v2", yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_NoTrailingNewline()
+        {
+            var token = Str("hello");
+            string yaml = TemplateTokenYamlAdapter.Serialize(token, 0);
+            Assert.False(yaml.EndsWith("\n"));
+        }
+    }
+}

--- a/src/Test/L0/Worker/TemplateTokenYamlAdapterL0.cs
+++ b/src/Test/L0/Worker/TemplateTokenYamlAdapterL0.cs
@@ -60,12 +60,31 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Trait("Category", "Worker")]
         public void Serialize_PreservesCompositeExpressionInStringToken()
         {
-            // Composite strings like `${{ runner.os }}-primes` are parsed
-            // as a StringToken whose value is exactly that literal. The
-            // adapter must round-trip the literal unchanged.
+            // A StringToken constructed directly with the literal text
+            // round-trips unchanged. (The workflow parser does NOT produce
+            // a StringToken for this input — see
+            // Serialize_ReversesFormatRewriteForCompositeExpression — but
+            // direct StringToken construction must still preserve the
+            // literal verbatim.)
             var token = Str("${{ runner.os }}-primes");
             string yaml = TemplateTokenYamlAdapter.Serialize(token, 0);
             Assert.Contains("${{ runner.os }}-primes", yaml);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Serialize_ReversesFormatRewriteForCompositeExpression()
+        {
+            // The workflow parser tokenizes a mixed scalar like
+            // `${{ runner.os }}-primes` as a single BasicExpressionToken
+            // whose internal expression is `format('{0}-primes', runner.os)`.
+            // The adapter must surface the author-facing form, not the
+            // parser's normalized rewrite.
+            var token = Expr("format('{0}-primes', runner.os)");
+            string yaml = TemplateTokenYamlAdapter.Serialize(token, 0);
+            Assert.Contains("${{ runner.os }}-primes", yaml);
+            Assert.DoesNotContain("format(", yaml);
         }
 
         [Fact]


### PR DESCRIPTION
This is part 1 of 2 of the work to serve the job "source" during debugging.

In this PR is all the code to build that representation: this is intended to be a 1:1 representation of how the runner sees the job it's executing rendered as YAML, it's _not_ the workflow file the job comes from; this allows us to consider pre and post actions steps as "lines" we can pause/add breakpoints (coming next) and show things exactly as the runner interprets them. We use YamlDotNet to render scalar values but we "hand-write" the source skeleton because we need to keep track of each step's line to be able to refer to it later (and to write comments but that's secondary at the moment).

<details>

<summary><strong>Example YAML served as source</strong></summary>

```yaml
# Job: build
# Runner execution plan — read-only.

setup:
  - step: Setup job

main:
  - step: Run actions/checkout@v6
    uses: actions/checkout@v6
    if: success()
  - step: Cache Primes
    id: cache-primes
    uses: actions/cache@v5
    if: success()
    with:
      path: prime-numbers
      key: ${{ runner.os }}-primes
  - step: Check prerequisites
    run: |
      echo banana
      echo "Checking system requirements..."
      echo "Node version: $(node --version 2>/dev/null || echo 'not installed')"
      echo "Python version: $(python3 --version 2>/dev/null || echo 'not installed')"
    if: success()
  - step: Install dependencies
    run: |
      cat > package.json << 'EOF'
      {
        "name": "demo",
        "scripts": {
          "build": "node build.js",
          "test": "node test.js"
        }
      }
      EOF
      cat > build.js << 'EOF'
      const fs = require('fs');
      const config = require('./config.json');
      fs.writeFileSync('dist/output.js', `// Built for ${config.env}`);
      EOF
    if: success()
  - step: Build
    run: |
      mkdir -p dist
      npm run build
    if: success()
  - step: Verify build
    run: |
      test -f dist/output.js && echo "Build successful!"
    if: success()

post:
  - step: Post Cache Primes
    action: actions/cache@v5
  - step: Post Run actions/checkout@v6
    action: actions/checkout@v6

cleanup:
  - step: Complete job
```

</details>
