### PR TITLE
feat: add self-repository action reference syntax

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -180,6 +180,7 @@ namespace GitHub.Runner.Common
                 public static readonly string BatchActionResolution = "actions_batch_action_resolution";
                 public static readonly string UseBearerTokenForCodeload = "actions_use_bearer_token_for_codeload";
                 public static readonly string OverrideDebuggerWelcomeMessage = "actions_runner_override_debugger_welcome_message";
+                public static readonly string DollarSelfReference = "actions_dollar_self_reference";
             }
 
             // Node version migration related constants

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -180,7 +180,7 @@ namespace GitHub.Runner.Common
                 public static readonly string BatchActionResolution = "actions_batch_action_resolution";
                 public static readonly string UseBearerTokenForCodeload = "actions_use_bearer_token_for_codeload";
                 public static readonly string OverrideDebuggerWelcomeMessage = "actions_runner_override_debugger_welcome_message";
-                public static readonly string DollarSelfReference = "actions_dollar_self_reference";
+                public static readonly string SelfReference = "actions_self_reference";
             }
 
             // Node version migration related constants

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -180,7 +180,7 @@ namespace GitHub.Runner.Common
                 public static readonly string BatchActionResolution = "actions_batch_action_resolution";
                 public static readonly string UseBearerTokenForCodeload = "actions_use_bearer_token_for_codeload";
                 public static readonly string OverrideDebuggerWelcomeMessage = "actions_runner_override_debugger_welcome_message";
-                public static readonly string SelfReference = "actions_self_reference";
+                public static readonly string SelfRepository = "actions_self_repository";
             }
 
             // Node version migration related constants

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -427,23 +427,12 @@ namespace GitHub.Runner.Worker
         /// sub-actions individually, with no cross-depth deduplication.
         /// Used when the BatchActionResolution feature flag is disabled.
         /// </summary>
-        private async Task<PrepareActionsState> PrepareActionsRecursiveLegacyAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Int32 depth = 0, Guid parentStepId = default(Guid), string dollarSelfRepoName = null, string dollarSelfRepoRef = null)
+        private async Task<PrepareActionsState> PrepareActionsRecursiveLegacyAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Int32 depth = 0, Guid parentStepId = default(Guid))
         {
             ArgUtil.NotNull(executionContext, nameof(executionContext));
             if (depth > Constants.CompositeActionsMaxDepth)
             {
                 throw new Exception($"Composite action depth exceeded max depth {Constants.CompositeActionsMaxDepth}");
-            }
-
-            // Resolve dollar-self ($/path) references before processing
-            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DollarSelfReference) == true)
-            {
-                if (string.IsNullOrEmpty(dollarSelfRepoName))
-                {
-                    dollarSelfRepoName = executionContext.JobContext?.WorkflowRepository;
-                    dollarSelfRepoRef = executionContext.JobContext?.WorkflowSha;
-                }
-                ResolveDollarSelfReferences(executionContext, actions, dollarSelfRepoName, dollarSelfRepoRef);
             }
 
             var repositoryActions = new List<Pipelines.ActionStep>();
@@ -570,18 +559,7 @@ namespace GitHub.Runner.Worker
                     }
                     else if (setupInfo != null && setupInfo.Steps != null && setupInfo.Steps.Count > 0)
                     {
-                        // Determine dollar-self resolution context for child steps
-                        string childRepoName = dollarSelfRepoName;
-                        string childRepoRef = dollarSelfRepoRef;
-                        var parentRef = action.Reference as Pipelines.RepositoryPathReference;
-                        if (parentRef != null &&
-                            string.Equals(parentRef.RepositoryType, Pipelines.RepositoryTypes.GitHub, StringComparison.OrdinalIgnoreCase))
-                        {
-                            childRepoName = parentRef.Name;
-                            childRepoRef = parentRef.Ref;
-                        }
-
-                        state = await PrepareActionsRecursiveLegacyAsync(executionContext, state, setupInfo.Steps, depth + 1, action.Id, childRepoName, childRepoRef);
+                        state = await PrepareActionsRecursiveLegacyAsync(executionContext, state, setupInfo.Steps, depth + 1, action.Id);
                     }
                     var repoAction = action.Reference as Pipelines.RepositoryPathReference;
                     if (repoAction.RepositoryType != Pipelines.PipelineConstants.SelfAlias)

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -175,7 +175,6 @@ namespace GitHub.Runner.Worker
                 }
 #endif
             }
-
             return new PrepareResult(containerSetupSteps, result.PreStepTracker);
         }
 
@@ -188,7 +187,7 @@ namespace GitHub.Runner.Worker
             }
 
             // Resolve self-repository ($/) references before processing
-            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
+            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfRepository) == true)
             {
                 if (string.IsNullOrEmpty(selfRepoName))
                 {
@@ -199,7 +198,7 @@ namespace GitHub.Runner.Worker
                     selfRepoName = executionContext.JobContext?.WorkflowRepository;
                     selfRepoRef = executionContext.JobContext?.WorkflowSha;
                 }
-                ResolveSelfReferences(executionContext, actions, selfRepoName, selfRepoRef);
+                ResolveSelfRepositoryReferences(executionContext, actions, selfRepoName, selfRepoRef);
             }
 
             var repositoryActions = new List<Pipelines.ActionStep>();
@@ -317,7 +316,7 @@ namespace GitHub.Runner.Worker
                 // then recurse per parent (which hits the cache, not the API).
                 if (nextLevel.Count > 0)
                 {
-                    if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
+                    if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfRepository) == true)
                     {
                         // Self-repository path: group by parent so each group's
                         // $/ refs resolve against the correct parent repo context.
@@ -337,7 +336,7 @@ namespace GitHub.Runner.Worker
 
                         foreach (var group in groups)
                         {
-                            ResolveSelfReferences(executionContext, group.Actions, group.RepoName, group.RepoRef);
+                            ResolveSelfRepositoryReferences(executionContext, group.Actions, group.RepoName, group.RepoRef);
                         }
 
                         var nextLevelRepoActions = nextLevel
@@ -448,14 +447,14 @@ namespace GitHub.Runner.Worker
             }
 
             // Resolve self-repository ($/) references before processing
-            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
+            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfRepository) == true)
             {
                 if (string.IsNullOrEmpty(selfRepoName))
                 {
                     selfRepoName = executionContext.JobContext?.WorkflowRepository;
                     selfRepoRef = executionContext.JobContext?.WorkflowSha;
                 }
-                ResolveSelfReferences(executionContext, actions, selfRepoName, selfRepoRef);
+                ResolveSelfRepositoryReferences(executionContext, actions, selfRepoName, selfRepoRef);
             }
 
             var repositoryActions = new List<Pipelines.ActionStep>();
@@ -845,16 +844,16 @@ namespace GitHub.Runner.Worker
                         // During setup, resolution happens on a separate copy of these
                         // step objects. At runtime, action.yml is re-parsed, producing
                         // fresh self-repository refs that need resolution here.
-                        if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
+                        if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfRepository) == true)
                         {
-                            ResolveSelfReferences(executionContext, compositeAction.Steps, repoAction.Name, repoAction.Ref);
+                            ResolveSelfRepositoryReferences(executionContext, compositeAction.Steps, repoAction.Name, repoAction.Ref);
                             if (compositeAction.PreSteps != null)
                             {
-                                ResolveSelfReferences(executionContext, compositeAction.PreSteps, repoAction.Name, repoAction.Ref);
+                                ResolveSelfRepositoryReferences(executionContext, compositeAction.PreSteps, repoAction.Name, repoAction.Ref);
                             }
                             if (compositeAction.PostSteps != null)
                             {
-                                ResolveSelfReferences(executionContext, compositeAction.PostSteps, repoAction.Name, repoAction.Ref);
+                                ResolveSelfRepositoryReferences(executionContext, compositeAction.PostSteps, repoAction.Name, repoAction.Ref);
                             }
                         }
                     }
@@ -1541,7 +1540,7 @@ namespace GitHub.Runner.Worker
         /// to standard GitHub repository references with the containing repo's
         /// name and ref.
         /// </summary>
-        private void ResolveSelfReferences(IExecutionContext executionContext, IEnumerable<Pipelines.ActionStep> actions, string repoName, string repoRef)
+        private void ResolveSelfRepositoryReferences(IExecutionContext executionContext, IEnumerable<Pipelines.ActionStep> actions, string repoName, string repoRef)
         {
             if (string.IsNullOrEmpty(repoName) || string.IsNullOrEmpty(repoRef))
             {

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -175,15 +175,31 @@ namespace GitHub.Runner.Worker
                 }
 #endif
             }
+
             return new PrepareResult(containerSetupSteps, result.PreStepTracker);
         }
 
-        private async Task<PrepareActionsState> PrepareActionsRecursiveAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Dictionary<string, WebApi.ActionDownloadInfo> resolvedDownloadInfos, Int32 depth = 0, Guid parentStepId = default(Guid))
+        private async Task<PrepareActionsState> PrepareActionsRecursiveAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Dictionary<string, WebApi.ActionDownloadInfo> resolvedDownloadInfos, Int32 depth = 0, Guid parentStepId = default(Guid), string dollarSelfRepoName = null, string dollarSelfRepoRef = null)
         {
             ArgUtil.NotNull(executionContext, nameof(executionContext));
             if (depth > Constants.CompositeActionsMaxDepth)
             {
                 throw new Exception($"Composite action depth exceeded max depth {Constants.CompositeActionsMaxDepth}");
+            }
+
+            // Resolve dollar-self ($/path) references before processing
+            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DollarSelfReference) == true)
+            {
+                if (string.IsNullOrEmpty(dollarSelfRepoName))
+                {
+                    // job.workflow_repository/workflow_sha point to the repo
+                    // containing the workflow file — correct for both regular
+                    // and reusable workflows. Always present when the server
+                    // supports $/. See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context
+                    dollarSelfRepoName = executionContext.JobContext?.WorkflowRepository;
+                    dollarSelfRepoRef = executionContext.JobContext?.WorkflowSha;
+                }
+                ResolveDollarSelfReferences(executionContext, actions, dollarSelfRepoName, dollarSelfRepoRef);
             }
 
             var repositoryActions = new List<Pipelines.ActionStep>();
@@ -301,16 +317,41 @@ namespace GitHub.Runner.Worker
                 // then recurse per parent (which hits the cache, not the API).
                 if (nextLevel.Count > 0)
                 {
+                    // Pre-compute parent context per group for dollar-self
+                    // resolution and recursion. Dollar-self refs in nextLevel
+                    // must be resolved BEFORE batch download-info resolution,
+                    // since GetDownloadInfoLookupKey requires concrete refs.
+                    var groups = nextLevel.GroupBy(x => x.parentId).Select(group =>
+                    {
+                        string childRepoName = dollarSelfRepoName;
+                        string childRepoRef = dollarSelfRepoRef;
+                        var parentAction = repositoryActions.FirstOrDefault(a => a.Id == group.Key);
+                        if (parentAction?.Reference is Pipelines.RepositoryPathReference parentRef &&
+                            string.Equals(parentRef.RepositoryType, Pipelines.RepositoryTypes.GitHub, StringComparison.OrdinalIgnoreCase))
+                        {
+                            childRepoName = parentRef.Name;
+                            childRepoRef = parentRef.Ref;
+                        }
+                        return new { ParentId = group.Key, Actions = group.Select(x => x.action).ToList(), RepoName = childRepoName, RepoRef = childRepoRef };
+                    }).ToList();
+
+                    if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DollarSelfReference) == true)
+                    {
+                        foreach (var group in groups)
+                        {
+                            ResolveDollarSelfReferences(executionContext, group.Actions, group.RepoName, group.RepoRef);
+                        }
+                    }
+
                     var nextLevelRepoActions = nextLevel
                         .Where(x => x.action.Reference.Type == Pipelines.ActionSourceType.Repository)
                         .Select(x => x.action)
                         .ToList();
                     await ResolveNewActionsAsync(executionContext, nextLevelRepoActions, resolvedDownloadInfos);
 
