### PR TITLE
Bump Docker to 29.6.1 and add INSTALL_DOCKER_TOOLING build arg

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -5,8 +5,12 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG RUNNER_VERSION
 ARG RUNNER_CONTAINER_HOOKS_VERSION=0.7.0
-ARG DOCKER_VERSION=29.6.0
+ARG DOCKER_VERSION=29.6.1
 ARG BUILDX_VERSION=0.35.0
+# Set to "false" to skip installing the in-image docker CLI/daemon, containerd,
+# runc and buildx. Consumers running ARC with a docker sidecar or host-socket
+# pattern don't need these binaries and otherwise inherit every CVE in them.
+ARG INSTALL_DOCKER_TOOLING=true
 
 RUN apt update -y && apt install curl unzip -y
 
@@ -25,16 +29,20 @@ RUN curl -f -L -o runner-container-hooks.zip https://github.com/actions/runner-c
     && unzip ./runner-container-hooks.zip -d ./k8s-novolume \
     && rm runner-container-hooks.zip
 
-RUN export RUNNER_ARCH=${TARGETARCH} \
-    && if [ "$RUNNER_ARCH" = "amd64" ]; then export DOCKER_ARCH=x86_64 ; fi \
-    && if [ "$RUNNER_ARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
-    && curl -fLo docker.tgz https://download.docker.com/${TARGETOS}/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz \
-    && tar zxvf docker.tgz \
-    && rm -rf docker.tgz \
-    && mkdir -p /usr/local/lib/docker/cli-plugins \
-    && curl -fLo /usr/local/lib/docker/cli-plugins/docker-buildx \
-    "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TARGETARCH}" \
-    && chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
+# Always create the target dirs so the later COPY steps succeed even when the
+# docker tooling is skipped (empty dir copies are fine; a missing file is not).
+RUN mkdir -p docker /usr/local/lib/docker/cli-plugins \
+    && if [ "${INSTALL_DOCKER_TOOLING}" = "true" ]; then \
+        export RUNNER_ARCH=${TARGETARCH} ; \
+        if [ "$RUNNER_ARCH" = "amd64" ]; then export DOCKER_ARCH=x86_64 ; fi ; \
+        if [ "$RUNNER_ARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi ; \
+        curl -fLo docker.tgz https://download.docker.com/${TARGETOS}/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz \
+        && tar zxvf docker.tgz \
+        && rm -rf docker.tgz \
+        && curl -fLo /usr/local/lib/docker/cli-plugins/docker-buildx \
+        "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TARGETARCH}" \
+        && chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx ; \
+    fi
 
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-noble
 
@@ -65,8 +73,11 @@ RUN adduser --disabled-password --gecos "" --uid 1001 runner \
 WORKDIR /home/runner
 
 COPY --chown=runner:docker --from=build /actions-runner .
-COPY --from=build /usr/local/lib/docker/cli-plugins/docker-buildx /usr/local/lib/docker/cli-plugins/docker-buildx
+# Copy the whole cli-plugins dir (always present, possibly empty) rather than a
+# specific file, so the build doesn't fail when docker tooling is skipped.
+COPY --from=build /usr/local/lib/docker/cli-plugins /usr/local/lib/docker/cli-plugins
 
-RUN install -o root -g root -m 755 docker/* /usr/bin/ && rm -rf docker
+RUN if [ -n "$(ls -A docker 2>/dev/null)" ]; then install -o root -g root -m 755 docker/* /usr/bin/ ; fi \
+    && rm -rf docker
 
 USER runner


### PR DESCRIPTION
## Why

Grype flags Critical findings on `ghcr.io/actions/actions-runner:latest`. Two changes here address them:

1. **Bump `DOCKER_VERSION` 29.6.0 → 29.6.1.** Clears Critical findings in the bundled docker CLI/daemon binaries (`/usr/bin/docker`, `/usr/bin/dockerd`, `/usr/bin/docker-proxy`): `golang.org/x/crypto`, `golang.org/x/net`, and Go stdlib findings tied to the Docker Go toolchain. docker-29.6.1 was released 2026-06-26.

2. **Add `INSTALL_DOCKER_TOOLING` build arg (default `true`).** Many runner consumers — ARC users with a docker sidecar or host-socket pattern — don't need the in-image `docker` CLI, `dockerd`, `containerd`, `runc`, or `buildx`, yet they inherit every CVE in those binaries. Setting `--build-arg INSTALL_DOCKER_TOOLING=false` skips installing them. Default `true` preserves current behavior exactly. The target directories are still created in the build stage so the final-stage `COPY` steps succeed when the tooling is skipped.

## Validation

Built locally for `linux/arm64` with `RUNNER_VERSION=2.335.1`:

- `docker build --check` — passes, no warnings.
- **Default (`INSTALL_DOCKER_TOOLING=true`)** — builds successfully. Inside the image, both `docker --version` and `dockerd --version` report `29.6.1`; the `docker-buildx` cli-plugin is present.
- **`INSTALL_DOCKER_TOOLING=false`** — builds successfully. `docker`/`dockerd`/buildx are absent, the `cli-plugins` directory still exists (empty), and the runner itself (`run.sh`, `config.sh`) is intact.
- **Image size**: default `1.83GB` vs no-tooling `1.14GB` (~690MB / ~38% smaller).

## Notes / out of scope

- `BUILDX_VERSION` is intentionally **not** bumped: `0.35.0` is the current latest release. The remaining buildx finding (`github.com/docker/docker v28.5.2+incompatible`, vendored in `docker-buildx`) can only clear once `docker/buildx` ships a release with updated vendored deps.
- containerd-side findings (`google.golang.org/grpc`, `go.opentelemetry.io/otel`, Go stdlib in `containerd`) come from the upstream Docker static tarball and will clear when a future `DOCKER_VERSION` picks up a rebuilt containerd. Not addressable in this repo.
