### PR TITLE
Add job execution view model

### DIFF
--- a/src/Runner.Worker/Dap/JobExecutionView.cs
+++ b/src/Runner.Worker/Dap/JobExecutionView.cs
@@ -1,0 +1,358 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace GitHub.Runner.Worker.Dap
+{
+    internal sealed class JobExecutionView
+    {
+        private const string _sourceFileName = "execution.yml";
+
+        private readonly object _lock = new object();
+        private readonly List<SourceEntry> _preEntries = new List<SourceEntry>();
+        private readonly List<SourceEntry> _mainEntries = new List<SourceEntry>();
+        private readonly List<SourceEntry> _postEntries = new List<SourceEntry>();
+        private readonly List<StepLine> _lineByStep = new List<StepLine>();
+        private string _content;
+        private int _completeJobLine;
+
+        public JobExecutionView(
+            string jobId,
+            IEnumerable<IStep> steps,
+            IEnumerable<IStep> initialPostSteps,
+            IEnumerable<PredictedPostStep> predictedPostSteps = null)
+        {
+            JobId = string.IsNullOrWhiteSpace(jobId) ? "job" : jobId;
+
+            _preEntries.Add(new SourceEntry("Setup job"));
+            AddSteps(steps);
+            AddPredictedPostSteps(predictedPostSteps);
+            AddSteps(initialPostSteps);
+            _postEntries.Add(SourceEntry.CreateSyntheticCompleteJob());
+            Render();
+        }
+
+        public string JobId { get; }
+        public string SourceFileName => _sourceFileName;
+
+        public string Content
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _content;
+                }
+            }
+        }
+
+        public int CompleteJobLine
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _completeJobLine;
+                }
+            }
+        }
+
+        public int? TryClaimPredictedStep(string matchKey, IStep step)
+        {
+            if (string.IsNullOrEmpty(matchKey) || step == null)
+            {
+                return null;
+            }
+
+            lock (_lock)
+            {
+                var existingLine = TryGetLineForStepNoLock(step);
+                if (existingLine.HasValue)
+                {
+                    return existingLine;
+                }
+
+                foreach (var entry in _postEntries)
+                {
+                    if (!string.Equals(entry.MatchKey, matchKey, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (entry.Step != null && !ReferenceEquals(entry.Step, step))
+                    {
+                        return null;
+                    }
+
+                    entry.Step = step;
+                    Render();
+                    return TryGetLineForStepNoLock(step);
+                }
+
+                return null;
+            }
+        }
+
+        public int? TryGetLineForStep(IStep step)
+        {
+            if (step == null)
+            {
+                return null;
+            }
+
+            lock (_lock)
+            {
+                return TryGetLineForStepNoLock(step);
+            }
+        }
+
+        private int? TryGetLineForStepNoLock(IStep step)
+        {
+            foreach (var stepLine in _lineByStep)
+            {
+                if (ReferenceEquals(stepLine.Step, step))
+                {
+                    return stepLine.Line;
+                }
+            }
+
+            return null;
+        }
+
+        private void AddSteps(IEnumerable<IStep> steps)
+        {
+            if (steps == null)
+            {
+                return;
+            }
+
+            foreach (var step in steps)
+            {
+                if (step == null)
+                {
+                    continue;
+                }
+
+                GetEntries(GetSection(step)).Add(new SourceEntry(step));
+            }
+        }
+
+        private void AddPredictedPostSteps(IEnumerable<PredictedPostStep> steps)
+        {
+            if (steps == null)
+            {
+                return;
+            }
+
+            foreach (var step in steps)
+            {
+                if (step == null)
+                {
+                    continue;
+                }
+
+                _postEntries.Add(new SourceEntry(step.DisplayName, step.MatchKey));
+            }
+        }
+
+        private List<SourceEntry> GetEntries(SourceSection section)
+        {
+            switch (section)
+            {
+                case SourceSection.Pre:
+                    return _preEntries;
+                case SourceSection.Post:
+                    return _postEntries;
+                default:
+                    return _mainEntries;
+            }
+        }
+
+        private static SourceSection GetSection(IStep step)
+        {
+            if (step is IActionRunner actionRunner)
+            {
+                return GetSection(actionRunner.Stage);
+            }
+
+            if (step.ExecutionContext != null)
+            {
+                return GetSection(step.ExecutionContext.Stage);
+            }
+
+            return SourceSection.Main;
+        }
+
+        private static SourceSection GetSection(ActionRunStage stage)
+        {
+            switch (stage)
+            {
+                case ActionRunStage.Pre:
+                    return SourceSection.Pre;
+                case ActionRunStage.Post:
+                    return SourceSection.Post;
+                default:
+                    return SourceSection.Main;
+            }
+        }
+
+        private void Render()
+        {
+            _lineByStep.Clear();
+            _completeJobLine = 0;
+
+            var sb = new StringBuilder();
+            var line = 1;
+
+            AppendSection(sb, "pre", _preEntries, ref line, appendSeparatorLine: true);
+            AppendSection(sb, "main", _mainEntries, ref line, appendSeparatorLine: true);
+            AppendSection(sb, "post", _postEntries, ref line, appendSeparatorLine: false);
+
+            _content = sb.ToString();
+        }
+
+        private void AppendSection(
+            StringBuilder sb,
+            string sectionName,
+            IReadOnlyList<SourceEntry> entries,
+            ref int line,
+            bool appendSeparatorLine)
+        {
+            sb.Append(sectionName).Append(":\n");
+            line++;
+
+            foreach (var entry in entries)
+            {
+                if (entry.Step != null && TryGetLineForStepNoLock(entry.Step) == null)
+                {
+                    _lineByStep.Add(new StepLine(entry.Step, line));
+                }
+
+                sb.Append("  - step: ");
+                sb.Append(FormatYamlString(entry.DisplayName));
+                sb.Append('\n');
+                if (entry.IsSyntheticCompleteJob)
+                {
+                    _completeJobLine = line;
+                }
+
+                line++;
+            }
+
+            if (appendSeparatorLine)
+            {
+                sb.Append('\n');
+                line++;
+            }
+        }
+
+        private static string FormatYamlString(string value)
+        {
+            var sb = new StringBuilder();
+            sb.Append('"');
+            foreach (var c in value)
+            {
+                switch (c)
+                {
+                    case '\\':
+                        sb.Append(@"\\");
+                        break;
+                    case '"':
+                        sb.Append("\\\"");
+                        break;
+                    case '\r':
+                        sb.Append(@"\r");
+                        break;
+                    case '\n':
+                        sb.Append(@"\n");
+                        break;
+                    case '\t':
+                        sb.Append(@"\t");
+                        break;
+                    default:
+                        if (char.IsControl(c))
+                        {
+                            sb.Append(@"\u");
+                            sb.Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+                        break;
+                }
+            }
+
+            sb.Append('"');
+            return sb.ToString();
+        }
+
+        internal sealed class PredictedPostStep
+        {
+            public PredictedPostStep(string displayName, string matchKey)
+            {
+                DisplayName = string.IsNullOrEmpty(displayName) ? "step" : displayName;
+                MatchKey = matchKey;
+            }
+
+            public string DisplayName { get; }
+            public string MatchKey { get; }
+        }
+
+        private sealed class StepLine
+        {
+            public StepLine(IStep step, int line)
+            {
+                Step = step;
+                Line = line;
+            }
+
+            public IStep Step { get; }
+            public int Line { get; }
+        }
+
+        private sealed class SourceEntry
+        {
+            public SourceEntry(string displayName)
+            {
+                DisplayName = string.IsNullOrEmpty(displayName) ? "step" : displayName;
+            }
+
+            public SourceEntry(string displayName, string matchKey)
+                : this(displayName)
+            {
+                MatchKey = matchKey;
+            }
+
+            public SourceEntry(IStep step)
+            {
+                Step = step;
+                DisplayName = string.IsNullOrEmpty(step.DisplayName) ? "step" : step.DisplayName;
+            }
+
+            private SourceEntry(string displayName, bool isSyntheticCompleteJob)
+                : this(displayName)
+            {
+                IsSyntheticCompleteJob = isSyntheticCompleteJob;
+            }
+
+            public static SourceEntry CreateSyntheticCompleteJob()
+            {
+                return new SourceEntry("Complete job", isSyntheticCompleteJob: true);
+            }
+
+            public IStep Step { get; set; }
+            public string DisplayName { get; }
+            public string MatchKey { get; }
+            public bool IsSyntheticCompleteJob { get; }
+        }
+
+        private enum SourceSection
+        {
+            Pre,
+            Main,
+            Post
+        }
+    }
+}

--- a/src/Runner.Worker/Dap/JobExecutionView.cs
+++ b/src/Runner.Worker/Dap/JobExecutionView.cs
@@ -25,7 +25,7 @@ namespace GitHub.Runner.Worker.Dap
         {
             JobId = string.IsNullOrWhiteSpace(jobId) ? "job" : jobId;
 
-            _preEntries.Add(new SourceEntry("Setup job"));
+            _preEntries.Add(new SourceEntry("Set up job"));
             AddSteps(steps);
             AddPredictedPostSteps(predictedPostSteps);
             AddSteps(initialPostSteps);

--- a/src/Runner.Worker/InternalsVisibleTo.cs
+++ b/src/Runner.Worker/InternalsVisibleTo.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Test")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Runner.Worker/InternalsVisibleTo.cs
+++ b/src/Runner.Worker/InternalsVisibleTo.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Test")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Test/L0/Worker/JobExecutionViewL0.cs
+++ b/src/Test/L0/Worker/JobExecutionViewL0.cs
@@ -24,7 +24,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 new[] { post.Object });
 
             Assert.Equal(
-                "pre:\n  - step: \"Setup job\"\n  - step: \"Pre cache\"\n\nmain:\n  - step: \"Checkout\"\n\npost:\n  - step: \"Post cache\"\n  - step: \"Complete job\"\n",
+                "pre:\n  - step: \"Set up job\"\n  - step: \"Pre cache\"\n\nmain:\n  - step: \"Checkout\"\n\npost:\n  - step: \"Post cache\"\n  - step: \"Complete job\"\n", 
                 view.Content);
             Assert.Equal(3, view.TryGetLineForStep(pre.Object));
             Assert.Equal(6, view.TryGetLineForStep(checkout.Object));
@@ -55,7 +55,7 @@ namespace GitHub.Runner.Common.Tests.Worker
             Assert.Equal(8, line);
             Assert.Equal(8, view.TryGetLineForStep(post.Object));
             Assert.Equal(
-                "pre:\n  - step: \"Setup job\"\n\nmain:\n  - step: \"Checkout\"\n\npost:\n  - step: \"Post Checkout\"\n  - step: \"Complete job\"\n",
+                "pre:\n  - step: \"Set up job\"\n\nmain:\n  - step: \"Checkout\"\n\npost:\n  - step: \"Post Checkout\"\n  - step: \"Complete job\"\n", 
                 view.Content);
         }
 