-                    foreach (var group in nextLevel.GroupBy(x => x.parentId))
+                    foreach (var group in groups)
                     {
-                        var groupActions = group.Select(x => x.action).ToList();
-                        state = await PrepareActionsRecursiveAsync(executionContext, state, groupActions, resolvedDownloadInfos, depth + 1, group.Key);
+                        state = await PrepareActionsRecursiveAsync(executionContext, state, group.Actions, resolvedDownloadInfos, depth + 1, group.ParentId, group.RepoName, group.RepoRef);
                     }
                 }
 
@@ -386,13 +427,25 @@ namespace GitHub.Runner.Worker
         /// sub-actions individually, with no cross-depth deduplication.
         /// Used when the BatchActionResolution feature flag is disabled.
         /// </summary>
-        private async Task<PrepareActionsState> PrepareActionsRecursiveLegacyAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Int32 depth = 0, Guid parentStepId = default(Guid))
+        private async Task<PrepareActionsState> PrepareActionsRecursiveLegacyAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Int32 depth = 0, Guid parentStepId = default(Guid), string dollarSelfRepoName = null, string dollarSelfRepoRef = null)
         {
             ArgUtil.NotNull(executionContext, nameof(executionContext));
             if (depth > Constants.CompositeActionsMaxDepth)
             {
                 throw new Exception($"Composite action depth exceeded max depth {Constants.CompositeActionsMaxDepth}");
             }
+
+            // Resolve dollar-self ($/path) references before processing
+            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DollarSelfReference) == true)
+            {
+                if (string.IsNullOrEmpty(dollarSelfRepoName))
+                {
+                    dollarSelfRepoName = executionContext.JobContext?.WorkflowRepository;
+                    dollarSelfRepoRef = executionContext.JobContext?.WorkflowSha;
+                }
+                ResolveDollarSelfReferences(executionContext, actions, dollarSelfRepoName, dollarSelfRepoRef);
+            }
+
             var repositoryActions = new List<Pipelines.ActionStep>();
 
             foreach (var action in actions)
@@ -517,7 +570,18 @@ namespace GitHub.Runner.Worker
                     }
                     else if (setupInfo != null && setupInfo.Steps != null && setupInfo.Steps.Count > 0)
                     {
-                        state = await PrepareActionsRecursiveLegacyAsync(executionContext, state, setupInfo.Steps, depth + 1, action.Id);
+                        // Determine dollar-self resolution context for child steps
+                        string childRepoName = dollarSelfRepoName;
+                        string childRepoRef = dollarSelfRepoRef;
+                        var parentRef = action.Reference as Pipelines.RepositoryPathReference;
+                        if (parentRef != null &&
+                            string.Equals(parentRef.RepositoryType, Pipelines.RepositoryTypes.GitHub, StringComparison.OrdinalIgnoreCase))
+                        {
+                            childRepoName = parentRef.Name;
+                            childRepoRef = parentRef.Ref;
+                        }
+
+                        state = await PrepareActionsRecursiveLegacyAsync(executionContext, state, setupInfo.Steps, depth + 1, action.Id, childRepoName, childRepoRef);
                     }
                     var repoAction = action.Reference as Pipelines.RepositoryPathReference;
                     if (repoAction.RepositoryType != Pipelines.PipelineConstants.SelfAlias)
@@ -763,6 +827,23 @@ namespace GitHub.Runner.Worker
                                 var guid = Guid.NewGuid();
                                 compositeStep.Id = guid;
                                 _cachedEmbeddedStepIds[action.Id].Add(guid);
+                            }
+                        }
+
+                        // Resolve dollar-self refs in composite steps at load time.
+                        // During setup, resolution happens on a separate copy of these
+                        // step objects. At runtime, action.yml is re-parsed, producing
+                        // fresh dollar-self refs that need resolution here.
+                        if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DollarSelfReference) == true)
+                        {
+                            ResolveDollarSelfReferences(executionContext, compositeAction.Steps, repoAction.Name, repoAction.Ref);
+                            if (compositeAction.PreSteps != null)
+                            {
+                                ResolveDollarSelfReferences(executionContext, compositeAction.PreSteps, repoAction.Name, repoAction.Ref);
+                            }
+                            if (compositeAction.PostSteps != null)
+                            {
+                                ResolveDollarSelfReferences(executionContext, compositeAction.PostSteps, repoAction.Name, repoAction.Ref);
                             }
                         }
                     }
@@ -1444,6 +1525,47 @@ namespace GitHub.Runner.Worker
             }
         }
 
+        /// <summary>
+        /// Resolves dollar-self ($/path) references by mutating them in-place
+        /// to standard GitHub repository references with the containing repo's
+        /// name and ref.
+        /// </summary>
+        private void ResolveDollarSelfReferences(IExecutionContext executionContext, IEnumerable<Pipelines.ActionStep> actions, string repoName, string repoRef)
+        {
+            if (string.IsNullOrEmpty(repoName) || string.IsNullOrEmpty(repoRef))
+            {
+                return;
+            }
+
+            foreach (var action in actions)
+            {
+                if (action.Reference.Type != Pipelines.ActionSourceType.Repository)
+                {
+                    continue;
+                }
+
+                var repoAction = action.Reference as Pipelines.RepositoryPathReference;
+                if (!string.Equals(repoAction.RepositoryType, Pipelines.PipelineConstants.DollarSelfAlias, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                Trace.Info($"Resolving dollar-self reference '$/{repoAction.Path}' to '{repoName}/{repoAction.Path}@{repoRef}'");
+                executionContext.Debug($"Resolving $/{repoAction.Path} → {repoName}/{repoAction.Path}@{repoRef}");
+
+                repoAction.RepositoryType = Pipelines.RepositoryTypes.GitHub;
+                repoAction.Name = repoName;
+                repoAction.Ref = repoRef;
+            }
+        }
+
+        /// <summary>
+        /// If this is a reusable workflow job, ensure the workflow repo tarball
+        /// is downloaded so self.workspace resolves to a real path on disk.
+        /// Always downloads for reusable workflows when the feature flag is on,
+        /// since step expressions are already expanded by the server and can't
+        /// be scanned for self.* usage.
+        /// </summary>
         private static string GetDownloadInfoLookupKey(Pipelines.ActionStep action)
         {
             if (action.Reference.Type != Pipelines.ActionSourceType.Repository)
@@ -1457,6 +1579,11 @@ namespace GitHub.Runner.Worker
             if (string.Equals(repositoryReference.RepositoryType, Pipelines.PipelineConstants.SelfAlias, StringComparison.OrdinalIgnoreCase))
             {
                 return null;
+            }
+
+            if (string.Equals(repositoryReference.RepositoryType, Pipelines.PipelineConstants.DollarSelfAlias, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException($"Dollar-self ($/path) reference was not resolved before download. Ensure the '{Constants.Runner.Features.DollarSelfReference}' feature flag is enabled.");
             }
 
             if (!string.Equals(repositoryReference.RepositoryType, Pipelines.RepositoryTypes.GitHub, StringComparison.OrdinalIgnoreCase))

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1544,7 +1544,7 @@ namespace GitHub.Runner.Worker
                 }
 
                 var repoAction = action.Reference as Pipelines.RepositoryPathReference;
-                if (!string.Equals(repoAction.RepositoryType, Pipelines.PipelineConstants.DollarSelfAlias, StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(repoAction.RepositoryType, Pipelines.PipelineConstants.SelfRepositoryAlias, StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }
@@ -1580,7 +1580,7 @@ namespace GitHub.Runner.Worker
                 return null;
             }
 
-            if (string.Equals(repositoryReference.RepositoryType, Pipelines.PipelineConstants.DollarSelfAlias, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(repositoryReference.RepositoryType, Pipelines.PipelineConstants.SelfRepositoryAlias, StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException($"Unable to resolve self-reference '$/'. Self-references require a server version that supports this syntax. Ensure the workflow is running on a compatible GitHub Actions environment.");
             }

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1582,7 +1582,7 @@ namespace GitHub.Runner.Worker
 
             if (string.Equals(repositoryReference.RepositoryType, Pipelines.PipelineConstants.SelfRepositoryAlias, StringComparison.OrdinalIgnoreCase))
             {
-                throw new InvalidOperationException($"Unable to resolve self-reference '$/'. Self-references require a server version that supports this syntax. Ensure the workflow is running on a compatible GitHub Actions environment.");
+                throw new InvalidOperationException($"Unable to resolve self-reference '$/'. This can occur when the server does not support this syntax, the feature flag is disabled, or the workflow context (repository/SHA) is unavailable.");
             }
 
             if (!string.Equals(repositoryReference.RepositoryType, Pipelines.RepositoryTypes.GitHub, StringComparison.OrdinalIgnoreCase))

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -427,12 +427,23 @@ namespace GitHub.Runner.Worker
         /// sub-actions individually, with no cross-depth deduplication.
         /// Used when the BatchActionResolution feature flag is disabled.
         /// </summary>
-        private async Task<PrepareActionsState> PrepareActionsRecursiveLegacyAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Int32 depth = 0, Guid parentStepId = default(Guid))
+        private async Task<PrepareActionsState> PrepareActionsRecursiveLegacyAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Int32 depth = 0, Guid parentStepId = default(Guid), string dollarSelfRepoName = null, string dollarSelfRepoRef = null)
         {
             ArgUtil.NotNull(executionContext, nameof(executionContext));
             if (depth > Constants.CompositeActionsMaxDepth)
             {
                 throw new Exception($"Composite action depth exceeded max depth {Constants.CompositeActionsMaxDepth}");
+            }
+
+            // Resolve dollar-self ($/path) references before processing
+            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DollarSelfReference) == true)
+            {
+                if (string.IsNullOrEmpty(dollarSelfRepoName))
+                {
+                    dollarSelfRepoName = executionContext.JobContext?.WorkflowRepository;
+                    dollarSelfRepoRef = executionContext.JobContext?.WorkflowSha;
+                }
+                ResolveDollarSelfReferences(executionContext, actions, dollarSelfRepoName, dollarSelfRepoRef);
             }
 
             var repositoryActions = new List<Pipelines.ActionStep>();
@@ -559,7 +570,17 @@ namespace GitHub.Runner.Worker
                     }
                     else if (setupInfo != null && setupInfo.Steps != null && setupInfo.Steps.Count > 0)
                     {
-                        state = await PrepareActionsRecursiveLegacyAsync(executionContext, state, setupInfo.Steps, depth + 1, action.Id);
+                        // Propagate parent's repo context for nested dollar-self resolution
+                        var parentRef = action.Reference as Pipelines.RepositoryPathReference;
+                        var childRepoName = dollarSelfRepoName;
+                        var childRepoRef = dollarSelfRepoRef;
+                        if (parentRef != null &&
+                            string.Equals(parentRef.RepositoryType, Pipelines.RepositoryTypes.GitHub, StringComparison.OrdinalIgnoreCase))
+                        {
+                            childRepoName = parentRef.Name;
+                            childRepoRef = parentRef.Ref;
+                        }
+                        state = await PrepareActionsRecursiveLegacyAsync(executionContext, state, setupInfo.Steps, depth + 1, action.Id, childRepoName, childRepoRef);
                     }
                     var repoAction = action.Reference as Pipelines.RepositoryPathReference;
                     if (repoAction.RepositoryType != Pipelines.PipelineConstants.SelfAlias)
@@ -1561,7 +1582,7 @@ namespace GitHub.Runner.Worker
 
             if (string.Equals(repositoryReference.RepositoryType, Pipelines.PipelineConstants.DollarSelfAlias, StringComparison.OrdinalIgnoreCase))
             {
-                throw new InvalidOperationException($"Dollar-self ($/path) reference was not resolved before download. Ensure the '{Constants.Runner.Features.DollarSelfReference}' feature flag is enabled.");
+                throw new InvalidOperationException($"Unable to resolve self-reference '$/'. Self-references require a server version that supports this syntax. Ensure the workflow is running on a compatible GitHub Actions environment.");
             }
 
             if (!string.Equals(repositoryReference.RepositoryType, Pipelines.RepositoryTypes.GitHub, StringComparison.OrdinalIgnoreCase))

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -704,6 +704,12 @@ namespace GitHub.Runner.Worker
                         actionDirectory = Path.Combine(actionDirectory, repoAction.Path);
                     }
                 }
