### PR TITLE
Allow disable node v8 maglev jit compiler on node24.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ TestLogs
 .DS_Store
 .mono
 **/*.DotSettings.user
+**/*.lscache

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -12,6 +12,7 @@ using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker.Container;
 using GitHub.Runner.Worker.Container.ContainerHooks;
+using GitHub.Services.Common;
 
 namespace GitHub.Runner.Worker.Handlers
 {
@@ -127,6 +128,17 @@ namespace GitHub.Runner.Worker.Handlers
             // 2) Escape double quotes within the script file path. Double-quote is a valid
             // file name character on Linux.
             string arguments = StepHost.ResolvePathForStepHost(ExecutionContext, StringUtil.Format(@"""{0}""", target.Replace(@"""", @"\""")));
+
+            // Disable maglev jit compiler in node.js 24.x.x on x64 Windows until the node.js bug is fixed.
+            // https://github.com/nodejs/node/issues/62260
+            if (nodeRuntimeVersion.StartsWith("node24", StringComparison.OrdinalIgnoreCase) &&
+                Constants.Runner.Platform == Constants.OSPlatform.Windows &&
+                Constants.Runner.PlatformArchitecture == Constants.Architecture.X64 &&
+                !StringUtil.ConvertToBoolean(System.Environment.GetEnvironmentVariable("ACTIONS_RUNNER_REENABLE_NODE_MAGLEV")) &&
+                !StringUtil.ConvertToBoolean(Environment.GetValueOrDefault("ACTIONS_RUNNER_REENABLE_NODE_MAGLEV")))
+            {
+                arguments = $"--no-maglev {arguments}";
+            }
 
 #if OS_WINDOWS
             // It appears that node.exe outputs UTF8 when not in TTY mode.

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -132,11 +132,9 @@ namespace GitHub.Runner.Worker.Handlers
             // Disable maglev jit compiler in node.js 24.x.x on x64 Windows until the node.js bug is fixed.
             // https://github.com/nodejs/node/issues/62260
             if (nodeRuntimeVersion.StartsWith("node24", StringComparison.OrdinalIgnoreCase) &&
-                Constants.Runner.Platform == Constants.OSPlatform.Windows &&
-                Constants.Runner.PlatformArchitecture == Constants.Architecture.X64 &&
-                !StringUtil.ConvertToBoolean(System.Environment.GetEnvironmentVariable("ACTIONS_RUNNER_REENABLE_NODE_MAGLEV")) &&
-                !StringUtil.ConvertToBoolean(Environment.GetValueOrDefault("ACTIONS_RUNNER_REENABLE_NODE_MAGLEV")))
+                (StringUtil.ConvertToBoolean(System.Environment.GetEnvironmentVariable("ACTIONS_RUNNER_DISABLE_NODE_MAGLEV")) || StringUtil.ConvertToBoolean(Environment.GetValueOrDefault("ACTIONS_RUNNER_DISABLE_NODE_MAGLEV"))))
             {
+                Trace.Info("Disable maglev jit compiler in node.js");
                 arguments = $"--no-maglev {arguments}";
             }
 


### PR DESCRIPTION
Try to workaround https://github.com/nodejs/node/issues/62260 for actions/runner on Windows

Setting machine level env `ACTIONS_RUNNER_DISABLE_NODE_MAGLEV=1` or step level env `ACTIONS_RUNNER_DISABLE_NODE_MAGLEV=1`