### PR TITLE
DAP: add YamlScalarFormatter (1/5)

### DIFF
--- a/src/Runner.Worker/Dap/YamlScalarFormatter.cs
+++ b/src/Runner.Worker/Dap/YamlScalarFormatter.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using GitHub.Runner.Sdk;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace GitHub.Runner.Worker.Dap
+{
+    /// <summary>
+    /// Formats a single string as a quote-safe YAML scalar by routing it
+    /// through YamlDotNet's <see cref="Emitter"/>. The returned text is
+    /// safe to splice into a hand-emitted YAML document fragment.
+    ///
+    /// Caller responsibility: this only handles the scalar value; it does
+    /// not emit a key, indent, or trailing newline.
+    /// </summary>
+    internal static class YamlScalarFormatter
+    {
+        /// <summary>
+        /// Return <paramref name="value"/> formatted as a YAML scalar:
+        /// plain, single-quoted, or double-quoted as the emitter chooses,
+        /// with no surrounding document markers or trailing newline.
+        /// </summary>
+        public static string Format(string value)
+        {
+            ArgUtil.NotNull(value, nameof(value));
+
+            using var sw = new StringWriter(CultureInfo.InvariantCulture);
+            // Force LF line breaks; YamlDotNet's Emitter calls WriteLine,
+            // which would otherwise produce CRLF on Windows and break
+            // both our document-end stripping below and downstream
+            // consumers that assume a single line-break convention.
+            sw.NewLine = "\n";
+            var emitter = new Emitter(sw);
+            emitter.Emit(new StreamStart());
+            emitter.Emit(new DocumentStart(null, null, true));
+            emitter.Emit(new Scalar(null, null, value, ScalarStyle.Any, true, true));
+            emitter.Emit(new DocumentEnd(true));
+            emitter.Emit(new StreamEnd());
+
+            string raw = sw.ToString();
+            // Strip YAML document markers. Emitter elides these for most
+            // scalars but emits "--- " (with space) for some edge cases
+            // (e.g. empty strings). Defensively handle "---\n" too.
+            if (raw.StartsWith("--- ", StringComparison.Ordinal))
+            {
+                raw = raw.Substring(4);
+            }
+            else if (raw.StartsWith("---\n", StringComparison.Ordinal))
+            {
+                raw = raw.Substring(4);
+            }
+            raw = raw.TrimEnd('\n');
+            const string DocEndMarker = "\n...";
+            if (raw.EndsWith(DocEndMarker, StringComparison.Ordinal))
+            {
+                raw = raw.Substring(0, raw.Length - DocEndMarker.Length);
+            }
+            return raw.TrimEnd('\n');
+        }
+    }
+}

--- a/src/Runner.Worker/Dap/YamlScalarFormatter.cs
+++ b/src/Runner.Worker/Dap/YamlScalarFormatter.cs
@@ -57,7 +57,7 @@ namespace GitHub.Runner.Worker.Dap
             {
                 raw = raw.Substring(0, raw.Length - DocEndMarker.Length);
             }
-            return raw.TrimEnd('\n');
+            return raw;
         }
     }
 }

--- a/src/Test/L0/Worker/YamlScalarFormatterL0.cs
+++ b/src/Test/L0/Worker/YamlScalarFormatterL0.cs
@@ -27,7 +27,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             catch (Exception ex)
             {
                 throw new Xunit.Sdk.XunitException(
-                    $"Formatted scalar did not round-trip as valid YAML.\nInput: '{value}'\nFormatted: '{scalar}'\nFull YAML:\n{yaml}\nError: {ex.Message}");
+                    $"Formatted scalar did not round-trip as valid YAML.\nInput: '{value}'\nFormatted: '{scalar}'\nFull YAML:\n{yaml}\nError: {ex}");
             }
             Assert.NotNull(doc);
             Assert.True(doc.ContainsKey("k"), $"missing key in parsed doc. Formatted: '{scalar}'");

