### PR TITLE
Add SDK types and results plumbing for background step control

### DIFF
--- a/src/Sdk/DTPipelines/Pipelines/ActionStep.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ActionStep.cs
@@ -25,6 +25,7 @@ namespace GitHub.DistributedTask.Pipelines
             Inputs = actionToClone.Inputs?.Clone();
             ContextName = actionToClone?.ContextName;
             DisplayNameToken = actionToClone.DisplayNameToken?.Clone();
+            Background = actionToClone.Background;
         }
 
         public override StepType Type => StepType.Action;
@@ -48,6 +49,9 @@ namespace GitHub.DistributedTask.Pipelines
 
         [DataMember(EmitDefaultValue = false)]
         public TemplateToken Inputs { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public bool Background { get; set; }
 
         public override Step Clone()
         {

--- a/src/Sdk/DTPipelines/Pipelines/BackgroundStepControl.cs
+++ b/src/Sdk/DTPipelines/Pipelines/BackgroundStepControl.cs
@@ -40,10 +40,10 @@ namespace GitHub.DistributedTask.Pipelines
 
         public override StepType Type => StepType.BackgroundStepControl;
 
-        [JsonProperty("controlType")]
+        [DataMember(EmitDefaultValue = false)]
         public string ControlType { get; set; }
 
-        [JsonProperty("stepIds")]
+        [DataMember(EmitDefaultValue = false)]
         public string[] StepIds { get; set; }
 
         [DataMember(EmitDefaultValue = false)]

--- a/src/Sdk/DTPipelines/Pipelines/BackgroundStepControl.cs
+++ b/src/Sdk/DTPipelines/Pipelines/BackgroundStepControl.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel;
+using System.Runtime.Serialization;
+using GitHub.DistributedTask.ObjectTemplating.Tokens;
+using Newtonsoft.Json;
+
+namespace GitHub.DistributedTask.Pipelines
+{
+    /// <summary>
+    /// Known control-flow types for background step control steps.
+    /// Wire values must match run-service constants (wait, wait-all, cancel).
+    /// </summary>
+    public static class BackgroundControlTypes
+    {
+        public const string Wait = "wait";
+        public const string WaitAll = "wait-all";
+        public const string Cancel = "cancel";
+    }
+
+    /// <summary>
+    /// Represents a unified background step control-flow step (wait, wait-all, cancel).
+    /// </summary>
+    [DataContract]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class BackgroundStepControl : JobStep
+    {
+        [JsonConstructor]
+        public BackgroundStepControl()
+        {
+        }
+
+        private BackgroundStepControl(BackgroundStepControl stepToClone)
+            : base(stepToClone)
+        {
+            this.ControlType = stepToClone.ControlType;
+            this.StepIds = stepToClone.StepIds != null
+                ? (string[])stepToClone.StepIds.Clone()
+                : null;
+            this.DisplayNameToken = stepToClone.DisplayNameToken?.Clone();
+        }
+
+        public override StepType Type => StepType.BackgroundStepControl;
+
+        [JsonProperty("controlType")]
+        public string ControlType { get; set; }
+
+        [JsonProperty("stepIds")]
+        public string[] StepIds { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public TemplateToken DisplayNameToken { get; set; }
+
+        public override Step Clone()
+        {
+            return new BackgroundStepControl(this);
+        }
+    }
+}

--- a/src/Sdk/DTPipelines/Pipelines/JobStep.cs
+++ b/src/Sdk/DTPipelines/Pipelines/JobStep.cs
@@ -22,6 +22,7 @@ namespace GitHub.DistributedTask.Pipelines
             this.Condition = stepToClone.Condition;
             this.ContinueOnError = stepToClone.ContinueOnError?.Clone();
             this.TimeoutInMinutes = stepToClone.TimeoutInMinutes?.Clone();
+            this.ParallelGroupId = stepToClone.ParallelGroupId;
         }
 
         [DataMember(EmitDefaultValue = false)]
@@ -44,5 +45,8 @@ namespace GitHub.DistributedTask.Pipelines
             get;
             set;
         }
+
+        [DataMember(EmitDefaultValue = false)]
+        public string ParallelGroupId { get; set; }
     }
 }

