### PR TITLE
Populate telemetry for non-action post-job steps

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -337,6 +337,11 @@ namespace GitHub.Runner.Worker
             }
 
             step.ExecutionContext = Root.CreatePostChild(step.DisplayName, IntraActionState, siblingScopeName);
+            if (step is not IActionRunner)
+            {
+                step.ExecutionContext.StepTelemetry.Type = "runner";
+                step.ExecutionContext.StepTelemetry.Action = step.DisplayName.ToLowerInvariant().Replace(' ', '_');
+            }
             Root.PostJobSteps.Push(step);
         }
 

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -337,7 +337,7 @@ namespace GitHub.Runner.Worker
             }
 
             step.ExecutionContext = Root.CreatePostChild(step.DisplayName, IntraActionState, siblingScopeName);
-            if (step is not IActionRunner)
+            if (step is JobExtensionRunner)
             {
                 step.ExecutionContext.StepTelemetry.Type = "runner";
                 step.ExecutionContext.StepTelemetry.Action = step.DisplayName.ToLowerInvariant().Replace(' ', '_');

--- a/src/Test/L0/Worker/ExecutionContextL0.cs
+++ b/src/Test/L0/Worker/ExecutionContextL0.cs
@@ -364,6 +364,119 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        public void RegisterPostJobStep_JobExtensionRunner_DefaultsRunnerTelemetry()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // Arrange: Create a job request message.
+                TaskOrchestrationPlanReference plan = new();
+                TimelineReference timeline = new();
+                Guid jobId = Guid.NewGuid();
+                string jobName = "some job name";
+                var jobRequest = new Pipelines.AgentJobRequestMessage(plan, timeline, jobId, jobName, jobName, null, null, null, new Dictionary<string, VariableValue>(), new List<MaskHint>(), new Pipelines.JobResources(), new Pipelines.ContextData.DictionaryContextData(), new Pipelines.WorkspaceOptions(), new List<Pipelines.ActionStep>(), null, null, null, null, null);
+                jobRequest.Resources.Repositories.Add(new Pipelines.RepositoryResource()
+                {
+                    Alias = Pipelines.PipelineConstants.SelfAlias,
+                    Id = "github",
+                    Version = "sha1"
+                });
+                jobRequest.ContextData["github"] = new Pipelines.ContextData.DictionaryContextData();
+
+                var pagingLogger1 = new Mock<IPagingLogger>();
+                var pagingLogger2 = new Mock<IPagingLogger>();
+                var jobServerQueue = new Mock<IJobServerQueue>();
+                jobServerQueue.Setup(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.IsAny<TimelineRecord>()));
+
+                hc.EnqueueInstance(pagingLogger1.Object);
+                hc.EnqueueInstance(pagingLogger2.Object);
+                hc.SetSingleton(jobServerQueue.Object);
+
+                var jobContext = new Runner.Worker.ExecutionContext();
+                jobContext.Initialize(hc);
+
+                // Act.
+                jobContext.InitializeJob(jobRequest, CancellationToken.None);
+
+                var extensionStep = new JobExtensionRunner(
+                    runAsync: (_, _) => System.Threading.Tasks.Task.CompletedTask,
+                    condition: "always()",
+                    displayName: "Create Custom Image",
+                    data: null);
+
+                jobContext.RegisterPostJobStep(extensionStep);
+
+                // Assert: telemetry defaults are populated for non-action post-job steps.
+                Assert.NotNull(extensionStep.ExecutionContext);
+                Assert.Equal("runner", extensionStep.ExecutionContext.StepTelemetry.Type);
+                Assert.Equal("create_custom_image", extensionStep.ExecutionContext.StepTelemetry.Action);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void RegisterPostJobStep_ActionRunner_DoesNotOverrideTelemetry()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // Arrange: Create a job request message.
+                TaskOrchestrationPlanReference plan = new();
+                TimelineReference timeline = new();
+                Guid jobId = Guid.NewGuid();
+                string jobName = "some job name";
+                var jobRequest = new Pipelines.AgentJobRequestMessage(plan, timeline, jobId, jobName, jobName, null, null, null, new Dictionary<string, VariableValue>(), new List<MaskHint>(), new Pipelines.JobResources(), new Pipelines.ContextData.DictionaryContextData(), new Pipelines.WorkspaceOptions(), new List<Pipelines.ActionStep>(), null, null, null, null, null);
+                jobRequest.Resources.Repositories.Add(new Pipelines.RepositoryResource()
+                {
+                    Alias = Pipelines.PipelineConstants.SelfAlias,
+                    Id = "github",
+                    Version = "sha1"
+                });
+                jobRequest.ContextData["github"] = new Pipelines.ContextData.DictionaryContextData();
+
+                var pagingLogger1 = new Mock<IPagingLogger>();
+                var pagingLogger2 = new Mock<IPagingLogger>();
+                var pagingLogger3 = new Mock<IPagingLogger>();
+                var pagingLogger4 = new Mock<IPagingLogger>();
+                var jobServerQueue = new Mock<IJobServerQueue>();
+                jobServerQueue.Setup(x => x.QueueTimelineRecordUpdate(It.IsAny<Guid>(), It.IsAny<TimelineRecord>()));
+
+                var actionRunner = new ActionRunner();
+                actionRunner.Initialize(hc);
+
+                hc.EnqueueInstance(pagingLogger1.Object);
+                hc.EnqueueInstance(pagingLogger2.Object);
+                hc.EnqueueInstance(pagingLogger3.Object);
+                hc.EnqueueInstance(pagingLogger4.Object);
+                hc.EnqueueInstance(actionRunner as IActionRunner);
+                hc.SetSingleton(jobServerQueue.Object);
+
+                var jobContext = new Runner.Worker.ExecutionContext();
+                jobContext.Initialize(hc);
+
+                // Act.
+                jobContext.InitializeJob(jobRequest, CancellationToken.None);
+
+                var action = jobContext.CreateChild(Guid.NewGuid(), "action", "action", null, null, 0);
+
+                var postRunner = hc.CreateService<IActionRunner>();
+                postRunner.Action = new Pipelines.ActionStep() { Id = Guid.NewGuid(), Name = "post", DisplayName = "Post Action", Reference = new Pipelines.RepositoryPathReference() { Name = "actions/action" } };
+                postRunner.Stage = ActionRunStage.Post;
+                postRunner.Condition = "always()";
+                postRunner.DisplayName = "Post Action";
+
+                action.RegisterPostJobStep(postRunner);
+
+                // Assert: action post-step telemetry is left for the handler to fill in,
+                // so RegisterPostJobStep should NOT pre-populate runner-owned defaults.
+                Assert.NotNull(postRunner.ExecutionContext);
+                Assert.Null(postRunner.ExecutionContext.StepTelemetry.Type);
+                Assert.Null(postRunner.ExecutionContext.StepTelemetry.Action);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
         public void RegisterPostJobAction_ShareState()
         {
             using (TestHostContext hc = CreateTestContext())


### PR DESCRIPTION
## Summary
Populate `StepTelemetry.Type` and `StepTelemetry.Action` for non-action post-job steps. 

This is needed for snapshot requests, which are added as `RegisterPostJobStep`. Currently, `action_execution_history` telemetry type/action show as empty
 
issue:
- https://github.com/github/hosted-compute-ims/issues/1639

## Changes

- Set `Type = "runner"` and derive `Action` from `DisplayName` for post-job steps


Before:
<img width="1087" height="137" alt="image" src="https://github.com/user-attachments/assets/286f48fc-6451-40a3-929f-ca2645cbae68" />


After:
<img width="1135" height="144" alt="image" src="https://github.com/user-attachments/assets/a4d6a1a3-1308-4bd7-b3fe-f2fb55aaeb06" />

## Testing

- Added `RegisterPostJobStep_JobExtensionRunner_DefaultsRunnerTelemetry` test to verify that runner-owned post-job steps get default telemetry values.
- Added `RegisterPostJobStep_ActionRunner_DoesNotOverrideTelemetry` test to ensure that action post-job steps do not have their telemetry values pre-populated, allowing the handler to set them as needed.