--- a/src/Test/L0/Worker/YamlScalarFormatterL0.cs
+++ b/src/Test/L0/Worker/YamlScalarFormatterL0.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using GitHub.Runner.Worker.Dap;
+using Xunit;
+using YamlDotNet.Serialization;
+
+namespace GitHub.Runner.Common.Tests.Worker
+{
+    public sealed class YamlScalarFormatterL0
+    {
+        private static readonly IDeserializer Deserializer = new DeserializerBuilder().Build();
+
+        // Embed the formatter output inside a minimal YAML mapping and
+        // round-trip through YamlDotNet, asserting the parsed value equals
+        // the original input. Decouples assertions from the emitter's
+        // quoting choices (plain vs single- vs double-quoted).
+        private static void AssertRoundTrips(string value)
+        {
+            string scalar = YamlScalarFormatter.Format(value);
+            string yaml = $"k: {scalar}\n";
+
+            Dictionary<string, object> doc;
+            try
+            {
+                doc = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+            }
+            catch (Exception ex)
+            {
+                throw new Xunit.Sdk.XunitException(
+                    $"Formatted scalar did not round-trip as valid YAML.\nInput: '{value}'\nFormatted: '{scalar}'\nFull YAML:\n{yaml}\nError: {ex.Message}");
+            }
+            Assert.NotNull(doc);
+            Assert.True(doc.ContainsKey("k"), $"missing key in parsed doc. Formatted: '{scalar}'");
+            Assert.Equal(value, doc["k"] as string);
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData("hello")]
+        [InlineData("with: colon")]
+        [InlineData("with#hash")]
+        [InlineData(" leading")]
+        [InlineData("trailing ")]
+        [InlineData("a\"b")]
+        [InlineData("a\\b")]
+        [InlineData("@at")]
+        [InlineData("*star")]
+        [InlineData("&amp")]
+        [InlineData("?question")]
+        [InlineData("!exclaim")]
+        [InlineData("- dash")]
+        [InlineData("{brace}")]
+        [InlineData("[bracket]")]
+        public void Format_RoundTripsThroughYamlDeserializer(string value)
+        {
+            // The formatter must produce output that, embedded under a key,
+            // parses back to exactly the input. The emitter is free to
+            // pick plain, single-quoted, or double-quoted style.
+            AssertRoundTrips(value);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Format_PlainAscii_NoQuotingNeeded()
+        {
+            // Sanity check that the simple case stays plain.
+            Assert.Equal("hello", YamlScalarFormatter.Format("hello"));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Format_NoTrailingNewline()
+        {
+            Assert.False(YamlScalarFormatter.Format("hello").EndsWith("\n"));
+            Assert.False(YamlScalarFormatter.Format("with: colon").EndsWith("\n"));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Format_NoDocumentMarkers()
+        {
+            // The emitter wraps the scalar in a document; the formatter
+            // must strip both `--- ` (with space) and `---\n` (on its
+            // own line) prefixes plus the `\n...` suffix.
+            Assert.DoesNotContain("---", YamlScalarFormatter.Format("hello"));
+            Assert.DoesNotContain("...", YamlScalarFormatter.Format("hello"));
+            // Empty string is one of the cases where the emitter does
+            // produce a document marker by default.
+            Assert.DoesNotContain("---", YamlScalarFormatter.Format(""));
+            Assert.DoesNotContain("...", YamlScalarFormatter.Format(""));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Format_AlwaysUsesLfLineBreaks()
+        {
+            // Regression: YamlDotNet's Emitter calls WriteLine, which on
+            // Windows produces CRLF (the host's Environment.NewLine).
+            // Format must force LF so the output round-trips regardless
+            // of platform.
+            Assert.DoesNotContain('\r', YamlScalarFormatter.Format("hello"));
+            Assert.DoesNotContain('\r', YamlScalarFormatter.Format("with: colon"));
+            Assert.DoesNotContain('\r', YamlScalarFormatter.Format(""));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Format_NullValue_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => YamlScalarFormatter.Format(null));
+        }
+    }
+}


### PR DESCRIPTION
> **Part 1 of 5** of the foundation for the DAP debugger's job source view. **No caller yet** — the renderer in part 2 will consume this.
>
> Splitting the previously-monolithic foundation (#4417) so each piece can be reviewed in isolation.

## What this PR adds

A thin wrapper around YamlDotNet's `Emitter` that formats one string as a quote-safe YAML scalar — plain, single-quoted, or double-quoted as the emitter chooses — with no surrounding document markers or trailing newline. Safe to splice into a hand-emitted YAML document fragment.

## Why it exists

The upcoming execution-view renderer (part 2) hand-emits the YAML skeleton so it can track per-step line offsets (needed for `stackTrace` responses). Scalar values, however, must respect YAML's reserved chars, leading/trailing whitespace, and embedded `: `/`#` sequences. Doing this by hand is bug-prone, especially on edge cases (empty strings, expressions, multiline content), so we route scalars through the library.

## Notable details

- **LF line breaks forced** (`sw.NewLine = "\n"`). `StringWriter` otherwise picks up Windows's `Environment.NewLine` (CRLF), which corrupts the document-end stripping below.
- **Both `--- ` and `---\n` document-start prefixes are stripped.** The emitter elides them for most scalars but emits them for some edge cases (e.g. empty strings).

## Tests

Direct round-trip coverage: format a value → splice under a YAML key → parse with YamlDotNet's deserializer → assert the parsed value equals the input. Covers 15 special-character cases, empty strings, the LF guarantee, and document-marker stripping.