--- a/src/Sdk/DTPipelines/Pipelines/Step.cs
+++ b/src/Sdk/DTPipelines/Pipelines/Step.cs
@@ -7,6 +7,7 @@ namespace GitHub.DistributedTask.Pipelines
 {
     [DataContract]
     [KnownType(typeof(ActionStep))]
+    [KnownType(typeof(BackgroundStepControl))]
     [JsonConverter(typeof(StepConverter))]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class Step
@@ -68,5 +69,7 @@ namespace GitHub.DistributedTask.Pipelines
     {
         [DataMember]
         Action = 4,
+        [DataMember]
+        BackgroundStepControl = 5,
     }
 }

--- a/src/Sdk/DTPipelines/Pipelines/StepConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/StepConverter.cs
@@ -51,6 +51,9 @@ namespace GitHub.DistributedTask.Pipelines
                     case StepType.Action:
                         stepObject = new ActionStep();
                         break;
+                    case StepType.BackgroundStepControl:
+                        stepObject = new BackgroundStepControl();
+                        break;
                 }
 
                 using (var objectReader = value.CreateReader())

--- a/src/Sdk/DTWebApi/WebApi/TimelineRecord.cs
+++ b/src/Sdk/DTWebApi/WebApi/TimelineRecord.cs
@@ -43,6 +43,10 @@ namespace GitHub.DistributedTask.WebApi
                 this.WarningCount = recordToBeCloned.WarningCount;
                 this.NoticeCount = recordToBeCloned.NoticeCount;
                 this.AgentPlatform = recordToBeCloned.AgentPlatform;
+                this.IsBackground = recordToBeCloned.IsBackground;
+                this.BackgroundControlType = recordToBeCloned.BackgroundControlType;
+                this.BackgroundControlStepIds = recordToBeCloned.BackgroundControlStepIds;
+                this.ParallelGroupId = recordToBeCloned.ParallelGroupId;
 
                 if (recordToBeCloned.Log != null)
                 {
@@ -284,6 +288,34 @@ namespace GitHub.DistributedTask.WebApi
 
         [DataMember(Order = 132, EmitDefaultValue = false)]
         public string AgentPlatform
+        {
+            get;
+            set;
+        }
+
+        [DataMember(Order = 140, EmitDefaultValue = false)]
+        public bool IsBackground
+        {
+            get;
+            set;
+        }
+
+        [DataMember(Order = 141, EmitDefaultValue = false)]
+        public string BackgroundControlType
+        {
+            get;
+            set;
+        }
+
+        [DataMember(Order = 142, EmitDefaultValue = false)]
+        public string[] BackgroundControlStepIds
+        {
+            get;
+            set;
+        }
+
+        [DataMember(Order = 144, EmitDefaultValue = false)]
+        public string ParallelGroupId
         {
             get;
             set;

--- a/src/Sdk/RSWebApi/Contracts/StepResult.cs
+++ b/src/Sdk/RSWebApi/Contracts/StepResult.cs
@@ -50,5 +50,14 @@ namespace GitHub.Actions.RunService.WebApi
 
         [DataMember(Name = "annotations", EmitDefaultValue = false)]
         public List<Annotation> Annotations { get; set; }
+
+        [DataMember(Name = "is_background", EmitDefaultValue = false)]
+        public bool IsBackground { get; set; }
+
+        [DataMember(Name = "background_control_type", EmitDefaultValue = false)]
+        public string BackgroundControlType { get; set; }
+
+        [DataMember(Name = "background_control_step_ids", EmitDefaultValue = false)]
+        public string[] BackgroundControlStepIds { get; set; }
     }
 }

--- a/src/Sdk/WebApi/WebApi/Contracts.cs
+++ b/src/Sdk/WebApi/WebApi/Contracts.cs
@@ -182,13 +182,10 @@ namespace GitHub.Services.Results.Contracts
         [DataMember(EmitDefaultValue = false)]
         public bool IsBackground;
         [DataMember(EmitDefaultValue = false)]
