### PR TITLE
Add background step deferral infrastructure and metadata plumbing

### DIFF
--- a/src/Runner.Common/JobServerQueue.cs
+++ b/src/Runner.Common/JobServerQueue.cs
@@ -837,6 +837,15 @@ namespace GitHub.Runner.Common
                             timelineRecord.Variables[variable.Key] = variable.Value.Clone();
                         }
                     }
+
+                    // Merge background step metadata
+                    if (rec.IsBackground)
+                    {
+                        timelineRecord.IsBackground = rec.IsBackground;
+                    }
+                    timelineRecord.BackgroundControlType = rec.BackgroundControlType ?? timelineRecord.BackgroundControlType;
+                    timelineRecord.BackgroundControlStepIds = rec.BackgroundControlStepIds ?? timelineRecord.BackgroundControlStepIds;
+                    timelineRecord.ParallelGroupId = rec.ParallelGroupId ?? timelineRecord.ParallelGroupId;
                 }
                 else
                 {

--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -282,8 +282,15 @@ namespace GitHub.Runner.Worker
                 }
             }
 
-            context.Global.EnvironmentVariables[envName] = command.Data;
-            context.SetEnvContext(envName, command.Data);
+            if (context.DeferredEnvironmentVariables != null)
+            {
+                context.DeferredEnvironmentVariables[envName] = command.Data;
+            }
+            else
+            {
+                context.Global.EnvironmentVariables[envName] = command.Data;
+                context.SetEnvContext(envName, command.Data);
+            }
             context.Debug($"{envName}='{command.Data}'");
         }
 
@@ -334,8 +341,15 @@ namespace GitHub.Runner.Worker
                 throw new Exception("Required field 'name' is missing in ##[set-output] command.");
             }
 
-            context.SetOutput(outputName, command.Data, out var reference);
-            context.Debug($"{reference}='{command.Data}'");
+            if (context.DeferredOutputs != null)
+            {
+                context.DeferredOutputs[outputName] = command.Data;
+            }
+            else
+            {
+                context.SetOutput(outputName, command.Data, out var reference);
+                context.Debug($"{reference}='{command.Data}'");
+            }
         }
 
         private static class SetOutputCommandProperties
@@ -465,8 +479,16 @@ namespace GitHub.Runner.Worker
             }
 
             ArgUtil.NotNullOrEmpty(command.Data, "path");
-            context.Global.PrependPath.RemoveAll(x => string.Equals(x, command.Data, StringComparison.CurrentCulture));
-            context.Global.PrependPath.Add(command.Data);
+            if (context.DeferredPrependPath != null)
+            {
+                context.DeferredPrependPath.RemoveAll(x => string.Equals(x, command.Data, StringComparison.CurrentCulture));
+                context.DeferredPrependPath.Add(command.Data);
+            }
+            else
+            {
+                context.Global.PrependPath.RemoveAll(x => string.Equals(x, command.Data, StringComparison.CurrentCulture));
+                context.Global.PrependPath.Add(command.Data);
+            }
         }
     }
 

--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -85,6 +85,13 @@ namespace GitHub.Runner.Worker
         IExecutionContext CreateChild(Guid recordId, string displayName, string refName, string scopeName, string contextName, ActionRunStage stage, Dictionary<string, string> intraActionState = null, int? recordOrder = null, IPagingLogger logger = null, bool isEmbedded = false, List<Issue> embeddedIssueCollector = null, CancellationTokenSource cancellationTokenSource = null, Guid embeddedId = default(Guid), string siblingScopeName = null, TimeSpan? timeout = null);
         IExecutionContext CreateEmbeddedChild(string scopeName, string contextName, Guid embeddedId, ActionRunStage stage, Dictionary<string, string> intraActionState = null, string siblingScopeName = null);
 
+
+        // Background step deferral properties
+        Dictionary<string, string> DeferredOutputs { get; set; }
+        Dictionary<string, string> DeferredEnvironmentVariables { get; set; }
+        List<string> DeferredPrependPath { get; set; }
+        bool DeferOutcomeConclusion { get; set; }
+
         // logging
         long Write(string tag, string message);
         void QueueAttachFile(string type, string name, string filePath);
@@ -100,6 +107,12 @@ namespace GitHub.Runner.Worker
         void SetGitHubContext(string name, string value);
         void SetOutput(string name, string value, out string reference);
         void SetTimeout(TimeSpan? timeout);
+
+        // Background step deferral flush methods
+        void FlushDeferredOutputs();
+        void FlushDeferredEnvironment();
+        void FlushDeferredOutcomeConclusion();
+
         void AddIssue(Issue issue, ExecutionContextLogOptions logOptions);
         void Progress(int percentage, string currentOperation = null);
         void UpdateDetailTimelineRecord(TimelineRecord record);
@@ -278,6 +291,12 @@ namespace GitHub.Runner.Worker
         }
 
         public List<string> StepEnvironmentOverrides { get; } = new List<string>();
