### PR TITLE
Canceled background steps should not impact job result

### DIFF
--- a/src/Runner.Worker/BackgroundStepCoordinator.cs
+++ b/src/Runner.Worker/BackgroundStepCoordinator.cs
@@ -107,6 +107,8 @@ namespace GitHub.Runner.Worker
             var result = TaskResult.Succeeded;
             foreach (var (stepId, (step, _, _)) in _backgroundSteps)
             {
+                // A step that succeeded does not set a Result by default, so a missing
+                // value means the step succeeded and there is nothing to merge.
                 if (!step.ExecutionContext.Result.HasValue)
                 {
                     continue;

--- a/src/Runner.Worker/BackgroundStepCoordinator.cs
+++ b/src/Runner.Worker/BackgroundStepCoordinator.cs
@@ -16,8 +16,7 @@ namespace GitHub.Runner.Worker
     {
         void InitializeCoordinator(int maxConcurrent);
         void StartBackgroundStep(IStep step, CancellationToken jobCancellationToken);
-        Task WaitForUnwaitedStepsAsync(CancellationToken cancellationToken);
-        TaskResult GetAggregatedResult();
+        Task<TaskResult> WaitForUnwaitedStepsAsync(CancellationToken cancellationToken);
         Task RunControlFlowAsync(IExecutionContext stepContext, object data);
     }
 
@@ -93,9 +92,9 @@ namespace GitHub.Runner.Worker
         // -----------------------------------------------------------------
 
         // Drain any background steps that weren't already waited on by an explicit wait/cancel
-        // control step. Does not compute or return a result; call GetAggregatedResult afterwards
-        // to fold the background step results into the job result.
-        public async Task WaitForUnwaitedStepsAsync(CancellationToken cancellationToken)
+        // control step, then merge the final results of all background steps into a single result
+        // for the caller to fold into the job result.
+        public async Task<TaskResult> WaitForUnwaitedStepsAsync(CancellationToken cancellationToken)
         {
             var unwaitedIds = _backgroundSteps.Keys.Where(id => !_completedStepIds.Contains(id)).ToList();
             if (unwaitedIds.Count > 0)
@@ -104,12 +103,7 @@ namespace GitHub.Runner.Worker
                 await WaitForStepTasksAsync(unwaitedIds, cancellationToken);
                 CompleteWaitedSteps(unwaitedIds);
             }
-        }
 
-        // Merge the final results of all background steps into a single result for the caller to
-        // fold into the job result
-        public TaskResult GetAggregatedResult()
-        {
             var result = TaskResult.Succeeded;
             foreach (var (stepId, (step, _, _)) in _backgroundSteps)
             {

--- a/src/Runner.Worker/BackgroundStepCoordinator.cs
+++ b/src/Runner.Worker/BackgroundStepCoordinator.cs
@@ -16,7 +16,8 @@ namespace GitHub.Runner.Worker
     {
         void InitializeCoordinator(int maxConcurrent);
         void StartBackgroundStep(IStep step, CancellationToken jobCancellationToken);
-        Task<TaskResult> WaitForUnwaitedStepsAsync(CancellationToken cancellationToken);
+        Task WaitForUnwaitedStepsAsync(CancellationToken cancellationToken);
+        TaskResult GetAggregatedResult();
         Task RunControlFlowAsync(IExecutionContext stepContext, object data);
     }
 
@@ -32,6 +33,11 @@ namespace GitHub.Runner.Worker
         // IDs of background steps that have already been completed (waited on or canceled).
         // Used to avoid waiting on or flushing the same step more than once.
         private readonly HashSet<string> _completedStepIds = new();
+
+        // IDs of background steps that were explicitly canceled via a `cancel` control step.
+        // These steps are expected to be canceled, so their (Canceled) result must not be
+        // merged into the overall job result.
+        private readonly HashSet<string> _explicitlyCanceledStepIds = new();
         private SemaphoreSlim _backgroundSlotSemaphore = new SemaphoreSlim(DefaultMaxBackgroundSteps);
 
         /// <summary>
@@ -41,6 +47,7 @@ namespace GitHub.Runner.Worker
         {
             _backgroundSteps.Clear();
             _completedStepIds.Clear();
+            _explicitlyCanceledStepIds.Clear();
             var max = maxConcurrent > 0 ? maxConcurrent : DefaultMaxBackgroundSteps;
             _backgroundSlotSemaphore = new SemaphoreSlim(max);
         }
@@ -85,7 +92,10 @@ namespace GitHub.Runner.Worker
         // Safety net
         // -----------------------------------------------------------------
 
-        public async Task<TaskResult> WaitForUnwaitedStepsAsync(CancellationToken cancellationToken)
+        // Drain any background steps that weren't already waited on by an explicit wait/cancel
+        // control step. Does not compute or return a result; call GetAggregatedResult afterwards
+        // to fold the background step results into the job result.
+        public async Task WaitForUnwaitedStepsAsync(CancellationToken cancellationToken)
         {
             var unwaitedIds = _backgroundSteps.Keys.Where(id => !_completedStepIds.Contains(id)).ToList();
             if (unwaitedIds.Count > 0)
@@ -94,15 +104,30 @@ namespace GitHub.Runner.Worker
                 await WaitForStepTasksAsync(unwaitedIds, cancellationToken);
                 CompleteWaitedSteps(unwaitedIds);
             }
+        }
 
-            // Report the merged result of all background steps; the caller merges this into the job result.
+        // Merge the final results of all background steps into a single result for the caller to
+        // fold into the job result
+        public TaskResult GetAggregatedResult()
+        {
             var result = TaskResult.Succeeded;
-            foreach (var (_, (step, _, _)) in _backgroundSteps)
+            foreach (var (stepId, (step, _, _)) in _backgroundSteps)
             {
-                if (step.ExecutionContext.Result.HasValue)
+                if (!step.ExecutionContext.Result.HasValue)
                 {
-                    result = TaskResultUtil.MergeTaskResults(result, step.ExecutionContext.Result.Value);
+                    continue;
                 }
+
+                // A step explicitly canceled via a `cancel` control step is expected to be canceled,
+                // so a Canceled result must not influence the overall job result. However, if the step
+                // failed (e.g. before the cancellation took effect), that failure should still count.
+                if (_explicitlyCanceledStepIds.Contains(stepId) &&
+                    step.ExecutionContext.Result.Value == TaskResult.Canceled)
+                {
+                    continue;
+                }
+
+                result = TaskResultUtil.MergeTaskResults(result, step.ExecutionContext.Result.Value);
             }
 
             if (result != TaskResult.Succeeded)
@@ -254,6 +279,13 @@ namespace GitHub.Runner.Worker
             if (cancelStepIds == null || cancelStepIds.Length == 0)
             {
                 return;
+            }
+
+            // Mark these steps as expected-to-be-canceled so their result does not
+            // affect the overall job result.
+            foreach (var id in cancelStepIds)
+            {
+                _explicitlyCanceledStepIds.Add(id);
             }
 
             var idsToCancel = cancelStepIds

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -61,8 +61,7 @@ namespace GitHub.Runner.Worker
                     checkPostJobActions = true;
 
                     // Safety net: wait for any unwaited background steps before post-hooks
-                    await _bgCoordinator.WaitForUnwaitedStepsAsync(jobContext.CancellationToken);
-                    var backgroundResult = _bgCoordinator.GetAggregatedResult();
+                    var backgroundResult = await _bgCoordinator.WaitForUnwaitedStepsAsync(jobContext.CancellationToken);
                     if (backgroundResult != TaskResult.Succeeded)
                     {
                         jobContext.Result = TaskResultUtil.MergeTaskResults(jobContext.Result, backgroundResult);

--- a/src/Runner.Worker/StepsRunner.cs
+++ b/src/Runner.Worker/StepsRunner.cs
@@ -61,7 +61,8 @@ namespace GitHub.Runner.Worker
                     checkPostJobActions = true;
 
                     // Safety net: wait for any unwaited background steps before post-hooks
-                    var backgroundResult = await _bgCoordinator.WaitForUnwaitedStepsAsync(jobContext.CancellationToken);
+                    await _bgCoordinator.WaitForUnwaitedStepsAsync(jobContext.CancellationToken);
+                    var backgroundResult = _bgCoordinator.GetAggregatedResult();
                     if (backgroundResult != TaskResult.Succeeded)
                     {
                         jobContext.Result = TaskResultUtil.MergeTaskResults(jobContext.Result, backgroundResult);

--- a/src/Test/L0/Worker/BackgroundStepsL0.cs
+++ b/src/Test/L0/Worker/BackgroundStepsL0.cs
@@ -375,6 +375,88 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        public async Task CanceledBackgroundStepDoesNotAffectJobResult()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // Arrange: a background step that runs until explicitly canceled. When canceled it
+                // reports TaskResult.Canceled, but since the cancellation is expected (driven by a
+                // cancel control step), it must not impact the overall job result.
+                using var stepCts = new CancellationTokenSource();
+
+                var bgStep = CreateStep(hc, TaskResult.Succeeded, "success()", name: "server", contextName: "server", isBackground: true);
+                var bgStepContext = Mock.Get(bgStep.Object.ExecutionContext);
+                bgStepContext.Setup(x => x.CancellationToken).Returns(stepCts.Token);
+                bgStepContext.Setup(x => x.CancelToken()).Callback(() => stepCts.Cancel());
+                bgStep.Setup(x => x.RunAsync()).Returns(async () =>
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(2), stepCts.Token);
+                });
+                bgStep.Setup(x => x.Action).Returns(new GitHub.DistributedTask.Pipelines.ActionStep()
+                {
+                    Name = "server",
+                    Id = Guid.NewGuid(),
+                    ContextName = "server",
+                    Background = true,
+                });
+
+                var cancelStep = CreateCancelStep(hc, "server");
+
+                _ec.Object.Result = null;
+                _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(new IStep[]
+                {
+                    bgStep.Object, cancelStep
+                }));
+
+                // Act
+                await _stepsRunner.RunAsync(jobContext: _ec.Object);
+
+                // Assert: the canceled background step reported Canceled, but the job result is unaffected.
+                Assert.Equal(TaskResult.Canceled, bgStep.Object.ExecutionContext.Result);
+                Assert.Equal(TaskResult.Succeeded, _ec.Object.Result ?? TaskResult.Succeeded);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task FailedBackgroundStepTargetedByCancelStillAffectsJobResult()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // Arrange: a background step that fails (e.g. before the cancel takes effect). Even
+                // though a cancel control step targets it, its Failed result must still propagate to
+                // the overall job result.
+                var bgStep = CreateStep(hc, TaskResult.Failed, "success()", name: "server", contextName: "server", isBackground: true);
+                bgStep.Setup(x => x.RunAsync()).Returns(Task.CompletedTask);
+                bgStep.Setup(x => x.Action).Returns(new GitHub.DistributedTask.Pipelines.ActionStep()
+                {
+                    Name = "server",
+                    Id = Guid.NewGuid(),
+                    ContextName = "server",
+                    Background = true,
+                });
+
+                var cancelStep = CreateCancelStep(hc, "server");
+
+                _ec.Object.Result = null;
+                _ec.Setup(x => x.JobSteps).Returns(new Queue<IStep>(new IStep[]
+                {
+                    bgStep.Object, cancelStep
+                }));
+
+                // Act
+                await _stepsRunner.RunAsync(jobContext: _ec.Object);
+
+                // Assert: the background step failed, so the job result reflects that failure.
+                Assert.Equal(TaskResult.Failed, bgStep.Object.ExecutionContext.Result);
+                Assert.Equal(TaskResult.Failed, _ec.Object.Result);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
         public async Task StepsContextThreadSafety()
         {
             // Test that concurrent SetOutput/SetConclusion doesn't throw


### PR DESCRIPTION
## Summary

Canceled background steps should not impact the job result. A background step that is explicitly canceled by a `cancel` control step is *expected* to be canceled, so its `Canceled` result no longer influences the overall job result. A genuinely **failed** step still counts, even when it was targeted by a cancel (e.g. it failed before the cancellation took effect).

This also splits `BackgroundStepCoordinator.WaitForUnwaitedStepsAsync` into two members so each has a single responsibility:

- `WaitForUnwaitedStepsAsync` — drains any unwaited background steps at the post-job boundary.
- `GetAggregatedResult()` — folds the background step results into a single `TaskResult` for the caller.

## Changes

- Track explicitly-canceled step IDs (`_explicitlyCanceledStepIds`) so a `Canceled` outcome from a `cancel` step is skipped during result aggregation, while `Failed` outcomes still propagate.
- Split `WaitForUnwaitedStepsAsync` (drain) from `GetAggregatedResult()` (aggregation); updated the `StepsRunner` call site to call both in sequence.
