### PR TITLE
Fix check command failure exit code

### DIFF
--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -113,6 +113,7 @@ namespace GitHub.Runner.Listener
                     var pat = command.GetGitHubPersonalAccessToken(required: true);
                     var checkExtensions = HostContext.GetService<IExtensionManager>().GetExtensions<ICheckExtension>();
                     var sortedChecks = checkExtensions.OrderBy(x => x.Order);
+                    var hasFailure = false;
                     foreach (var check in sortedChecks)
                     {
                         _term.WriteLine($"**********************************************************************************************************************");
@@ -122,6 +123,7 @@ namespace GitHub.Runner.Listener
                         var result = await check.RunCheck(url, pat);
                         if (!result)
                         {
+                            hasFailure = true;
                             _term.WriteLine($"**                                                                                                                  **");
                             _term.WriteLine($"**                                            F A I L                                                               **");
                             _term.WriteLine($"**                                                                                                                  **");
@@ -144,7 +146,7 @@ namespace GitHub.Runner.Listener
                         _term.WriteLine();
                     }
 
-                    return Constants.Runner.ReturnCode.Success;
+                    return hasFailure ? Constants.Runner.ReturnCode.TerminatedError : Constants.Runner.ReturnCode.Success;
                 }
 
                 // Configure runner prompt for args if not supplied

--- a/src/Test/L0/Listener/RunnerL0.cs
+++ b/src/Test/L0/Listener/RunnerL0.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Listener;
+using GitHub.Runner.Listener.Check;
 using GitHub.Runner.Listener.Configuration;
 using GitHub.Services.Common;
 using GitHub.Services.WebApi;
@@ -213,6 +214,44 @@ namespace GitHub.Runner.Common.Tests.Listener
                 await runner.ExecuteCommand(command);
 
                 _messageListener.Verify(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()), expectedTimes);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, Constants.Runner.ReturnCode.Success)]
+        [InlineData(false, Constants.Runner.ReturnCode.TerminatedError)]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async Task TestCheckCommandReturnsNonZeroWhenCheckFails(bool checkResult, int expectedReturnCode)
+        {
+            using (var hc = new TestHostContext(this))
+            {
+                var extensionManager = new Mock<IExtensionManager>();
+                var check = new Mock<ICheckExtension>();
+                check.Setup(x => x.Order).Returns(1);
+                check.Setup(x => x.CheckName).Returns("test check");
+                check.Setup(x => x.CheckDescription).Returns("test description");
+                check.Setup(x => x.CheckLog).Returns("test log");
+                check.Setup(x => x.HelpLink).Returns("test help");
+                check.Setup(x => x.RunCheck("https://github.com/actions/runner", "token"))
+                    .ReturnsAsync(checkResult);
+
+                extensionManager.Setup(x => x.GetExtensions<ICheckExtension>())
+                    .Returns(new List<ICheckExtension> { check.Object });
+
+                hc.SetSingleton<IConfigurationManager>(_configurationManager.Object);
+                hc.SetSingleton<IPromptManager>(_promptManager.Object);
+                hc.SetSingleton<IExtensionManager>(extensionManager.Object);
+                hc.SetSingleton<IRunnerServer>(_runnerServer.Object);
+                hc.EnqueueInstance<IErrorThrottler>(_acquireJobThrottler.Object);
+
+                var command = new CommandSettings(hc, new[] { "--check", "--url", "https://github.com/actions/runner", "--pat", "token" });
+
+                var runner = new Runner.Listener.Runner();
+                runner.Initialize(hc);
+                var result = await runner.ExecuteCommand(command);
+
+                Assert.Equal(expectedReturnCode, result);
             }
         }
 


### PR DESCRIPTION
## Summary

Return a non-zero exit code from `--check` when any check extension reports failure.

Fixes #4395.

## Testing

- `../_dotnetsdk/8.0.421/dotnet format ActionsRunner.sln --exclude / --include Runner.Listener/Runner.cs Test/L0/Listener/RunnerL0.cs --verify-no-changes`
- `../_dotnetsdk/8.0.421/dotnet test Test/Test.csproj -c Debug --filter "FullyQualifiedName~RunnerL0.TestCheckCommandReturnsNonZeroWhenCheckFails" --logger "console;verbosity=normal"`
- `./dev.sh test`
