### PR TITLE
Update Node 24 default date to June 16th, 2026

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -206,7 +206,7 @@ namespace GitHub.Runner.Common
                 public static readonly string Node20DeprecationUrl = "https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/";
 
                 // Node 20 migration dates (hardcoded fallbacks, can be overridden via job variables)
-                public static readonly string Node24DefaultDate = "June 2nd, 2026";
+                public static readonly string Node24DefaultDate = "June 16th, 2026";
                 public static readonly string Node20RemovalDate = "September 16th, 2026";
 
                 // Variable keys for server-overridable dates


### PR DESCRIPTION
Updates the hardcoded fallback date for the Node.js 24 default switch from June 2nd to June 16th, 2026.

This date is displayed in the deprecation warning when workflows use Node.js 20 actions.