-        [JsonProperty("backgroundControlType")]
         public string BackgroundControlType;
         [DataMember(EmitDefaultValue = false)]
-        [JsonProperty("backgroundControlStepIds")]
         public string[] BackgroundControlStepIds;
         [DataMember(EmitDefaultValue = false)]
-        [JsonProperty("parallelGroupId")]
         public string ParallelGroupId;
     }
 

--- a/src/Sdk/WebApi/WebApi/Contracts.cs
+++ b/src/Sdk/WebApi/WebApi/Contracts.cs
@@ -179,6 +179,17 @@ namespace GitHub.Services.Results.Contracts
         public string CompletedAt;
         [DataMember]
         public Conclusion Conclusion;
+        [DataMember(EmitDefaultValue = false)]
+        public bool IsBackground;
+        [DataMember(EmitDefaultValue = false)]
+        [JsonProperty("backgroundControlType")]
+        public string BackgroundControlType;
+        [DataMember(EmitDefaultValue = false)]
+        [JsonProperty("backgroundControlStepIds")]
+        public string[] BackgroundControlStepIds;
+        [DataMember(EmitDefaultValue = false)]
+        [JsonProperty("parallelGroupId")]
+        public string ParallelGroupId;
     }
 
     public enum Status

--- a/src/Sdk/WebApi/WebApi/ResultsHttpClient.cs
+++ b/src/Sdk/WebApi/WebApi/ResultsHttpClient.cs
@@ -514,7 +514,7 @@ namespace GitHub.Services.Results.Client
 
         private Step ConvertTimelineRecordToStep(TimelineRecord r)
         {
-            return new Step()
+            var step = new Step()
             {
                 ExternalId = r.Id.ToString(),
                 Number = r.Order.GetValueOrDefault(),
@@ -522,8 +522,25 @@ namespace GitHub.Services.Results.Client
                 Status = ConvertStateToStatus(r.State.GetValueOrDefault()),
                 StartedAt = r.StartTime?.ToString(Constants.TimestampFormat, CultureInfo.InvariantCulture),
                 CompletedAt = r.FinishTime?.ToString(Constants.TimestampFormat, CultureInfo.InvariantCulture),
-                Conclusion = ConvertResultToConclusion(r.Result)
+                Conclusion = ConvertResultToConclusion(r.Result),
+                IsBackground = r.IsBackground,
             };
+
+            // Set background control type directly (no enum mapping needed)
+            if (!string.IsNullOrEmpty(r.BackgroundControlType))
+            {
+                step.BackgroundControlType = r.BackgroundControlType;
+            }
+            if (r.BackgroundControlStepIds != null)
+            {
+                step.BackgroundControlStepIds = r.BackgroundControlStepIds;
+            }
+            if (!string.IsNullOrEmpty(r.ParallelGroupId))
+            {
+                step.ParallelGroupId = r.ParallelGroupId;
+            }
+
+            return step;
         }
 
         private Status ConvertStateToStatus(TimelineRecordState s)


### PR DESCRIPTION
## Summary

Add SDK types and results plumbing for background step control

This PR adds the SDK-layer types and results service wiring needed for background steps

### SDK step models

- Add `BackgroundStepControl` pipeline type with `ControlType`, `StepIds`, and `BackgroundControlTypes` constants (`wait`, `wait-all`, `cancel`)
- Move `ParallelGroupId` to `JobStep` base class (shared by `ActionStep` and `BackgroundStepControl`)
- Add `Background` property to `ActionStep`

### Timeline & results plumbing

- Extend `TimelineRecord` with `IsBackground`, `BackgroundControlType`, `BackgroundControlStepIds`, and `ParallelGroupId`
- Wire new fields through `ResultsHttpClient.ConvertTimelineRecordToStep`
- Add matching fields to `StepResult` and `Step` contracts for results service communication

### Related

- github/actions-runtime#5420
- github/actions-runtime#5421