### PR TITLE
Add new env var to allow single-prefix multiline logs on stdout

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -308,7 +308,7 @@ namespace GitHub.Runner.Common
                 public static readonly string ForcedInternalNodeVersion = "ACTIONS_RUNNER_FORCED_INTERNAL_NODE_VERSION";
                 public static readonly string ForcedActionsNodeVersion = "ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION";
                 public static readonly string PrintLogToStdout = "ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT";
-                public static readonly string StdoutMultilineLogPrefixing = "ACTIONS_RUNNER_STDOUT_MULTILINE_LOG_PREFIXING";
+                public static readonly string DisableStdoutMultilineLogPrefixing = "ACTIONS_RUNNER_DISABLE_STDOUT_MULTILINE_LOG_PREFIXING";
                 public static readonly string ActionArchiveCacheDirectory = "ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE";
                 public static readonly string SymlinkCachedActions = "ACTIONS_RUNNER_SYMLINK_CACHED_ACTIONS";
                 public static readonly string EmitCompositeMarkers = "ACTIONS_RUNNER_EMIT_COMPOSITE_MARKERS";

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -308,6 +308,7 @@ namespace GitHub.Runner.Common
                 public static readonly string ForcedInternalNodeVersion = "ACTIONS_RUNNER_FORCED_INTERNAL_NODE_VERSION";
                 public static readonly string ForcedActionsNodeVersion = "ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION";
                 public static readonly string PrintLogToStdout = "ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT";
+                public static readonly string StdoutMultilineLogPrefixing = "ACTIONS_RUNNER_STDOUT_MULTILINE_LOG_PREFIXING";
                 public static readonly string ActionArchiveCacheDirectory = "ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE";
                 public static readonly string SymlinkCachedActions = "ACTIONS_RUNNER_SYMLINK_CACHED_ACTIONS";
                 public static readonly string EmitCompositeMarkers = "ACTIONS_RUNNER_EMIT_COMPOSITE_MARKERS";

--- a/src/Runner.Common/StdoutTraceListener.cs
+++ b/src/Runner.Common/StdoutTraceListener.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -9,18 +9,12 @@ namespace GitHub.Runner.Common
     public sealed class StdoutTraceListener : ConsoleTraceListener
     {
         private readonly string _hostType;
-        private readonly bool _prefixMultilineLogs = true;
+        private readonly bool _disablePrefixMultilineLogs = false;
 
         public StdoutTraceListener(string hostType)
         {
             this._hostType = hostType;
-            // The stdout log prefixing behaviour was on before this environment variable,
-            // so only disable it if the env var was set
-            bool multilinePrefixingEnvSetting = StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable(Constants.Variables.Agent.StdoutMultilineLogPrefixing), defaultValue: true);
-            if (!multilinePrefixingEnvSetting)
-            {
-                this._prefixMultilineLogs = false;
-            }
+            this._disablePrefixMultilineLogs = StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable(Constants.Variables.Agent.DisableStdoutMultilineLogPrefixing));
         }
 
         // Copied and modified slightly from .Net Core source code. Modification was required to make it compile.
@@ -34,7 +28,7 @@ namespace GitHub.Runner.Common
 
             if (!string.IsNullOrEmpty(message))
             {
-                if (this._prefixMultilineLogs)
+                if (!this._disablePrefixMultilineLogs)
                 {
                     var messageLines = message.Split(Environment.NewLine);
                     foreach (var messageLine in messageLines)

--- a/src/Runner.Common/StdoutTraceListener.cs
+++ b/src/Runner.Common/StdoutTraceListener.cs
@@ -9,10 +9,18 @@ namespace GitHub.Runner.Common
     public sealed class StdoutTraceListener : ConsoleTraceListener
     {
         private readonly string _hostType;
+        private readonly bool _prefixMultilineLogs = true;
 
         public StdoutTraceListener(string hostType)
         {
             this._hostType = hostType;
+            // The stdout log prefixing behaviour was on before this environment variable,
+            // so only disable it if the env var was set
+            bool multilinePrefixingEnvSetting = StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable(Constants.Variables.Agent.StdoutMultilineLogPrefixing), defaultValue: true);
+            if (!multilinePrefixingEnvSetting)
+            {
+                this._prefixMultilineLogs = false;
+            }
         }
 
         // Copied and modified slightly from .Net Core source code. Modification was required to make it compile.
@@ -26,11 +34,20 @@ namespace GitHub.Runner.Common
 
             if (!string.IsNullOrEmpty(message))
             {
-                var messageLines = message.Split(Environment.NewLine);
-                foreach (var messageLine in messageLines)
+                if (this._prefixMultilineLogs)
+                {
+                    var messageLines = message.Split(Environment.NewLine);
+                    foreach (var messageLine in messageLines)
+                    {
+                        WriteHeader(source, eventType, id);
+                        WriteLine(messageLine);
+                        WriteFooter(eventCache);
+                    }
+                }
+                else
                 {
                     WriteHeader(source, eventType, id);
-                    WriteLine(messageLine);
+                    WriteLine(message);
                     WriteFooter(eventCache);
                 }
             }


### PR DESCRIPTION
Addresses #4423.

Given the existing behaviour is that multiline messages have a prefix per line, I've designed the variable in a manner where it only _disables_ this behaviour if explicitly told to via the env var.