+                else if (string.Equals(repoAction.RepositoryType, Pipelines.PipelineConstants.SelfRepositoryAlias, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Unresolved self-repository reference at load time — this
+                    // shouldn't happen but guard against NRE if it does.
+                    throw new InvalidOperationException($"Self-repository reference '$/{repoAction.Path}' was not resolved before LoadAction. Ensure the '{Constants.Runner.Features.SelfRepository}' feature flag is enabled.");
+                }
                 else
                 {
                     actionDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Actions), repoAction.Name.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), repoAction.Ref);
@@ -844,16 +850,20 @@ namespace GitHub.Runner.Worker
                         // During setup, resolution happens on a separate copy of these
                         // step objects. At runtime, action.yml is re-parsed, producing
                         // fresh self-repository refs that need resolution here.
+                        // When the parent is a dot-slash (self local-workspace) action,
+                        // repoAction.Name/Ref are null — fall back to workflow context.
                         if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfRepository) == true)
                         {
-                            ResolveSelfRepositoryReferences(executionContext, compositeAction.Steps, repoAction.Name, repoAction.Ref);
+                            var parentName = repoAction.Name ?? executionContext.JobContext?.WorkflowRepository;
+                            var parentRef = repoAction.Ref ?? executionContext.JobContext?.WorkflowSha;
+                            ResolveSelfRepositoryReferences(executionContext, compositeAction.Steps, parentName, parentRef);
                             if (compositeAction.PreSteps != null)
                             {
-                                ResolveSelfRepositoryReferences(executionContext, compositeAction.PreSteps, repoAction.Name, repoAction.Ref);
+                                ResolveSelfRepositoryReferences(executionContext, compositeAction.PreSteps, parentName, parentRef);
                             }
                             if (compositeAction.PostSteps != null)
                             {
-                                ResolveSelfRepositoryReferences(executionContext, compositeAction.PostSteps, repoAction.Name, repoAction.Ref);
+                                ResolveSelfRepositoryReferences(executionContext, compositeAction.PostSteps, parentName, parentRef);
                             }
                         }
                     }

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -187,7 +187,7 @@ namespace GitHub.Runner.Worker
                 throw new Exception($"Composite action depth exceeded max depth {Constants.CompositeActionsMaxDepth}");
             }
 
-            // Resolve self-reference ($/) references before processing
+            // Resolve self-repository ($/) references before processing
             if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
             {
                 if (string.IsNullOrEmpty(selfRepoName))
@@ -317,41 +317,53 @@ namespace GitHub.Runner.Worker
                 // then recurse per parent (which hits the cache, not the API).
                 if (nextLevel.Count > 0)
                 {
-                    // Pre-compute parent context per group for self-reference
-                    // resolution and recursion. Self-reference refs in nextLevel
-                    // must be resolved BEFORE batch download-info resolution,
-                    // since GetDownloadInfoLookupKey requires concrete refs.
-                    var groups = nextLevel.GroupBy(x => x.parentId).Select(group =>
-                    {
-                        string childRepoName = selfRepoName;
-                        string childRepoRef = selfRepoRef;
-                        var parentAction = repositoryActions.FirstOrDefault(a => a.Id == group.Key);
-                        if (parentAction?.Reference is Pipelines.RepositoryPathReference parentRef &&
-                            string.Equals(parentRef.RepositoryType, Pipelines.RepositoryTypes.GitHub, StringComparison.OrdinalIgnoreCase))
-                        {
-                            childRepoName = parentRef.Name;
-                            childRepoRef = parentRef.Ref;
-                        }
-                        return new { ParentId = group.Key, Actions = group.Select(x => x.action).ToList(), RepoName = childRepoName, RepoRef = childRepoRef };
-                    }).ToList();
-
                     if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
                     {
+                        // Self-repository path: group by parent so each group's
+                        // $/ refs resolve against the correct parent repo context.
+                        var groups = nextLevel.GroupBy(x => x.parentId).Select(group =>
+                        {
+                            string childRepoName = selfRepoName;
+                            string childRepoRef = selfRepoRef;
+                            var parentAction = repositoryActions.FirstOrDefault(a => a.Id == group.Key);
+                            if (parentAction?.Reference is Pipelines.RepositoryPathReference parentRef &&
+                                string.Equals(parentRef.RepositoryType, Pipelines.RepositoryTypes.GitHub, StringComparison.OrdinalIgnoreCase))
+                            {
+                                childRepoName = parentRef.Name;
+                                childRepoRef = parentRef.Ref;
+                            }
+                            return new { ParentId = group.Key, Actions = group.Select(x => x.action).ToList(), RepoName = childRepoName, RepoRef = childRepoRef };
+                        }).ToList();
+
                         foreach (var group in groups)
                         {
                             ResolveSelfReferences(executionContext, group.Actions, group.RepoName, group.RepoRef);
                         }
+
+                        var nextLevelRepoActions = nextLevel
+                            .Where(x => x.action.Reference.Type == Pipelines.ActionSourceType.Repository)
+                            .Select(x => x.action)
+                            .ToList();
+                        await ResolveNewActionsAsync(executionContext, nextLevelRepoActions, resolvedDownloadInfos);
+
+                        foreach (var group in groups)
+                        {
+                            state = await PrepareActionsRecursiveAsync(executionContext, state, group.Actions, resolvedDownloadInfos, depth + 1, group.ParentId, group.RepoName, group.RepoRef);
+                        }
                     }
-
-                    var nextLevelRepoActions = nextLevel
-                        .Where(x => x.action.Reference.Type == Pipelines.ActionSourceType.Repository)
-                        .Select(x => x.action)
-                        .ToList();
-                    await ResolveNewActionsAsync(executionContext, nextLevelRepoActions, resolvedDownloadInfos);
-
-                    foreach (var group in groups)
+                    else
                     {
-                        state = await PrepareActionsRecursiveAsync(executionContext, state, group.Actions, resolvedDownloadInfos, depth + 1, group.ParentId, group.RepoName, group.RepoRef);
+                        // Original path: no self-repository resolution needed.
+                        var nextLevelActions = nextLevel.Select(x => x.action).ToList();
+                        var nextLevelRepoActions = nextLevelActions
+                            .Where(x => x.Reference.Type == Pipelines.ActionSourceType.Repository)
+                            .ToList();
+                        await ResolveNewActionsAsync(executionContext, nextLevelRepoActions, resolvedDownloadInfos);
+
+                        foreach (var grp in nextLevel.GroupBy(x => x.parentId))
+                        {
+                            state = await PrepareActionsRecursiveAsync(executionContext, state, grp.Select(x => x.action).ToList(), resolvedDownloadInfos, depth + 1, grp.Key);
+                        }
                     }
                 }
 
@@ -435,7 +447,7 @@ namespace GitHub.Runner.Worker
                 throw new Exception($"Composite action depth exceeded max depth {Constants.CompositeActionsMaxDepth}");
             }
 
-            // Resolve self-reference ($/) references before processing
+            // Resolve self-repository ($/) references before processing
             if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
             {
                 if (string.IsNullOrEmpty(selfRepoName))
@@ -570,7 +582,7 @@ namespace GitHub.Runner.Worker
                     }
                     else if (setupInfo != null && setupInfo.Steps != null && setupInfo.Steps.Count > 0)
                     {
-                        // Propagate parent's repo context for nested self-reference resolution
+                        // Propagate parent's repo context for nested self-repository resolution
                         var parentRef = action.Reference as Pipelines.RepositoryPathReference;
                         var childRepoName = selfRepoName;
                         var childRepoRef = selfRepoRef;
@@ -829,10 +841,10 @@ namespace GitHub.Runner.Worker
                             }
                         }
 
-                        // Resolve self-reference refs in composite steps at load time.
+                        // Resolve self-repository refs in composite steps at load time.
                         // During setup, resolution happens on a separate copy of these
                         // step objects. At runtime, action.yml is re-parsed, producing
-                        // fresh self-reference refs that need resolution here.
+                        // fresh self-repository refs that need resolution here.
                         if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
                         {
                             ResolveSelfReferences(executionContext, compositeAction.Steps, repoAction.Name, repoAction.Ref);
@@ -1549,7 +1561,7 @@ namespace GitHub.Runner.Worker
                     continue;
                 }
 
-                Trace.Info($"Resolving self-reference reference '$/{repoAction.Path}' to '{repoName}/{repoAction.Path}@{repoRef}'");
+                Trace.Info($"Resolving self-repository reference reference '$/{repoAction.Path}' to '{repoName}/{repoAction.Path}@{repoRef}'");
                 executionContext.Debug($"Resolving $/{repoAction.Path} → {repoName}/{repoAction.Path}@{repoRef}");
 
                 repoAction.RepositoryType = Pipelines.RepositoryTypes.GitHub;

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -179,7 +179,7 @@ namespace GitHub.Runner.Worker
             return new PrepareResult(containerSetupSteps, result.PreStepTracker);
         }
 
-        private async Task<PrepareActionsState> PrepareActionsRecursiveAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Dictionary<string, WebApi.ActionDownloadInfo> resolvedDownloadInfos, Int32 depth = 0, Guid parentStepId = default(Guid), string dollarSelfRepoName = null, string dollarSelfRepoRef = null)
+        private async Task<PrepareActionsState> PrepareActionsRecursiveAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Dictionary<string, WebApi.ActionDownloadInfo> resolvedDownloadInfos, Int32 depth = 0, Guid parentStepId = default(Guid), string selfRepoName = null, string selfRepoRef = null)
         {
             ArgUtil.NotNull(executionContext, nameof(executionContext));
             if (depth > Constants.CompositeActionsMaxDepth)
@@ -187,19 +187,19 @@ namespace GitHub.Runner.Worker
                 throw new Exception($"Composite action depth exceeded max depth {Constants.CompositeActionsMaxDepth}");
             }
 
-            // Resolve dollar-self ($/path) references before processing
-            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DollarSelfReference) == true)
+            // Resolve self-reference ($/) references before processing
+            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
             {
-                if (string.IsNullOrEmpty(dollarSelfRepoName))
+                if (string.IsNullOrEmpty(selfRepoName))
                 {
                     // job.workflow_repository/workflow_sha point to the repo
                     // containing the workflow file — correct for both regular
                     // and reusable workflows. Always present when the server
                     // supports $/. See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context
-                    dollarSelfRepoName = executionContext.JobContext?.WorkflowRepository;
-                    dollarSelfRepoRef = executionContext.JobContext?.WorkflowSha;
+                    selfRepoName = executionContext.JobContext?.WorkflowRepository;
+                    selfRepoRef = executionContext.JobContext?.WorkflowSha;
                 }
-                ResolveDollarSelfReferences(executionContext, actions, dollarSelfRepoName, dollarSelfRepoRef);
+                ResolveSelfReferences(executionContext, actions, selfRepoName, selfRepoRef);
             }
 
             var repositoryActions = new List<Pipelines.ActionStep>();
@@ -317,14 +317,14 @@ namespace GitHub.Runner.Worker
                 // then recurse per parent (which hits the cache, not the API).
                 if (nextLevel.Count > 0)
                 {
-                    // Pre-compute parent context per group for dollar-self
-                    // resolution and recursion. Dollar-self refs in nextLevel
+                    // Pre-compute parent context per group for self-reference
+                    // resolution and recursion. Self-reference refs in nextLevel
                     // must be resolved BEFORE batch download-info resolution,
                     // since GetDownloadInfoLookupKey requires concrete refs.
                     var groups = nextLevel.GroupBy(x => x.parentId).Select(group =>
                     {
-                        string childRepoName = dollarSelfRepoName;
-                        string childRepoRef = dollarSelfRepoRef;
+                        string childRepoName = selfRepoName;
+                        string childRepoRef = selfRepoRef;
                         var parentAction = repositoryActions.FirstOrDefault(a => a.Id == group.Key);
                         if (parentAction?.Reference is Pipelines.RepositoryPathReference parentRef &&
                             string.Equals(parentRef.RepositoryType, Pipelines.RepositoryTypes.GitHub, StringComparison.OrdinalIgnoreCase))
@@ -335,11 +335,11 @@ namespace GitHub.Runner.Worker
                         return new { ParentId = group.Key, Actions = group.Select(x => x.action).ToList(), RepoName = childRepoName, RepoRef = childRepoRef };
                     }).ToList();
 
-                    if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DollarSelfReference) == true)
+                    if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
                     {
                         foreach (var group in groups)
                         {
-                            ResolveDollarSelfReferences(executionContext, group.Actions, group.RepoName, group.RepoRef);
+                            ResolveSelfReferences(executionContext, group.Actions, group.RepoName, group.RepoRef);
                         }
                     }
 
