### PR TITLE
safe_sleep.sh: resolve reliability and maintainability issues

### DIFF
--- a/src/Misc/layoutroot/safe_sleep.sh
+++ b/src/Misc/layoutroot/safe_sleep.sh
@@ -1,37 +1,101 @@
 #!/bin/bash
 
-# try to use sleep if available
-if [ -x "$(command -v sleep)" ]; then
-    sleep "$1"
-    exit 0
-fi
+# This script provides a resilient sleep mechanism for
+# environments where:
+#
+# - `sleep` cannot be relied upon (even if it exists,
+#   it can't be trusted)
+# - `PATH` may be incomplete or misconfigured
+# - the runner is executing in minimal or bootstrap
+#   environments
+#
+# Busy-wait is included strictly as a last-resort
+# fallback.
 
-# try to use ping if available
-if [ -x "$(command -v ping)" ]; then
-    ping -c $(( $1 + 1 )) 127.0.0.1 > /dev/null
-    exit 0
-fi
+duration=$1
 
-# try to use read -t from stdin/stdout/stderr if we are in bash
-if [ -n "$BASH_VERSION" ]; then
-    if command -v read >/dev/null 2>&1; then
-        if [ -t 0 ]; then
-            read -t "$1" -u 0 || :;
-            exit 0
-        fi
-        if [ -t 1 ]; then
-            read -t "$1" -u 1 || :;
-            exit 0
-        fi
-        if [ -t 2 ]; then
-            read -t "$1" -u 2 || :;
-            exit 0
-        fi
+# Try to use sleep if available. We don't use sleep for
+# a duration of 1, because we need to test if time
+# actually passed during the execution of sleep, and we
+# can't reliably test that for a single second with
+# seconds precision.
+if [ -x "$(command -v sleep)" -a $duration -gt 1 ]; then
+    # Platforms have existed where executing sleep succeeded
+    # but returned immediately (might have been WSL 1.0?).
+    # Therefore, we check to make sure it hasn't returned
+    # immediately.
+
+    start=$(date +%s)
+
+    sleep "$duration"
+
+    elapsed=$(( $(date +%s) - start ))
+
+    if [[ $elapsed -gt 1 ]]; then
+        # We successfully waited
+        exit 0
     fi
 fi
 
-# fallback to a busy wait
-SECONDS=0
-while [[ $SECONDS -lt $1 ]]; do
+# Try to use ping if available.
+if [ -x "$(command -v ping)" ]; then
+    ping -c $(( duration + 1 )) 127.0.0.1 > /dev/null
+    exit 0
+fi
+
+# Try to use read -t from stdin/stdout/stderr.
+# This can only work with a builtin read.
+if [ "$(command -v builtin)" = "builtin" ]; then
+    if [ "$(builtin type -t read)" = "builtin" ]; then
+        # stdout and stderr will never produce data on a read,
+        # but you can still try to read from them and the
+        # supplied timeout applies.
+
+        for fd in 0 1 2; do
+            if [ -t $fd ]; then
+                read -t "$duration" -u $fd || :;
+                exit 0
+            fi
+        done
+    fi
+fi
+
+
+# Fall back to a busy wait
+
+# First, reduce the priority of this shell process to
+# minimize impact on other processes.
+
+if [ -x "$(command -v renice)" ]; then
+    if [ "$$" != "" ]; then
+        export POSIXLY_CORRECT=1 # for -n on Linux
+        renice -n 15 -p $$ > /dev/null 2>&1
+    fi
+fi
+
+# Check if we have subsecond precision. If not, then
+# our wait will be up to 1 second shorter than
+# requested (and on average 0.5 seconds shorter),
+# because we aren't in control of how long it has
+# been since the seconds counter last changed.
+
+fmt="%s%N"
+
+start=$(date +$fmt)
+
+if [[ "$start" == *'%'* ]]; then
+  # We only have seconds.
+  fmt="%s"
+  start="$(date +$fmt)"
+else
+  # Yey, we have subsecond precision. using %s%N, we
+  # are measuring the time in nanoseconds, so we need
+  # to convert the duration to nanoseconds too. That\
+  # just takes 9 zeroes.
+  duration="${duration}000000000"
+fi
+
+# Burn some CPU cycles.
+while [[ $(($(date +$fmt) - start)) -lt $duration ]]; do
     :
 done


### PR DESCRIPTION
As described in #185304, the `safe_sleep.sh` script is problematic because it isn't clear exactly what problems it is solving or whether it is doing so correctly.

This PR attempts to address this in the following ways:

- The purpose of the script is documented.
- Digging into the history revealed that the original root reason for the script's existence in the first place is environments where `sleep` cannot be trusted. Additional logic has been added to detect if `sleep` returns immediately and fall through to a fallback strategy.
- This script that already explicitly specifies `/bin/bash` on the shebang and directly uses Bash-specific syntax no longer has a branch where it double-checks that it is running under Bash. That branch now also simply uses Bash features like the rest of the script.
- The fallback to `read` verifies that `read` is a `builtin` before attempting to use it to read from the shell process' standard streams.
- In the extremely unlikely event that execution reaches the busy wait ultimate fallback, the script now `renice`s the shell it's running in to a lower priority.
- The busy wait now uses `date` to could elapsed time instead of the Bash built-in `SECONDS` variable, and it will now leverage the `%N` format specifier to `date` if it is supported by the host-supplied `date` implementation. This allows subsecond precision with the busy-wait. If subsecond precision isn't available, then it continues to loop with second-level precision, which means that the delay will be up to 1 second shorter than requested, depending on how far into the first second the wait was initiated (average 0.5 seconds shorter than requested).

These paths have been tested on modern Linux systems, on Linux hosted on WSL 1, and with Bash 3.2.57 running on FreeBSD.

Closes: #185304