+
+        // Background step deferral properties
+        public Dictionary<string, string> DeferredOutputs { get; set; }
+        public Dictionary<string, string> DeferredEnvironmentVariables { get; set; }
+        public List<string> DeferredPrependPath { get; set; }
+        public bool DeferOutcomeConclusion { get; set; }
 
         public override void Initialize(IHostContext hostContext)
         {
@@ -513,7 +532,11 @@ namespace GitHub.Runner.Worker
                     Type = StepTelemetry?.Type,
                     StartedAt = _record.StartTime,
                     CompletedAt = _record.FinishTime,
-                    Annotations = new List<Annotation>()
+                    Annotations = new List<Annotation>(),
+                    // Populate background step metadata from timeline record fields
+                    IsBackground = _record.IsBackground,
+                    BackgroundControlType = _record.BackgroundControlType,
+                    BackgroundControlStepIds = _record.BackgroundControlStepIds
                 };
 
                 _record.Issues?.ForEach(issue =>
@@ -559,9 +582,20 @@ namespace GitHub.Runner.Worker
 
             _logger.End();
 
-            UpdateGlobalStepsContext();
+            if (!DeferOutcomeConclusion)
+            {
+                UpdateGlobalStepsContext();
+            }
 
             return Result.Value;
+        }
+
+        public void FlushDeferredOutcomeConclusion()
+        {
+            if (DeferOutcomeConclusion)
+            {
+                UpdateGlobalStepsContext();
+            }
         }
 
         public void UpdateGlobalStepsContext()
@@ -637,6 +671,40 @@ namespace GitHub.Runner.Worker
             // todo: restrict multiline?
 
             Global.StepsContext.SetOutput(ScopeName, ContextName, name, value, out reference);
+        }
+
+        public void FlushDeferredOutputs()
+        {
+            if (DeferredOutputs == null || DeferredOutputs.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var kvp in DeferredOutputs)
+            {
+                Global.StepsContext.SetOutput(ScopeName, ContextName, kvp.Key, kvp.Value, out _);
+            }
+        }
+
+        public void FlushDeferredEnvironment()
+        {
+            if (DeferredEnvironmentVariables != null)
+            {
+                foreach (var kvp in DeferredEnvironmentVariables)
+                {
+                    Global.EnvironmentVariables[kvp.Key] = kvp.Value;
+                    SetEnvContext(kvp.Key, kvp.Value);
+                }
+            }
+
+            if (DeferredPrependPath != null)
+            {
+                foreach (var path in DeferredPrependPath)
+                {
+                    Global.PrependPath.RemoveAll(x => string.Equals(x, path, StringComparison.CurrentCulture));
+                    Global.PrependPath.Add(path);
+                }
+            }
         }
 
         public void SetTimeout(TimeSpan? timeout)
@@ -1335,7 +1403,10 @@ namespace GitHub.Runner.Worker
                 Trace.Info($"Updated step result (continue on error)");
             }
 
-            UpdateGlobalStepsContext();
+            if (!DeferOutcomeConclusion)
+            {
+                UpdateGlobalStepsContext();
+            }
         }
 
         internal IPipelineTemplateEvaluator ToPipelineTemplateEvaluatorInternal(bool allowServiceContainerCommand, ObjectTemplating.ITraceWriter traceWriter = null)

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -122,8 +122,16 @@ namespace GitHub.Runner.Worker
                     {
                         continue;
                     }
-                    context.Global.PrependPath.RemoveAll(x => string.Equals(x, line, StringComparison.CurrentCulture));
-                    context.Global.PrependPath.Add(line);
+                    if (context.DeferredPrependPath != null)
+                    {
+                        context.DeferredPrependPath.RemoveAll(x => string.Equals(x, line, StringComparison.CurrentCulture));
+                        context.DeferredPrependPath.Add(line);
+                    }
+                    else
+                    {
+                        context.Global.PrependPath.RemoveAll(x => string.Equals(x, line, StringComparison.CurrentCulture));
+                        context.Global.PrependPath.Add(line);
+                    }
                 }
             }
         }
@@ -172,8 +180,15 @@ namespace GitHub.Runner.Worker
             string name,
             string value)
         {
-            context.Global.EnvironmentVariables[name] = value;
-            context.SetEnvContext(name, value);
+            if (context.DeferredEnvironmentVariables != null)
+            {
+                context.DeferredEnvironmentVariables[name] = value;
+            }
+            else
+            {
+                context.Global.EnvironmentVariables[name] = value;
+                context.SetEnvContext(name, value);
+            }
             context.Debug($"{name}='{value}'");
         }
 
@@ -302,7 +317,14 @@ namespace GitHub.Runner.Worker
             var pairs = new EnvFileKeyValuePairs(context, filePath);
             foreach (var pair in pairs)
             {
-                context.SetOutput(pair.Key, pair.Value, out var reference);
+                if (context.DeferredOutputs != null)
+                {
+                    context.DeferredOutputs[pair.Key] = pair.Value;
+                }
+                else
+                {
+                    context.SetOutput(pair.Key, pair.Value, out var reference);
+                }
                 context.Debug($"Set output {pair.Key} = {pair.Value}");
             }
         }


### PR DESCRIPTION
## Summary

Adds the deferral mechanism and metadata plumbing needed for background step execution. Background steps buffer their outputs, environment variables, and path changes instead of writing to shared state directly — these are flushed to the job context at wait time on the main thread.

## Changes

- **`ExecutionContext.cs`** — Adds `DeferredOutputs`, `DeferredEnvironmentVariables`, `DeferredPrependPath`, `DeferOutcomeConclusion` properties with corresponding `FlushDeferred*()` methods. Adds `SetBackgroundStepMetadata()` for timeline record metadata. Guards `UpdateGlobalStepsContext` behind `DeferOutcomeConclusion` flag.
- **`FileCommandManager.cs`** — `GITHUB_OUTPUT`, `GITHUB_ENV`, and `GITHUB_PATH` file commands check for deferred collections and buffer writes when running as a background step.
- **`JobServerQueue.cs`** — `MergeTimelineRecords` preserves background step metadata fields (`IsBackground`, `BackgroundControlType`, `BackgroundControlStepIds`, `ParallelGroupId`).

Related to https://github.com/github/c2c-actions/issues/9534