--- a/src/Test/L0/Worker/JobExecutionViewL0.cs
+++ b/src/Test/L0/Worker/JobExecutionViewL0.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using GitHub.DistributedTask.Pipelines;
+using GitHub.Runner.Worker;
+using GitHub.Runner.Worker.Dap;
+using Moq;
+using Xunit;
+
+namespace GitHub.Runner.Common.Tests.Worker
+{
+    public sealed class JobExecutionViewL0
+    {
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void RendersPreMainAndPostSections()
+        {
+            var pre = CreateStep("Pre cache", ActionRunStage.Pre);
+            var checkout = CreateStep("Checkout");
+            var post = CreateStep("Post cache", ActionRunStage.Post);
+
+            var view = new JobExecutionView(
+                "job",
+                new[] { pre.Object, checkout.Object },
+                new[] { post.Object });
+
+            Assert.Equal(
+                "pre:\n  - step: \"Setup job\"\n  - step: \"Pre cache\"\n\nmain:\n  - step: \"Checkout\"\n\npost:\n  - step: \"Post cache\"\n  - step: \"Complete job\"\n",
+                view.Content);
+            Assert.Equal(3, view.TryGetLineForStep(pre.Object));
+            Assert.Equal(6, view.TryGetLineForStep(checkout.Object));
+            Assert.Equal(9, view.TryGetLineForStep(post.Object));
+            Assert.Equal(10, view.CompleteJobLine);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void ClaimsPredictedPostStepWithoutChangingLine()
+        {
+            var action = CreateRepositoryActionStep("actions/cache");
+            var checkout = CreateActionRunner("Checkout", ActionRunStage.Main, action);
+            var predicted = new JobExecutionView.PredictedPostStep(
+                "Post Checkout",
+                MatchKeyFor(action.Id));
+
+            var view = new JobExecutionView(
+                "job",
+                new[] { checkout.Object },
+                Array.Empty<IStep>(),
+                new[] { predicted });
+
+            var post = CreateActionRunner("Post Checkout", ActionRunStage.Post, action);
+            var line = view.TryClaimPredictedStep(MatchKeyFor(action.Id), post.Object);
+
+            Assert.Equal(8, line);
+            Assert.Equal(8, view.TryGetLineForStep(post.Object));
+            Assert.Equal(
+                "pre:\n  - step: \"Setup job\"\n\nmain:\n  - step: \"Checkout\"\n\npost:\n  - step: \"Post Checkout\"\n  - step: \"Complete job\"\n",
+                view.Content);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void UsesSyntheticCompleteJobLineWhenPostStepSharesName()
+        {
+            var checkout = CreateStep("Checkout");
+            var realPost = CreateStep("Complete job", ActionRunStage.Post);
+
+            var view = new JobExecutionView(
+                "job",
+                new[] { checkout.Object },
+                new[] { realPost.Object });
+
+            Assert.Equal(8, view.TryGetLineForStep(realPost.Object));
+            Assert.Equal(9, view.CompleteJobLine);
+        }
+
+        private static Mock<IStep> CreateStep(string displayName, ActionRunStage? stage = null)
+        {
+            var step = new Mock<IStep>();
+            step.Setup(s => s.DisplayName).Returns(displayName);
+            if (stage.HasValue)
+            {
+                var executionContext = new Mock<IExecutionContext>();
+                executionContext.Setup(x => x.Stage).Returns(stage.Value);
+                step.Setup(s => s.ExecutionContext).Returns(executionContext.Object);
+            }
+            else
+            {
+                step.Setup(s => s.ExecutionContext).Returns((IExecutionContext)null);
+            }
+
+            return step;
+        }
+
+        private static Mock<IActionRunner> CreateActionRunner(string displayName, ActionRunStage stage, ActionStep action)
+        {
+            var executionContext = new Mock<IExecutionContext>();
+            executionContext.Setup(x => x.Stage).Returns(stage);
+
+            var runner = new Mock<IActionRunner>();
+            runner.Setup(s => s.DisplayName).Returns(displayName);
+            runner.Setup(s => s.ExecutionContext).Returns(executionContext.Object);
+            runner.Setup(s => s.Stage).Returns(stage);
+            runner.Setup(s => s.Action).Returns(action);
+            return runner;
+        }
+
+        private static ActionStep CreateRepositoryActionStep(string name)
+        {
+            return new ActionStep
+            {
+                Id = Guid.NewGuid(),
+                Name = name,
+                Reference = new RepositoryPathReference
+                {
+                    Name = name,
+                    Ref = "v1",
+                    RepositoryType = RepositoryTypes.GitHub
+                }
+            };
+        }
+
+        private static string MatchKeyFor(Guid actionId)
+        {
+            return $"post:{actionId:N}";
+        }
+    }
+}


### PR DESCRIPTION
**Part 1 of 2** of adding a job execution view for the DAP debugger. Followed by #4471.

This PR introduces a typed `JobExecutionView` model so we can define and review the rendered job view separately from the debugger plumbing that will serve it.

The reason for splitting it this way is that the view has its own behavior and invariants:
- it needs to render a stable synthetic source for the job
- it needs to preserve source lines so the debugger can point at the right step later
- it needs to model pre/main/post sections, predicted post steps, and the synthetic `Complete job` row consistently

Putting that behavior behind a dedicated type keeps the follow-up DAP integration PR much smaller and lets us validate the output shape directly in focused tests.

Example rendered job view:

```yaml
pre:
  - step: "Setup job"
  - step: "Pre cache"

main:
  - step: "Checkout"
  - step: "Build"

post:
  - step: "Post cache"
  - step: "Complete job"
```