@@ -427,7 +427,7 @@ namespace GitHub.Runner.Worker
         /// sub-actions individually, with no cross-depth deduplication.
         /// Used when the BatchActionResolution feature flag is disabled.
         /// </summary>
-        private async Task<PrepareActionsState> PrepareActionsRecursiveLegacyAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Int32 depth = 0, Guid parentStepId = default(Guid), string dollarSelfRepoName = null, string dollarSelfRepoRef = null)
+        private async Task<PrepareActionsState> PrepareActionsRecursiveLegacyAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable<Pipelines.ActionStep> actions, Int32 depth = 0, Guid parentStepId = default(Guid), string selfRepoName = null, string selfRepoRef = null)
         {
             ArgUtil.NotNull(executionContext, nameof(executionContext));
             if (depth > Constants.CompositeActionsMaxDepth)
@@ -435,15 +435,15 @@ namespace GitHub.Runner.Worker
                 throw new Exception($"Composite action depth exceeded max depth {Constants.CompositeActionsMaxDepth}");
             }
 
-            // Resolve dollar-self ($/path) references before processing
-            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DollarSelfReference) == true)
+            // Resolve self-reference ($/) references before processing
+            if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
             {
-                if (string.IsNullOrEmpty(dollarSelfRepoName))
+                if (string.IsNullOrEmpty(selfRepoName))
                 {
-                    dollarSelfRepoName = executionContext.JobContext?.WorkflowRepository;
-                    dollarSelfRepoRef = executionContext.JobContext?.WorkflowSha;
+                    selfRepoName = executionContext.JobContext?.WorkflowRepository;
+                    selfRepoRef = executionContext.JobContext?.WorkflowSha;
                 }
-                ResolveDollarSelfReferences(executionContext, actions, dollarSelfRepoName, dollarSelfRepoRef);
+                ResolveSelfReferences(executionContext, actions, selfRepoName, selfRepoRef);
             }
 
             var repositoryActions = new List<Pipelines.ActionStep>();
@@ -570,10 +570,10 @@ namespace GitHub.Runner.Worker
                     }
                     else if (setupInfo != null && setupInfo.Steps != null && setupInfo.Steps.Count > 0)
                     {
-                        // Propagate parent's repo context for nested dollar-self resolution
+                        // Propagate parent's repo context for nested self-reference resolution
                         var parentRef = action.Reference as Pipelines.RepositoryPathReference;
-                        var childRepoName = dollarSelfRepoName;
-                        var childRepoRef = dollarSelfRepoRef;
+                        var childRepoName = selfRepoName;
+                        var childRepoRef = selfRepoRef;
                         if (parentRef != null &&
                             string.Equals(parentRef.RepositoryType, Pipelines.RepositoryTypes.GitHub, StringComparison.OrdinalIgnoreCase))
                         {
@@ -829,20 +829,20 @@ namespace GitHub.Runner.Worker
                             }
                         }
 
-                        // Resolve dollar-self refs in composite steps at load time.
+                        // Resolve self-reference refs in composite steps at load time.
                         // During setup, resolution happens on a separate copy of these
                         // step objects. At runtime, action.yml is re-parsed, producing
-                        // fresh dollar-self refs that need resolution here.
-                        if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.DollarSelfReference) == true)
+                        // fresh self-reference refs that need resolution here.
+                        if (executionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SelfReference) == true)
                         {
-                            ResolveDollarSelfReferences(executionContext, compositeAction.Steps, repoAction.Name, repoAction.Ref);
+                            ResolveSelfReferences(executionContext, compositeAction.Steps, repoAction.Name, repoAction.Ref);
                             if (compositeAction.PreSteps != null)
                             {
-                                ResolveDollarSelfReferences(executionContext, compositeAction.PreSteps, repoAction.Name, repoAction.Ref);
+                                ResolveSelfReferences(executionContext, compositeAction.PreSteps, repoAction.Name, repoAction.Ref);
                             }
                             if (compositeAction.PostSteps != null)
                             {
-                                ResolveDollarSelfReferences(executionContext, compositeAction.PostSteps, repoAction.Name, repoAction.Ref);
+                                ResolveSelfReferences(executionContext, compositeAction.PostSteps, repoAction.Name, repoAction.Ref);
                             }
                         }
                     }
@@ -1525,11 +1525,11 @@ namespace GitHub.Runner.Worker
         }
 
         /// <summary>
-        /// Resolves dollar-self ($/path) references by mutating them in-place
+        /// Resolves self-reference ($/) references by mutating them in-place
         /// to standard GitHub repository references with the containing repo's
         /// name and ref.
         /// </summary>
-        private void ResolveDollarSelfReferences(IExecutionContext executionContext, IEnumerable<Pipelines.ActionStep> actions, string repoName, string repoRef)
+        private void ResolveSelfReferences(IExecutionContext executionContext, IEnumerable<Pipelines.ActionStep> actions, string repoName, string repoRef)
         {
             if (string.IsNullOrEmpty(repoName) || string.IsNullOrEmpty(repoRef))
             {
@@ -1549,7 +1549,7 @@ namespace GitHub.Runner.Worker
                     continue;
                 }
 
-                Trace.Info($"Resolving dollar-self reference '$/{repoAction.Path}' to '{repoName}/{repoAction.Path}@{repoRef}'");
+                Trace.Info($"Resolving self-reference reference '$/{repoAction.Path}' to '{repoName}/{repoAction.Path}@{repoRef}'");
                 executionContext.Debug($"Resolving $/{repoAction.Path} → {repoName}/{repoAction.Path}@{repoRef}");
 
                 repoAction.RepositoryType = Pipelines.RepositoryTypes.GitHub;

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -611,12 +611,12 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                         Path = uses.Value
                     };
                 }
-                else if (PipelineConstants.TryParseDollarSelfReference(uses.Value, out var dollarSelfPath))
+                else if (PipelineConstants.TryParseSelfReference(uses.Value, out var selfPath))
                 {
                     result.Reference = new RepositoryPathReference
                     {
                         RepositoryType = PipelineConstants.SelfRepositoryAlias,
-                        Path = dollarSelfPath
+                        Path = selfPath
                     };
                 }
                 else

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -611,7 +611,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                         Path = uses.Value
                     };
                 }
-                else if (PipelineConstants.TryParseSelfReference(uses.Value, out var selfPath))
+                else if (PipelineConstants.TryParseSelfRepository(uses.Value, out var selfPath))
                 {
                     result.Reference = new RepositoryPathReference
                     {

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -55,7 +55,18 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                         break;
                     case ActionSourceType.Repository:
                         var repositoryReference = step.Reference as RepositoryPathReference;
-                        name = !String.IsNullOrEmpty(repositoryReference.Name) ? repositoryReference.Name : PipelineConstants.SelfAlias;
+                        if (!String.IsNullOrEmpty(repositoryReference.Name))
+                        {
+                            name = repositoryReference.Name;
+                        }
+                        else if (String.Equals(repositoryReference.RepositoryType, PipelineConstants.DollarSelfAlias, StringComparison.OrdinalIgnoreCase))
+                        {
+                            name = PipelineConstants.DollarSelfAlias;
+                        }
+                        else
+                        {
+                            name = PipelineConstants.SelfAlias;
+                        }
                         break;
                 }
 
@@ -598,6 +609,14 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                     {
                         RepositoryType = PipelineConstants.SelfAlias,
                         Path = uses.Value
+                    };
+                }
+                else if (PipelineConstants.TryParseDollarSelfReference(uses.Value, out var dollarSelfPath))
+                {
+                    result.Reference = new RepositoryPathReference
+                    {
+                        RepositoryType = PipelineConstants.DollarSelfAlias,
+                        Path = dollarSelfPath
                     };
                 }
                 else

--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -59,9 +59,9 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                         {
                             name = repositoryReference.Name;
                         }
-                        else if (String.Equals(repositoryReference.RepositoryType, PipelineConstants.DollarSelfAlias, StringComparison.OrdinalIgnoreCase))
+                        else if (String.Equals(repositoryReference.RepositoryType, PipelineConstants.SelfRepositoryAlias, StringComparison.OrdinalIgnoreCase))
                         {
-                            name = PipelineConstants.DollarSelfAlias;
+                            name = PipelineConstants.SelfRepositoryAlias;
                         }
                         else
                         {
@@ -615,7 +615,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
                 {
                     result.Reference = new RepositoryPathReference
                     {
-                        RepositoryType = PipelineConstants.DollarSelfAlias,
+                        RepositoryType = PipelineConstants.SelfRepositoryAlias,
                         Path = dollarSelfPath
                     };
                 }

--- a/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
@@ -61,7 +61,12 @@ namespace GitHub.DistributedTask.Pipelines
         {
             if (usesValue != null && usesValue.StartsWith(DollarSelfPrefix, StringComparison.Ordinal))
             {
-                path = usesValue.Substring(DollarSelfPrefix.Length);
+                path = usesValue.Substring(DollarSelfPrefix.Length).TrimStart('/');
+                if (string.IsNullOrEmpty(path))
+                {
+                    path = null;
+                    return false;
+                }
                 return true;
             }
 

--- a/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
@@ -38,23 +38,24 @@ namespace GitHub.DistributedTask.Pipelines
         public static readonly Int32 MaxNodeNameLength = 100;
 
         /// <summary>
-        /// Alias for the self repository.
+        /// Alias for the self local-workspace repository type (./ syntax).
+        /// Resolves to the local checkout on the runner.
         /// </summary>
         public static readonly String SelfAlias = "self";
 
         /// <summary>
-        /// RepositoryType for self-references ($/path).
+        /// RepositoryType for self-repository references ($/ syntax).
         /// Resolves to "this repo, at this SHA" based on the containing YAML file.
         /// </summary>
         public static readonly String SelfRepositoryAlias = "selfRepository";
 
         /// <summary>
-        /// The prefix for self-reference references in uses: values.
+        /// The prefix for self-repository references in uses: values.
         /// </summary>
         public const String SelfReferencePrefix = "$/";
 
         /// <summary>
-        /// Returns true if the uses value is a self-reference reference (starts with $/),
+        /// Returns true if the uses value is a self-repository reference (starts with $/),
         /// and outputs the subpath after the prefix.
         /// </summary>
         public static bool TryParseSelfReference(string usesValue, out string path)

--- a/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
@@ -43,6 +43,33 @@ namespace GitHub.DistributedTask.Pipelines
         public static readonly String SelfAlias = "self";
 
         /// <summary>
+        /// Alias for dollar-self references ($/path).
+        /// Resolves to "this repo, at this SHA" based on the containing YAML file.
+        /// </summary>
+        public static readonly String DollarSelfAlias = "dollar-self";
+
+        /// <summary>
+        /// The prefix for dollar-self references in uses: values.
+        /// </summary>
+        public const String DollarSelfPrefix = "$/";
+
+        /// <summary>
+        /// Returns true if the uses value is a dollar-self reference (starts with $/),
+        /// and outputs the subpath after the prefix.
+        /// </summary>
+        public static bool TryParseDollarSelfReference(string usesValue, out string path)
+        {
+            if (usesValue != null && usesValue.StartsWith(DollarSelfPrefix, StringComparison.Ordinal))
+            {
+                path = usesValue.Substring(DollarSelfPrefix.Length);
+                return true;
+            }
+
+            path = null;
+            return false;
+        }
+
+        /// <summary>
         /// Error code during graph validation.
         /// </summary>
         internal const String DependencyNotFound = nameof(DependencyNotFound);

--- a/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
@@ -49,19 +49,19 @@ namespace GitHub.DistributedTask.Pipelines
         public static readonly String SelfRepositoryAlias = "selfRepository";
 
         /// <summary>
-        /// The prefix for dollar-self references in uses: values.
+        /// The prefix for self-reference references in uses: values.
         /// </summary>
-        public const String DollarSelfPrefix = "$/";
+        public const String SelfReferencePrefix = "$/";
 
         /// <summary>
-        /// Returns true if the uses value is a dollar-self reference (starts with $/),
+        /// Returns true if the uses value is a self-reference reference (starts with $/),
         /// and outputs the subpath after the prefix.
         /// </summary>
-        public static bool TryParseDollarSelfReference(string usesValue, out string path)
+        public static bool TryParseSelfReference(string usesValue, out string path)
         {
-            if (usesValue != null && usesValue.StartsWith(DollarSelfPrefix, StringComparison.Ordinal))
+            if (usesValue != null && usesValue.StartsWith(SelfReferencePrefix, StringComparison.Ordinal))
             {
-                path = usesValue.Substring(DollarSelfPrefix.Length).TrimStart('/');
+                path = usesValue.Substring(SelfReferencePrefix.Length).TrimStart('/');
                 if (string.IsNullOrEmpty(path))
                 {
                     path = null;

--- a/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
@@ -52,17 +52,17 @@ namespace GitHub.DistributedTask.Pipelines
         /// <summary>
         /// The prefix for self-repository references in uses: values.
         /// </summary>
-        public const String SelfReferencePrefix = "$/";
+        public const String SelfRepositoryPrefix = "$/";
 
         /// <summary>
         /// Returns true if the uses value is a self-repository reference (starts with $/),
         /// and outputs the subpath after the prefix.
         /// </summary>
-        public static bool TryParseSelfReference(string usesValue, out string path)
+        public static bool TryParseSelfRepository(string usesValue, out string path)
         {
-            if (usesValue != null && usesValue.StartsWith(SelfReferencePrefix, StringComparison.Ordinal))
+            if (usesValue != null && usesValue.StartsWith(SelfRepositoryPrefix, StringComparison.Ordinal))
             {
-                path = usesValue.Substring(SelfReferencePrefix.Length).TrimStart('/');
+                path = usesValue.Substring(SelfRepositoryPrefix.Length).TrimStart('/');
                 if (string.IsNullOrEmpty(path))
                 {
                     path = null;

--- a/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
+++ b/src/Sdk/DTPipelines/Pipelines/PipelineConstants.cs
@@ -43,10 +43,10 @@ namespace GitHub.DistributedTask.Pipelines
         public static readonly String SelfAlias = "self";
 
         /// <summary>
-        /// Alias for dollar-self references ($/path).
+        /// RepositoryType for self-references ($/path).
         /// Resolves to "this repo, at this SHA" based on the containing YAML file.
         /// </summary>
-        public static readonly String DollarSelfAlias = "dollar-self";
+        public static readonly String SelfRepositoryAlias = "selfRepository";
 
         /// <summary>
         /// The prefix for dollar-self references in uses: values.

--- a/src/Sdk/WorkflowParser/Conversion/WorkflowTemplateConverter.cs
+++ b/src/Sdk/WorkflowParser/Conversion/WorkflowTemplateConverter.cs
@@ -1605,7 +1605,7 @@ namespace GitHub.Actions.WorkflowParser.Conversion
                     {
                         id = WorkflowConstants.SelfAlias;
                     }
-                    else if (GitHub.DistributedTask.Pipelines.PipelineConstants.TryParseSelfReference(action.Uses!.Value, out _))
+                    else if (GitHub.DistributedTask.Pipelines.PipelineConstants.TryParseSelfRepository(action.Uses!.Value, out _))
                     {
                         id = WorkflowConstants.SelfRepositoryAlias;
                     }

--- a/src/Sdk/WorkflowParser/Conversion/WorkflowTemplateConverter.cs
+++ b/src/Sdk/WorkflowParser/Conversion/WorkflowTemplateConverter.cs
@@ -1607,7 +1607,7 @@ namespace GitHub.Actions.WorkflowParser.Conversion
                     }
                     else if (GitHub.DistributedTask.Pipelines.PipelineConstants.TryParseDollarSelfReference(action.Uses!.Value, out _))
                     {
-                        id = WorkflowConstants.DollarSelfAlias;
+                        id = WorkflowConstants.SelfRepositoryAlias;
                     }
                     else
                     {

--- a/src/Sdk/WorkflowParser/Conversion/WorkflowTemplateConverter.cs
+++ b/src/Sdk/WorkflowParser/Conversion/WorkflowTemplateConverter.cs
@@ -1605,6 +1605,10 @@ namespace GitHub.Actions.WorkflowParser.Conversion
                     {
                         id = WorkflowConstants.SelfAlias;
                     }
+                    else if (GitHub.DistributedTask.Pipelines.PipelineConstants.TryParseDollarSelfReference(action.Uses!.Value, out _))
+                    {
+                        id = WorkflowConstants.DollarSelfAlias;
+                    }
                     else
                     {
                         var usesSegments = action.Uses!.Value.Split('@');

--- a/src/Sdk/WorkflowParser/Conversion/WorkflowTemplateConverter.cs
+++ b/src/Sdk/WorkflowParser/Conversion/WorkflowTemplateConverter.cs
@@ -1605,7 +1605,7 @@ namespace GitHub.Actions.WorkflowParser.Conversion
                     {
                         id = WorkflowConstants.SelfAlias;
                     }
-                    else if (GitHub.DistributedTask.Pipelines.PipelineConstants.TryParseDollarSelfReference(action.Uses!.Value, out _))
+                    else if (GitHub.DistributedTask.Pipelines.PipelineConstants.TryParseSelfReference(action.Uses!.Value, out _))
                     {
                         id = WorkflowConstants.SelfRepositoryAlias;
                     }

--- a/src/Sdk/WorkflowParser/WorkflowConstants.cs
+++ b/src/Sdk/WorkflowParser/WorkflowConstants.cs
@@ -31,9 +31,9 @@ namespace GitHub.Actions.WorkflowParser
         internal const String SelfAlias = "self";
 
         /// <summary>
-        /// Alias for dollar-self references ($/path).
+        /// RepositoryType for self-references ($/path).
         /// </summary>
-        internal const String DollarSelfAlias = "dollar-self";
+        internal const String SelfRepositoryAlias = "selfRepository";
 
         public static class PermissionsPolicy
         {

--- a/src/Sdk/WorkflowParser/WorkflowConstants.cs
+++ b/src/Sdk/WorkflowParser/WorkflowConstants.cs
@@ -26,12 +26,12 @@ namespace GitHub.Actions.WorkflowParser
         internal const Int32 MaxNodeNameLength = 100;
 
         /// <summary>
-        /// Alias for the self repository.
+        /// Alias for the self local-workspace repository type (./ syntax).
         /// </summary>
         internal const String SelfAlias = "self";
 
         /// <summary>
-        /// RepositoryType for self-references ($/path).
+        /// RepositoryType for self-repository references ($/ syntax).
         /// </summary>
         internal const String SelfRepositoryAlias = "selfRepository";
 

--- a/src/Sdk/WorkflowParser/WorkflowConstants.cs
+++ b/src/Sdk/WorkflowParser/WorkflowConstants.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace GitHub.Actions.WorkflowParser
 {
@@ -29,6 +29,11 @@ namespace GitHub.Actions.WorkflowParser
         /// Alias for the self repository.
         /// </summary>
         internal const String SelfAlias = "self";
+
+        /// <summary>
+        /// Alias for dollar-self references ($/path).
+        /// </summary>
+        internal const String DollarSelfAlias = "dollar-self";
 
         public static class PermissionsPolicy
         {

--- a/src/Sdk/WorkflowParser/WorkflowConstants.cs
+++ b/src/Sdk/WorkflowParser/WorkflowConstants.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace GitHub.Actions.WorkflowParser
 {

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -3564,7 +3564,7 @@ runs:
                         Id = actionId,
                         Reference = new Pipelines.RepositoryPathReference()
                         {
-                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            RepositoryType = Pipelines.PipelineConstants.SelfRepositoryAlias,
                             Path = "actions/my-action"
                         }
                     }
@@ -3630,7 +3630,7 @@ runs:
                         Id = actionId,
                         Reference = new Pipelines.RepositoryPathReference()
                         {
-                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            RepositoryType = Pipelines.PipelineConstants.SelfRepositoryAlias,
                             Path = "actions/my-action"
                         }
                     }
@@ -3709,7 +3709,7 @@ runs:
                         Id = Guid.NewGuid(),
                         Reference = new Pipelines.RepositoryPathReference()
                         {
-                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            RepositoryType = Pipelines.PipelineConstants.SelfRepositoryAlias,
                             Path = "actions/parent"
                         }
                     }
@@ -3871,7 +3871,7 @@ runs:
                         Id = Guid.NewGuid(),
                         Reference = new Pipelines.RepositoryPathReference()
                         {
-                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            RepositoryType = Pipelines.PipelineConstants.SelfRepositoryAlias,
                             Path = "a"
                         }
                     }
@@ -3923,7 +3923,7 @@ runs:
                         Id = actionId,
                         Reference = new Pipelines.RepositoryPathReference()
                         {
-                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            RepositoryType = Pipelines.PipelineConstants.SelfRepositoryAlias,
                             Path = "actions/my-action"
                         }
                     }
@@ -4019,7 +4019,7 @@ runs:
                         Id = Guid.NewGuid(),
                         Reference = new Pipelines.RepositoryPathReference()
                         {
-                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            RepositoryType = Pipelines.PipelineConstants.SelfRepositoryAlias,
                             Path = "actions/parent"
                         }
                     }

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -3537,9 +3537,9 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_DollarSelf_ResolvesAtDepthZero()
+        public async void PrepareActions_SelfReference_ResolvesAtDepthZero()
         {
-            // Dollar-self is only supported via run service (batch resolution path)
+            // Self-references are only supported via run service (batch resolution path)
             Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", "true");
             try
             {
@@ -3549,7 +3549,7 @@ runs:
                 const string RepoSha = "abc123def456";
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RepoName;
                 jobContext.WorkflowSha = RepoSha;
@@ -3611,7 +3611,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_DollarSelf_NotResolvedWhenFeatureFlagDisabled()
+        public async void PrepareActions_SelfReference_NotResolvedWhenFeatureFlagDisabled()
         {
             try
             {
@@ -3636,7 +3636,7 @@ runs:
                     }
                 };
 
-                // Act & Assert — should throw because unresolved dollar-self hits GetDownloadInfoLookupKey
+                // Act & Assert — should throw because unresolved self-reference hits GetDownloadInfoLookupKey
                 await Assert.ThrowsAsync<InvalidOperationException>(async () =>
                     await _actionManager.PrepareActionsAsync(_ec.Object, actions));
             }
@@ -3649,7 +3649,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_DollarSelf_ResolvesNestedInComposite()
+        public async void PrepareActions_SelfReference_ResolvesNestedInComposite()
         {
             // Composite action at $/actions/parent uses $/actions/child (same repo).
             // This tests the batch path fix: $/ refs in nextLevel must be resolved
@@ -3668,7 +3668,7 @@ runs:
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
                 _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RepoName;
                 jobContext.WorkflowSha = RepoSha;
@@ -3735,7 +3735,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_DollarSelf_CrossRepoCompositeResolvesToParentRepo()
+        public async void PrepareActions_SelfReference_CrossRepoCompositeResolvesToParentRepo()
         {
             // External composite (external/foo@v1) uses $/lib/bar.
             // $/lib/bar should resolve to external/foo@v1 (the parent's repo),
@@ -3752,7 +3752,7 @@ runs:
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RootRepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RootRepoSha);
                 _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RootRepoName;
                 jobContext.WorkflowSha = RootRepoSha;
@@ -3813,7 +3813,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_DollarSelf_MultiLevelChain()
+        public async void PrepareActions_SelfReference_MultiLevelChain()
         {
             // $/a → composite → $/b → composite → $/c (three levels, same repo)
             Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", "true");
@@ -3826,7 +3826,7 @@ runs:
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
                 _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RepoName;
                 jobContext.WorkflowSha = RepoSha;
@@ -3897,7 +3897,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_DollarSelf_ResolvesAtDepthZero_LegacyPath()
+        public async void PrepareActions_SelfReference_ResolvesAtDepthZero_LegacyPath()
         {
             // Same as ResolvesAtDepthZero but on the legacy (non-batch) path
             try
@@ -3908,7 +3908,7 @@ runs:
                 const string RepoSha = "abc123def456";
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RepoName;
                 jobContext.WorkflowSha = RepoSha;
@@ -3967,7 +3967,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_DollarSelf_ResolvesNestedInComposite_LegacyPath()
+        public async void PrepareActions_SelfReference_ResolvesNestedInComposite_LegacyPath()
         {
             // Same as ResolvesNestedInComposite but on the legacy (non-batch) path.
             // Verifies that $/ resolution works when batch action resolution is disabled.
@@ -3980,7 +3980,7 @@ runs:
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
                 _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RepoName;
                 jobContext.WorkflowSha = RepoSha;

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -4041,5 +4041,96 @@ runs:
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void LoadAction_DotSlashCompositeWithNestedSelfRepository_ResolvesViaWorkflowContext()
+        {
+            // Regression test: when a dot-slash (./) composite action contains a
+            // nested $/actions/child step, LoadAction re-parses the action.yml at
+            // runtime and must resolve the $/ ref. The parent is repositoryType "self"
+            // so its Name and Ref are null — resolution must fall back to
+            // WorkflowRepository/WorkflowSha from the job context. Before the fix,
+            // this path hit a NullReferenceException at repoAction.Name.Replace().
+            try
+            {
+                // Arrange
+                Setup();
+                const string WorkflowRepo = "my-org/my-repo";
+                const string WorkflowSha = "abc123def456";
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfRepository, "true");
+                var jobContext = new JobContext();
+                jobContext.WorkflowRepository = WorkflowRepo;
+                jobContext.WorkflowSha = WorkflowSha;
+                _ec.Setup(x => x.JobContext).Returns(jobContext);
+
+                // Stage the dot-slash composite in the workspace directory.
+                // It contains a nested $/actions/child step.
+                string workspaceDir = Path.Combine(_workFolder, "actions", "actions");
+                string compositeDir = Path.Combine(workspaceDir, "my-composite");
+                Directory.CreateDirectory(compositeDir);
+                File.WriteAllText(Path.Combine(compositeDir, Constants.Path.ActionManifestYmlFile), @"
+name: 'DotSlash Parent'
+description: 'Composite loaded via ./ that nests a $/ ref'
+runs:
+  using: 'composite'
+  steps:
+    - run: echo 'hello'
+      shell: bash
+    - uses: $/actions/child
+");
+
+                // Stage the child action in the actions cache under the workflow repo.
+                string actionsDir = Path.Combine(_workFolder, Constants.Path.ActionsDirectory);
+                string childDir = Path.Combine(actionsDir, WorkflowRepo.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), WorkflowSha, "actions", "child");
+                Directory.CreateDirectory(childDir);
+                File.WriteAllText(Path.Combine(childDir, Constants.Path.ActionManifestYmlFile), @"
+name: 'Child'
+description: 'Leaf action'
+runs:
+  using: 'node20'
+  main: 'index.js'
+");
+
+                // Create dot-slash step with Name = null (the real scenario).
+                var instance = new Pipelines.ActionStep()
+                {
+                    Id = Guid.NewGuid(),
+                    Reference = new Pipelines.RepositoryPathReference()
+                    {
+                        Name = null,
+                        Ref = null,
+                        RepositoryType = Pipelines.PipelineConstants.SelfAlias,
+                        Path = "my-composite"
+                    }
+                };
+
+                // Act — should NOT throw NullReferenceException
+                Definition definition = _actionManager.LoadAction(_ec.Object, instance);
+
+                // Assert — loaded the composite successfully
+                Assert.NotNull(definition);
+                Assert.NotNull(definition.Data);
+                Assert.Equal(ActionExecutionType.Composite, definition.Data.Execution.ExecutionType);
+
+                // Assert — the nested $/ step was resolved to the workflow repo
+                var compositeData = definition.Data.Execution as CompositeActionExecutionData;
+                Assert.NotNull(compositeData);
+                var childStep = compositeData.Steps
+                    .OfType<Pipelines.ActionStep>()
+                    .FirstOrDefault(s => s.Reference is Pipelines.RepositoryPathReference r
+                        && r.Path == "actions/child");
+                Assert.NotNull(childStep);
+                var childRef = childStep.Reference as Pipelines.RepositoryPathReference;
+                Assert.Equal(Pipelines.RepositoryTypes.GitHub, childRef.RepositoryType);
+                Assert.Equal(WorkflowRepo, childRef.Name);
+                Assert.Equal(WorkflowSha, childRef.Ref);
+            }
+            finally
+            {
+                Teardown();
+            }
+        }
+
     }
 }

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -3537,7 +3537,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_SelfReference_ResolvesAtDepthZero()
+        public async void PrepareActions_SelfRepository_ResolvesAtDepthZero()
         {
             // Self-references are only supported via run service (batch resolution path)
             Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", "true");
@@ -3549,7 +3549,7 @@ runs:
                 const string RepoSha = "abc123def456";
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfRepository, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RepoName;
                 jobContext.WorkflowSha = RepoSha;
@@ -3611,7 +3611,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_SelfReference_NotResolvedWhenFeatureFlagDisabled()
+        public async void PrepareActions_SelfRepository_NotResolvedWhenFeatureFlagDisabled()
         {
             try
             {
@@ -3649,7 +3649,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_SelfReference_ResolvesNestedInComposite()
+        public async void PrepareActions_SelfRepository_ResolvesNestedInComposite()
         {
             // Composite action at $/actions/parent uses $/actions/child (same repo).
             // This tests the batch path fix: $/ refs in nextLevel must be resolved
@@ -3668,7 +3668,7 @@ runs:
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
                 _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfRepository, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RepoName;
                 jobContext.WorkflowSha = RepoSha;
@@ -3735,7 +3735,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_SelfReference_CrossRepoCompositeResolvesToParentRepo()
+        public async void PrepareActions_SelfRepository_CrossRepoCompositeResolvesToParentRepo()
         {
             // External composite (external/foo@v1) uses $/lib/bar.
             // $/lib/bar should resolve to external/foo@v1 (the parent's repo),
@@ -3752,7 +3752,7 @@ runs:
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RootRepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RootRepoSha);
                 _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfRepository, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RootRepoName;
                 jobContext.WorkflowSha = RootRepoSha;
@@ -3813,7 +3813,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_SelfReference_MultiLevelChain()
+        public async void PrepareActions_SelfRepository_MultiLevelChain()
         {
             // $/a → composite → $/b → composite → $/c (three levels, same repo)
             Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", "true");
@@ -3826,7 +3826,7 @@ runs:
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
                 _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfRepository, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RepoName;
                 jobContext.WorkflowSha = RepoSha;
@@ -3897,7 +3897,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_SelfReference_ResolvesAtDepthZero_LegacyPath()
+        public async void PrepareActions_SelfRepository_ResolvesAtDepthZero_LegacyPath()
         {
             // Same as ResolvesAtDepthZero but on the legacy (non-batch) path
             try
@@ -3908,7 +3908,7 @@ runs:
                 const string RepoSha = "abc123def456";
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfRepository, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RepoName;
                 jobContext.WorkflowSha = RepoSha;
@@ -3967,7 +3967,7 @@ runs:
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async void PrepareActions_SelfReference_ResolvesNestedInComposite_LegacyPath()
+        public async void PrepareActions_SelfRepository_ResolvesNestedInComposite_LegacyPath()
         {
             // Same as ResolvesNestedInComposite but on the legacy (non-batch) path.
             // Verifies that $/ resolution works when batch action resolution is disabled.
@@ -3980,7 +3980,7 @@ runs:
                 _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
                 _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
                 _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfReference, "true");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.SelfRepository, "true");
                 var jobContext = new JobContext();
                 jobContext.WorkflowRepository = RepoName;
                 jobContext.WorkflowSha = RepoSha;

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -585,9 +585,9 @@ runs:
 
                 //Assert
                 string destDirectory = Path.Combine(_hc.GetDirectory(WellKnownDirectory.Actions), "actions", "checkout", "master");
-                Assert.True(Directory.Exists(destDirectory), "Destination directory does not exist");  
-                var di = new DirectoryInfo(destDirectory);   
-                Assert.NotNull(di.LinkTarget); 
+                Assert.True(Directory.Exists(destDirectory), "Destination directory does not exist");
+                var di = new DirectoryInfo(destDirectory);
+                Assert.NotNull(di.LinkTarget);
             }
             finally
             {
@@ -2441,7 +2441,7 @@ runs:
             }
         }
 
-         [Fact]
+        [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
         public void LoadsNode24ActionDefinition()
@@ -2509,7 +2509,7 @@ runs:
                 Teardown();
             }
         }
-        
+
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
@@ -3533,5 +3533,435 @@ runs:
                 Teardown();
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async void PrepareActions_DollarSelf_ResolvesAtDepthZero()
+        {
+            try
+            {
+                // Arrange
+                Setup();
+                const string RepoName = "my-org/my-repo";
+                const string RepoSha = "abc123def456";
+                _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
+                _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                var jobContext = new JobContext();
+                jobContext.WorkflowRepository = RepoName;
+                jobContext.WorkflowSha = RepoSha;
+                _ec.Setup(x => x.JobContext).Returns(jobContext);
+
+                var actionId = Guid.NewGuid();
+                var actions = new List<Pipelines.ActionStep>
+                {
+                    new Pipelines.ActionStep()
+                    {
+                        Name = "action",
+                        Id = actionId,
+                        Reference = new Pipelines.RepositoryPathReference()
+                        {
+                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            Path = "actions/my-action"
+                        }
+                    }
+                };
+
+                string archiveFile = await CreateRepoArchive();
+                using var stream = File.OpenRead(archiveFile);
+                string archiveLink = GetLinkToActionArchive("https://api.github.com", RepoName, RepoSha);
+                var mockClientHandler = new Mock<HttpClientHandler>();
+                mockClientHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(m => m.RequestUri == new Uri(archiveLink)), ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream) });
+                var mockHandlerFactory = new Mock<IHttpClientHandlerFactory>();
+                mockHandlerFactory.Setup(p => p.CreateClientHandler(It.IsAny<RunnerWebProxy>())).Returns(mockClientHandler.Object);
+                _hc.SetSingleton(mockHandlerFactory.Object);
+
+                _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
+
+                // Act — resolution mutates the reference in-place before download/prepare.
+                // The archive doesn't contain the subpath, so prepare will fail, but the
+                // reference is already resolved by that point.
+                try
+                {
+                    await _actionManager.PrepareActionsAsync(_ec.Object, actions);
+                }
+                catch (InvalidOperationException ex) when (ex.Message.Contains("Can't find"))
+                {
+                    // Expected: test archive lacks the action.yml at the resolved subpath
+                }
+
+                // Assert — the reference should be resolved to a GitHub repo reference
+                var repoRef = actions[0].Reference as Pipelines.RepositoryPathReference;
+                Assert.Equal(Pipelines.RepositoryTypes.GitHub, repoRef.RepositoryType);
+                Assert.Equal(RepoName, repoRef.Name);
+                Assert.Equal(RepoSha, repoRef.Ref);
+                Assert.Equal("actions/my-action", repoRef.Path);
+            }
+            finally
+            {
+                Teardown();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async void PrepareActions_DollarSelf_NotResolvedWhenFeatureFlagDisabled()
+        {
+            try
+            {
+                // Arrange
+                Setup();
+                _ec.Setup(x => x.GetGitHubContext("repository")).Returns("my-org/my-repo");
+                _ec.Setup(x => x.GetGitHubContext("sha")).Returns("abc123");
+                // Feature flag NOT set
+
+                var actionId = Guid.NewGuid();
+                var actions = new List<Pipelines.ActionStep>
+                {
+                    new Pipelines.ActionStep()
+                    {
+                        Name = "action",
+                        Id = actionId,
+                        Reference = new Pipelines.RepositoryPathReference()
+                        {
+                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            Path = "actions/my-action"
+                        }
+                    }
+                };
+
+                // Act & Assert — should throw because unresolved dollar-self hits GetDownloadInfoLookupKey
+                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    await _actionManager.PrepareActionsAsync(_ec.Object, actions));
+            }
+            finally
+            {
+                Teardown();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async void PrepareActions_DollarSelf_ResolvesNestedInComposite()
+        {
+            // Composite action at $/actions/parent uses $/actions/child (same repo).
+            // This tests the batch path fix: $/ refs in nextLevel must be resolved
+            // BEFORE ResolveNewActionsAsync, otherwise GetDownloadInfoLookupKey throws.
+            // We pre-stage only the parent action.yml on disk so the composite steps
+            // are discovered, but we DON'T stage the child — a download failure for
+            // the child is fine; the important thing is that $/ was resolved
+            // (no InvalidOperationException from GetDownloadInfoLookupKey).
+            Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", "true");
+            try
+            {
+                // Arrange
+                Setup();
+                const string RepoName = "my-org/my-repo";
+                const string RepoSha = "abc123def456";
+                _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
+                _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
+                _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                var jobContext = new JobContext();
+                jobContext.WorkflowRepository = RepoName;
+                jobContext.WorkflowSha = RepoSha;
+                _ec.Setup(x => x.JobContext).Returns(jobContext);
+
+                // Stage parent action on disk as a composite that uses $/actions/child.
+                // We use rootStepId != default to avoid directory deletion,
+                // and create the watermark + action.yml in the expected location.
+                string actionsDir = Path.Combine(_workFolder, Constants.Path.ActionsDirectory);
+                string destDir = Path.Combine(actionsDir, RepoName.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), RepoSha);
+                Directory.CreateDirectory(Path.Combine(destDir, "actions", "parent"));
+                File.WriteAllText(Path.Combine(destDir, "actions", "parent", Constants.Path.ActionManifestYmlFile), @"
+name: 'Parent'
+description: 'Composite parent'
+runs:
+  using: 'composite'
+  steps:
+    - uses: $/actions/child
+");
+                // Stage child action too (as a leaf node action)
+                Directory.CreateDirectory(Path.Combine(destDir, "actions", "child"));
+                File.WriteAllText(Path.Combine(destDir, "actions", "child", Constants.Path.ActionManifestYmlFile), @"
+name: 'Child'
+description: 'Node child'
+runs:
+  using: 'node20'
+  main: 'index.js'
+");
+                // Write watermark
+                File.WriteAllText($"{destDir}.completed", string.Empty);
+
+                var rootStepId = Guid.NewGuid();
+                var actions = new List<Pipelines.ActionStep>
+                {
+                    new Pipelines.ActionStep()
+                    {
+                        Name = "action",
+                        Id = Guid.NewGuid(),
+                        Reference = new Pipelines.RepositoryPathReference()
+                        {
+                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            Path = "actions/parent"
+                        }
+                    }
+                };
+
+                // Act — should resolve $/ and not throw InvalidOperationException
+                await _actionManager.PrepareActionsAsync(_ec.Object, actions, rootStepId);
+
+                // Assert — top-level $/ resolved
+                var topRef = actions[0].Reference as Pipelines.RepositoryPathReference;
+                Assert.Equal(Pipelines.RepositoryTypes.GitHub, topRef.RepositoryType);
+                Assert.Equal(RepoName, topRef.Name);
+                Assert.Equal(RepoSha, topRef.Ref);
+                Assert.Equal("actions/parent", topRef.Path);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", null);
+                Teardown();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async void PrepareActions_DollarSelf_ResolvesNestedInComposite_LegacyPath()
+        {
+            // Same as above but exercises the legacy (non-batch) path.
+            try
+            {
+                // Arrange
+                Setup();
+                const string RepoName = "my-org/my-repo";
+                const string RepoSha = "abc123def456";
+                _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
+                _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
+                _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                var jobContext = new JobContext();
+                jobContext.WorkflowRepository = RepoName;
+                jobContext.WorkflowSha = RepoSha;
+                _ec.Setup(x => x.JobContext).Returns(jobContext);
+
+                string actionsDir = Path.Combine(_workFolder, Constants.Path.ActionsDirectory);
+                string destDir = Path.Combine(actionsDir, RepoName.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), RepoSha);
+                Directory.CreateDirectory(Path.Combine(destDir, "actions", "parent"));
+                File.WriteAllText(Path.Combine(destDir, "actions", "parent", Constants.Path.ActionManifestYmlFile), @"
+name: 'Parent'
+description: 'Composite parent'
+runs:
+  using: 'composite'
+  steps:
+    - uses: $/actions/child
+");
+                Directory.CreateDirectory(Path.Combine(destDir, "actions", "child"));
+                File.WriteAllText(Path.Combine(destDir, "actions", "child", Constants.Path.ActionManifestYmlFile), @"
+name: 'Child'
+description: 'Node child'
+runs:
+  using: 'node20'
+  main: 'index.js'
+");
+                File.WriteAllText($"{destDir}.completed", string.Empty);
+
+                var rootStepId = Guid.NewGuid();
+                var actions = new List<Pipelines.ActionStep>
+                {
+                    new Pipelines.ActionStep()
+                    {
+                        Name = "action",
+                        Id = Guid.NewGuid(),
+                        Reference = new Pipelines.RepositoryPathReference()
+                        {
+                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            Path = "actions/parent"
+                        }
+                    }
+                };
+
+                // Act
+                await _actionManager.PrepareActionsAsync(_ec.Object, actions, rootStepId);
+
+                // Assert
+                var topRef = actions[0].Reference as Pipelines.RepositoryPathReference;
+                Assert.Equal(Pipelines.RepositoryTypes.GitHub, topRef.RepositoryType);
+                Assert.Equal(RepoName, topRef.Name);
+                Assert.Equal(RepoSha, topRef.Ref);
+            }
+            finally
+            {
+                Teardown();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async void PrepareActions_DollarSelf_CrossRepoCompositeResolvesToParentRepo()
+        {
+            // External composite (external/foo@v1) uses $/lib/bar.
+            // $/lib/bar should resolve to external/foo@v1 (the parent's repo),
+            // NOT to the workflow's root repo.
+            Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", "true");
+            try
+            {
+                // Arrange
+                Setup();
+                const string RootRepoName = "my-org/my-repo";
+                const string RootRepoSha = "root-sha-111";
+                const string ExtRepoName = "external/foo";
+                const string ExtRepoRef = "v1";
+                _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RootRepoName);
+                _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RootRepoSha);
+                _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                var jobContext = new JobContext();
+                jobContext.WorkflowRepository = RootRepoName;
+                jobContext.WorkflowSha = RootRepoSha;
+                _ec.Setup(x => x.JobContext).Returns(jobContext);
+
+                string actionsDir = Path.Combine(_workFolder, Constants.Path.ActionsDirectory);
+                string destDir = Path.Combine(actionsDir, ExtRepoName.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), ExtRepoRef);
+                Directory.CreateDirectory(destDir);
+                File.WriteAllText(Path.Combine(destDir, Constants.Path.ActionManifestYmlFile), @"
+name: 'External Foo'
+description: 'External composite'
+runs:
+  using: 'composite'
+  steps:
+    - uses: $/lib/bar
+");
+                Directory.CreateDirectory(Path.Combine(destDir, "lib", "bar"));
+                File.WriteAllText(Path.Combine(destDir, "lib", "bar", Constants.Path.ActionManifestYmlFile), @"
+name: 'Bar'
+description: 'Node action in external repo'
+runs:
+  using: 'node20'
+  main: 'index.js'
+");
+                File.WriteAllText($"{destDir}.completed", string.Empty);
+
+                var rootStepId = Guid.NewGuid();
+                var actions = new List<Pipelines.ActionStep>
+                {
+                    new Pipelines.ActionStep()
+                    {
+                        Name = "action",
+                        Id = Guid.NewGuid(),
+                        Reference = new Pipelines.RepositoryPathReference()
+                        {
+                            Name = ExtRepoName,
+                            Ref = ExtRepoRef,
+                            RepositoryType = Pipelines.RepositoryTypes.GitHub
+                        }
+                    }
+                };
+
+                // Act — should resolve $/lib/bar to external/foo@v1/lib/bar
+                await _actionManager.PrepareActionsAsync(_ec.Object, actions, rootStepId);
+
+                // Assert — the top-level ref is unchanged (it was already concrete)
+                var topRef = actions[0].Reference as Pipelines.RepositoryPathReference;
+                Assert.Equal(ExtRepoName, topRef.Name);
+                Assert.Equal(ExtRepoRef, topRef.Ref);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", null);
+                Teardown();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async void PrepareActions_DollarSelf_MultiLevelChain()
+        {
+            // $/a → composite → $/b → composite → $/c (three levels, same repo)
+            Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", "true");
+            try
+            {
+                // Arrange
+                Setup();
+                const string RepoName = "my-org/my-repo";
+                const string RepoSha = "chain-sha-222";
+                _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
+                _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
+                _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                var jobContext = new JobContext();
+                jobContext.WorkflowRepository = RepoName;
+                jobContext.WorkflowSha = RepoSha;
+                _ec.Setup(x => x.JobContext).Returns(jobContext);
+
+                string actionsDir = Path.Combine(_workFolder, Constants.Path.ActionsDirectory);
+                string destDir = Path.Combine(actionsDir, RepoName.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), RepoSha);
+                Directory.CreateDirectory(Path.Combine(destDir, "a"));
+                File.WriteAllText(Path.Combine(destDir, "a", Constants.Path.ActionManifestYmlFile), @"
+name: 'A'
+description: 'Level 0 composite'
+runs:
+  using: 'composite'
+  steps:
+    - uses: $/b
+");
+                Directory.CreateDirectory(Path.Combine(destDir, "b"));
+                File.WriteAllText(Path.Combine(destDir, "b", Constants.Path.ActionManifestYmlFile), @"
+name: 'B'
+description: 'Level 1 composite'
+runs:
+  using: 'composite'
+  steps:
+    - uses: $/c
+");
+                Directory.CreateDirectory(Path.Combine(destDir, "c"));
+                File.WriteAllText(Path.Combine(destDir, "c", Constants.Path.ActionManifestYmlFile), @"
+name: 'C'
+description: 'Level 2 node leaf'
+runs:
+  using: 'node20'
+  main: 'index.js'
+");
+                File.WriteAllText($"{destDir}.completed", string.Empty);
+
+                var rootStepId = Guid.NewGuid();
+                var actions = new List<Pipelines.ActionStep>
+                {
+                    new Pipelines.ActionStep()
+                    {
+                        Name = "action",
+                        Id = Guid.NewGuid(),
+                        Reference = new Pipelines.RepositoryPathReference()
+                        {
+                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            Path = "a"
+                        }
+                    }
+                };
+
+                // Act — three-level $/ chain should resolve without error
+                await _actionManager.PrepareActionsAsync(_ec.Object, actions, rootStepId);
+
+                // Assert — top-level ref resolved
+                var topRef = actions[0].Reference as Pipelines.RepositoryPathReference;
+                Assert.Equal(Pipelines.RepositoryTypes.GitHub, topRef.RepositoryType);
+                Assert.Equal(RepoName, topRef.Name);
+                Assert.Equal(RepoSha, topRef.Ref);
+                Assert.Equal("a", topRef.Path);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", null);
+                Teardown();
+            }
+        }
+
     }
 }

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -3539,6 +3539,8 @@ runs:
         [Trait("Category", "Worker")]
         public async void PrepareActions_DollarSelf_ResolvesAtDepthZero()
         {
+            // Dollar-self is only supported via run service (batch resolution path)
+            Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", "true");
             try
             {
                 // Arrange
@@ -3601,6 +3603,7 @@ runs:
             }
             finally
             {
+                Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", null);
                 Teardown();
             }
         }
@@ -3725,78 +3728,6 @@ runs:
             finally
             {
                 Environment.SetEnvironmentVariable("ACTIONS_BATCH_ACTION_RESOLUTION", null);
-                Teardown();
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Worker")]
-        public async void PrepareActions_DollarSelf_ResolvesNestedInComposite_LegacyPath()
-        {
-            // Same as above but exercises the legacy (non-batch) path.
-            try
-            {
-                // Arrange
-                Setup();
-                const string RepoName = "my-org/my-repo";
-                const string RepoSha = "abc123def456";
-                _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
-                _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
-                _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
-                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
-                var jobContext = new JobContext();
-                jobContext.WorkflowRepository = RepoName;
-                jobContext.WorkflowSha = RepoSha;
-                _ec.Setup(x => x.JobContext).Returns(jobContext);
-
-                string actionsDir = Path.Combine(_workFolder, Constants.Path.ActionsDirectory);
-                string destDir = Path.Combine(actionsDir, RepoName.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), RepoSha);
-                Directory.CreateDirectory(Path.Combine(destDir, "actions", "parent"));
-                File.WriteAllText(Path.Combine(destDir, "actions", "parent", Constants.Path.ActionManifestYmlFile), @"
-name: 'Parent'
-description: 'Composite parent'
-runs:
-  using: 'composite'
-  steps:
-    - uses: $/actions/child
-");
-                Directory.CreateDirectory(Path.Combine(destDir, "actions", "child"));
-                File.WriteAllText(Path.Combine(destDir, "actions", "child", Constants.Path.ActionManifestYmlFile), @"
-name: 'Child'
-description: 'Node child'
-runs:
-  using: 'node20'
-  main: 'index.js'
-");
-                File.WriteAllText($"{destDir}.completed", string.Empty);
-
-                var rootStepId = Guid.NewGuid();
-                var actions = new List<Pipelines.ActionStep>
-                {
-                    new Pipelines.ActionStep()
-                    {
-                        Name = "action",
-                        Id = Guid.NewGuid(),
-                        Reference = new Pipelines.RepositoryPathReference()
-                        {
-                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
-                            Path = "actions/parent"
-                        }
-                    }
-                };
-
-                // Act
-                await _actionManager.PrepareActionsAsync(_ec.Object, actions, rootStepId);
-
-                // Assert
-                var topRef = actions[0].Reference as Pipelines.RepositoryPathReference;
-                Assert.Equal(Pipelines.RepositoryTypes.GitHub, topRef.RepositoryType);
-                Assert.Equal(RepoName, topRef.Name);
-                Assert.Equal(RepoSha, topRef.Ref);
-            }
-            finally
-            {
                 Teardown();
             }
         }

--- a/src/Test/L0/Worker/ActionManagerL0.cs
+++ b/src/Test/L0/Worker/ActionManagerL0.cs
@@ -3894,5 +3894,152 @@ runs:
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async void PrepareActions_DollarSelf_ResolvesAtDepthZero_LegacyPath()
+        {
+            // Same as ResolvesAtDepthZero but on the legacy (non-batch) path
+            try
+            {
+                // Arrange
+                Setup();
+                const string RepoName = "my-org/my-repo";
+                const string RepoSha = "abc123def456";
+                _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
+                _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                var jobContext = new JobContext();
+                jobContext.WorkflowRepository = RepoName;
+                jobContext.WorkflowSha = RepoSha;
+                _ec.Setup(x => x.JobContext).Returns(jobContext);
+
+                var actionId = Guid.NewGuid();
+                var actions = new List<Pipelines.ActionStep>
+                {
+                    new Pipelines.ActionStep()
+                    {
+                        Name = "action",
+                        Id = actionId,
+                        Reference = new Pipelines.RepositoryPathReference()
+                        {
+                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            Path = "actions/my-action"
+                        }
+                    }
+                };
+
+                string archiveFile = await CreateRepoArchive();
+                using var stream = File.OpenRead(archiveFile);
+                string archiveLink = GetLinkToActionArchive("https://api.github.com", RepoName, RepoSha);
+                var mockClientHandler = new Mock<HttpClientHandler>();
+                mockClientHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(m => m.RequestUri == new Uri(archiveLink)), ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream) });
+                var mockHandlerFactory = new Mock<IHttpClientHandlerFactory>();
+                mockHandlerFactory.Setup(p => p.CreateClientHandler(It.IsAny<RunnerWebProxy>())).Returns(mockClientHandler.Object);
+                _hc.SetSingleton(mockHandlerFactory.Object);
+
+                _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
+
+                // Act
+                try
+                {
+                    await _actionManager.PrepareActionsAsync(_ec.Object, actions);
+                }
+                catch (InvalidOperationException ex) when (ex.Message.Contains("Can't find"))
+                {
+                    // Expected: test archive lacks the action.yml at the resolved subpath
+                }
+
+                // Assert — the reference should be resolved to a GitHub repo reference
+                var repoRef = actions[0].Reference as Pipelines.RepositoryPathReference;
+                Assert.Equal(Pipelines.RepositoryTypes.GitHub, repoRef.RepositoryType);
+                Assert.Equal(RepoName, repoRef.Name);
+                Assert.Equal(RepoSha, repoRef.Ref);
+                Assert.Equal("actions/my-action", repoRef.Path);
+            }
+            finally
+            {
+                Teardown();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async void PrepareActions_DollarSelf_ResolvesNestedInComposite_LegacyPath()
+        {
+            // Same as ResolvesNestedInComposite but on the legacy (non-batch) path.
+            // Verifies that $/ resolution works when batch action resolution is disabled.
+            try
+            {
+                // Arrange
+                Setup();
+                const string RepoName = "my-org/my-repo";
+                const string RepoSha = "abc123def456";
+                _ec.Setup(x => x.GetGitHubContext("repository")).Returns(RepoName);
+                _ec.Setup(x => x.GetGitHubContext("sha")).Returns(RepoSha);
+                _ec.Setup(x => x.GetGitHubContext("api_url")).Returns("https://api.github.com");
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.DollarSelfReference, "true");
+                var jobContext = new JobContext();
+                jobContext.WorkflowRepository = RepoName;
+                jobContext.WorkflowSha = RepoSha;
+                _ec.Setup(x => x.JobContext).Returns(jobContext);
+
+                // Stage parent action on disk as a composite that uses $/actions/child.
+                string actionsDir = Path.Combine(_workFolder, Constants.Path.ActionsDirectory);
+                string destDir = Path.Combine(actionsDir, RepoName.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), RepoSha);
+                Directory.CreateDirectory(Path.Combine(destDir, "actions", "parent"));
+                File.WriteAllText(Path.Combine(destDir, "actions", "parent", Constants.Path.ActionManifestYmlFile), @"
+name: 'Parent'
+description: 'Composite parent'
+runs:
+  using: 'composite'
+  steps:
+    - uses: $/actions/child
+");
+                // Stage child action too (as a leaf node action)
+                Directory.CreateDirectory(Path.Combine(destDir, "actions", "child"));
+                File.WriteAllText(Path.Combine(destDir, "actions", "child", Constants.Path.ActionManifestYmlFile), @"
+name: 'Child'
+description: 'Node child'
+runs:
+  using: 'node20'
+  main: 'index.js'
+");
+                // Write watermark
+                File.WriteAllText($"{destDir}.completed", string.Empty);
+
+                var rootStepId = Guid.NewGuid();
+                var actions = new List<Pipelines.ActionStep>
+                {
+                    new Pipelines.ActionStep()
+                    {
+                        Name = "action",
+                        Id = Guid.NewGuid(),
+                        Reference = new Pipelines.RepositoryPathReference()
+                        {
+                            RepositoryType = Pipelines.PipelineConstants.DollarSelfAlias,
+                            Path = "actions/parent"
+                        }
+                    }
+                };
+
+                // Act — should resolve $/ and not throw InvalidOperationException
+                await _actionManager.PrepareActionsAsync(_ec.Object, actions, rootStepId);
+
+                // Assert — top-level $/ resolved
+                var topRef = actions[0].Reference as Pipelines.RepositoryPathReference;
+                Assert.Equal(Pipelines.RepositoryTypes.GitHub, topRef.RepositoryType);
+                Assert.Equal(RepoName, topRef.Name);
+                Assert.Equal(RepoSha, topRef.Ref);
+                Assert.Equal("actions/parent", topRef.Path);
+            }
+            finally
+            {
+                Teardown();
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## `$/` — self-referencing action syntax

Adds `$/path` as a new `uses:` syntax meaning "this repo, at this SHA, at the given subpath." The containing YAML file determines which repo and SHA — so `$/lib/helper` inside `acme/toolkit@v1` resolves to `acme/toolkit` at that SHA with path `lib/helper`, not the caller's repo.

### Why

Composite actions that ship multiple sub-actions in one repo currently hardcode `owner/repo@ref` to reference siblings. This creates a circular versioning problem — you can't cut a release tag until the YAML already references that tag. `$/` breaks the cycle: siblings reference each other by path, and the ref is inherited from whatever version the caller pinned.

### Feature flag

`actions_dollar_self_reference` — gates parsing (Launch → parser), server-side resolution (ARS), and runner-side resolution. Unified name across all four repos.

### How it works

**Parsing.** Both template converters (`PipelineTemplateConverter` for action.yml, `WorkflowTemplateConverter` for workflow YAML) detect `$/` via `PipelineConstants.TryParseDollarSelfReference()`. The parsed reference gets `RepositoryType = "selfRepository"` and `Path = <subpath>` — no `Name` or `Ref` yet. Leading slashes are stripped and bare `$/` (no subpath) is rejected.

**Resolution.** `ActionManager.ResolveDollarSelfReferences()` rewrites `selfRepository` refs to concrete `GitHub`-type refs in-place before they reach any download logic:

| Depth | Source of truth | Why |
|-------|----------------|-----|
| 0 (workflow steps) | `job.WorkflowRepository` / `job.WorkflowSha` | Points to the repo containing the workflow file. Correct for both regular and reusable workflows. |
| > 0 (inside composites) | Parent action's `RepositoryPathReference.Name` / `.Ref` | The parent is already resolved. `$/` in a child always means "the repo that contains me." |

After resolution, the ref is indistinguishable from a normal `owner/repo/path@sha` reference.

**Both resolution paths supported.** Works on both the batch resolution path (`PrepareActionsRecursiveAsync`, gated on `actions_batch_action_resolution`) and the legacy serial path (`PrepareActionsRecursiveLegacyAsync`). The batch path is not yet broadly rolled out, so legacy support is required.

**Upfront resolution (not lazy).** All `$/` refs are resolved during `PrepareActionsAsync` (Setup Job phase) before any step executes. Pre/post step registration depends on the complete recursive walk having finished, so lazy resolution would break it.

**Runtime re-resolution.** `LoadAction` re-parses action.yml from disk at execution time, producing fresh `RepositoryPathReference` objects with `RepositoryType = "selfRepository"`. `ResolveDollarSelfReferences` runs again using the parent's already-resolved `Name`/`Ref`. No network calls — the tarball is already cached.

**Safety net.** `GetDownloadInfoLookupKey` throws `InvalidOperationException` if a `selfRepository` ref reaches it unresolved.

### Cross-repo `$/` context propagation

```
private-server-1/actions/crossrepo-chain/action.yml
  └─ uses: github/public-server/actions/leaf@sha
       └─ leaf/action.yml says: uses: $/actions/other-leaf
          → resolves to public-server/actions/other-leaf@sha  ✅
          (NOT private-server-1 — $/ means the repo containing THIS file)
```

This works because `childRepoName`/`childRepoRef` at each depth come from the parent action's resolved `RepositoryPathReference.Name/.Ref`, not from the workflow-level context.

### Tests (7 total)

- `ResolvesAtDepthZero` — batch path, top-level `$/` resolution
- `ResolvesAtDepthZero_LegacyPath` — legacy path equivalent
- `NotResolvedWhenFeatureFlagDisabled` — `$/` stays unresolved, hits safety net
- `ResolvesNestedInComposite` — depth-1 `$/` inside a composite (batch)
- `ResolvesNestedInComposite_LegacyPath` — legacy path equivalent
- `CrossRepoCompositeResolvesToParentRepo` — `$/` resolves to parent's repo, not caller's
- `MultiLevelChain` — 3-level composite chain with `$/` at each depth


