### PR TITLE
feat: expose effective cache-mode to steps via ACTIONS_CACHE_MODE

### DIFF
--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -239,6 +239,11 @@ namespace GitHub.Runner.Worker.Handlers
                 Environment["ACTIONS_RESULTS_URL"] = resultsUrl;
             }
 
+            if (ExecutionContext.Global.Variables.TryGetValue("actions_cache_mode", out var cacheMode) && !string.IsNullOrEmpty(cacheMode))
+            {
+                Environment["ACTIONS_CACHE_MODE"] = cacheMode;
+            }
+
             if (ExecutionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SetOrchestrationIdEnvForActions) ?? false)
             {
                 if (ExecutionContext.Global.Variables.TryGetValue(Constants.Variables.System.OrchestrationId, out var orchestrationId) && !string.IsNullOrEmpty(orchestrationId))

--- a/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
+++ b/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs
@@ -78,6 +78,11 @@ namespace GitHub.Runner.Worker.Handlers
                 Environment["ACTIONS_CACHE_SERVICE_V2"] = bool.TrueString;
             }
 
+            if (ExecutionContext.Global.Variables.TryGetValue("actions_cache_mode", out var cacheMode) && !string.IsNullOrEmpty(cacheMode))
+            {
+                Environment["ACTIONS_CACHE_MODE"] = cacheMode;
+            }
+
             if (ExecutionContext.Global.Variables.GetBoolean(Constants.Runner.Features.SetOrchestrationIdEnvForActions) ?? false)
             {
                 if (ExecutionContext.Global.Variables.TryGetValue(Constants.Variables.System.OrchestrationId, out var orchestrationId) && !string.IsNullOrEmpty(orchestrationId))

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -171,6 +171,12 @@ namespace GitHub.Runner.Worker
                         context.Output($"Secret source: {secretSource}");
                     }
 
+                    var cacheMode = jobContext.Global.Variables.Get("actions_cache_mode");
+                    if (!string.IsNullOrEmpty(cacheMode))
+                    {
+                        context.Output($"Actions cache-mode: {cacheMode}");
+                    }
+
                     var repoFullName = context.GetGitHubContext("repository");
                     ArgUtil.NotNull(repoFullName, nameof(repoFullName));
                     context.Debug($"Primary repository: {repoFullName}");

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -174,7 +174,7 @@ namespace GitHub.Runner.Worker
                     var cacheMode = jobContext.Global.Variables.Get("actions_cache_mode");
                     if (!string.IsNullOrEmpty(cacheMode))
                     {
-                        context.Output($"Actions cache-mode: {cacheMode}");
+                        context.Output($"Cache mode: {cacheMode}");
                     }
 
                     var repoFullName = context.GetGitHubContext("repository");

--- a/src/Test/L0/Worker/HandlerL0.cs
+++ b/src/Test/L0/Worker/HandlerL0.cs
@@ -2,14 +2,18 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using GitHub.Actions.RunService.WebApi;
 using GitHub.DistributedTask.Pipelines;
 using GitHub.DistributedTask.Pipelines.ContextData;
 using GitHub.DistributedTask.WebApi;
+using GitHub.Runner.Common;
 using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker;
+using GitHub.Runner.Worker.Container;
+using GitHub.Runner.Worker.Container.ContainerHooks;
 using GitHub.Runner.Worker.Handlers;
 using Moq;
 using Xunit;
@@ -174,6 +178,109 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.False(environment.ContainsKey("ACTIONS_CACHE_MODE"));
                 Assert.False(environment.ContainsKey("ACTIONS_CACHE_SERVICE_V2"));
             }
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData("read")]
+        [InlineData("none")]
+        public async Task ContainerRunAsync_ExportsCacheModeEnv_WhenVariableSet(string mode)
+        {
+            // Container actions only run on Linux; RunAsync throws on other platforms.
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return;
+            }
+
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var container = await RunContainerActionHandlerAsync(hc, new Dictionary<string, VariableValue>
+                {
+                    { "actions_cache_mode", mode }
+                });
+
+                Assert.True(container.ContainerEnvironmentVariables.TryGetValue("ACTIONS_CACHE_MODE", out var value));
+                Assert.Equal(mode, value);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task ContainerRunAsync_DoesNotExportCacheModeEnv_WhenVariableAbsent()
+        {
+            // Container actions only run on Linux; RunAsync throws on other platforms.
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return;
+            }
+
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var container = await RunContainerActionHandlerAsync(hc, new Dictionary<string, VariableValue>());
+
+                Assert.False(container.ContainerEnvironmentVariables.ContainsKey("ACTIONS_CACHE_MODE"));
+            }
+        }
+
+        private async Task<ContainerInfo> RunContainerActionHandlerAsync(TestHostContext hc, IDictionary<string, VariableValue> variables)
+        {
+            // Route through the container-hooks path so the handler skips docker build/run.
+            variables[Constants.Runner.Features.AllowRunnerContainerHooks] = "true";
+            Environment.SetEnvironmentVariable(Constants.Hooks.ContainerHooksPath, Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "hooks.js"));
+
+            var tempDirectory = hc.GetDirectory(WellKnownDirectory.Temp);
+            Directory.CreateDirectory(Path.Combine(tempDirectory, "_runner_file_commands"));
+            Directory.CreateDirectory(Path.Combine(tempDirectory, "_github_workflow"));
+            var workspace = Path.Combine(hc.GetDirectory(WellKnownDirectory.Work), "workspace");
+            Directory.CreateDirectory(workspace);
+
+            var serverVariables = new Variables(hc, variables);
+            var endpoints = new List<ServiceEndpoint>
+            {
+                new ServiceEndpoint()
+                {
+                    Name = WellKnownServiceEndpointNames.SystemVssConnection,
+                    Url = new Uri("https://pipelines.actions.githubusercontent.com"),
+                    Authorization = new EndpointAuthorization()
+                    {
+                        Scheme = "Test",
+                        Parameters = { { "AccessToken", "token" } }
+                    }
+                }
+            };
+
+            _ec.Setup(x => x.Global).Returns(new GlobalContext()
+            {
+                Variables = serverVariables,
+                Endpoints = endpoints,
+                PrependPath = new List<string>(),
+                EnvironmentVariables = new Dictionary<string, string>()
+            });
+            _ec.Setup(x => x.ExpressionValues).Returns(new DictionaryContextData());
+            _ec.Setup(x => x.JobContext).Returns(new JobContext());
+            _ec.Setup(x => x.GetGitHubContext("workspace")).Returns(workspace);
+
+            ContainerInfo captured = null;
+            var hookManager = new Mock<IContainerHookManager>();
+            hookManager.Setup(x => x.RunContainerStepAsync(It.IsAny<IExecutionContext>(), It.IsAny<ContainerInfo>(), It.IsAny<string>()))
+                       .Callback((IExecutionContext ec, ContainerInfo container, string dockerFile) => { captured = container; })
+                       .Returns(Task.CompletedTask);
+            hc.SetSingleton(hookManager.Object);
+            hc.SetSingleton(new Mock<IActionManifestManagerWrapper>().Object);
+
+            var handler = new ContainerActionHandler();
+            handler.Initialize(hc);
+            handler.ExecutionContext = _ec.Object;
+            handler.Environment = new Dictionary<string, string>();
+            handler.Inputs = new Dictionary<string, string>();
+            handler.Action = new ContainerRegistryReference() { Image = "alpine:latest" };
+            handler.Data = new ContainerActionExecutionData() { Image = "docker://alpine:latest" };
+
+            await handler.RunAsync(ActionRunStage.Main);
+
+            return captured;
         }
 
         private async Task<Dictionary<string, string>> RunNodeScriptActionHandlerAsync(TestHostContext hc, IDictionary<string, VariableValue> variables)

--- a/src/Test/L0/Worker/HandlerL0.cs
+++ b/src/Test/L0/Worker/HandlerL0.cs
@@ -141,6 +141,41 @@ namespace GitHub.Runner.Common.Tests.Worker
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task RunAsync_CacheModeCoexistsWithCacheServiceV2()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var environment = await RunNodeScriptActionHandlerAsync(hc, new Dictionary<string, VariableValue>
+                {
+                    { "actions_uses_cache_service_v2", "true" },
+                    { "actions_cache_mode", "read" }
+                });
+
+                Assert.Equal(bool.TrueString, environment["ACTIONS_CACHE_SERVICE_V2"]);
+                Assert.Equal("read", environment["ACTIONS_CACHE_MODE"]);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task RunAsync_DoesNotAffectRuntimeEnv_WhenCacheModeAbsent()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var environment = await RunNodeScriptActionHandlerAsync(hc, new Dictionary<string, VariableValue>());
+
+                // Baseline runtime env is still exported and cache-mode adds nothing.
+                Assert.Equal("https://pipelines.actions.githubusercontent.com/", environment["ACTIONS_RUNTIME_URL"]);
+                Assert.Equal("token", environment["ACTIONS_RUNTIME_TOKEN"]);
+                Assert.False(environment.ContainsKey("ACTIONS_CACHE_MODE"));
+                Assert.False(environment.ContainsKey("ACTIONS_CACHE_SERVICE_V2"));
+            }
+        }
+
         private async Task<Dictionary<string, string>> RunNodeScriptActionHandlerAsync(TestHostContext hc, IDictionary<string, VariableValue> variables)
         {
             var actionDirectory = Path.Combine(hc.GetDirectory(WellKnownDirectory.Work), Guid.NewGuid().ToString());

--- a/src/Test/L0/Worker/HandlerL0.cs
+++ b/src/Test/L0/Worker/HandlerL0.cs
@@ -1,7 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 using GitHub.Actions.RunService.WebApi;
 using GitHub.DistributedTask.Pipelines;
+using GitHub.DistributedTask.Pipelines.ContextData;
 using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker;
@@ -84,6 +89,123 @@ namespace GitHub.Runner.Common.Tests.Worker
                 Assert.Equal("docker", _stepTelemetry.Type);
                 Assert.Equal("ubuntu:20.04", _stepTelemetry.Action);
             }
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData("read")]
+        [InlineData("none")]
+        [InlineData("write")]
+        [InlineData("write-only")]
+        public async Task RunAsync_ExportsCacheModeEnv_WhenVariableSet(string mode)
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var environment = await RunNodeScriptActionHandlerAsync(hc, new Dictionary<string, VariableValue>
+                {
+                    { "actions_cache_mode", mode }
+                });
+
+                Assert.True(environment.TryGetValue("ACTIONS_CACHE_MODE", out var value));
+                Assert.Equal(mode, value);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task RunAsync_DoesNotExportCacheModeEnv_WhenVariableAbsent()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var environment = await RunNodeScriptActionHandlerAsync(hc, new Dictionary<string, VariableValue>());
+
+                Assert.False(environment.ContainsKey("ACTIONS_CACHE_MODE"));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task RunAsync_DoesNotExportCacheModeEnv_WhenVariableEmpty()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var environment = await RunNodeScriptActionHandlerAsync(hc, new Dictionary<string, VariableValue>
+                {
+                    { "actions_cache_mode", "" }
+                });
+
+                Assert.False(environment.ContainsKey("ACTIONS_CACHE_MODE"));
+            }
+        }
+
+        private async Task<Dictionary<string, string>> RunNodeScriptActionHandlerAsync(TestHostContext hc, IDictionary<string, VariableValue> variables)
+        {
+            var actionDirectory = Path.Combine(hc.GetDirectory(WellKnownDirectory.Work), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(actionDirectory);
+            var scriptFile = "main.js";
+            File.WriteAllText(Path.Combine(actionDirectory, scriptFile), "// noop");
+
+            var serverVariables = new Variables(hc, variables);
+            var endpoints = new List<ServiceEndpoint>
+            {
+                new ServiceEndpoint()
+                {
+                    Name = WellKnownServiceEndpointNames.SystemVssConnection,
+                    Url = new Uri("https://pipelines.actions.githubusercontent.com"),
+                    Authorization = new EndpointAuthorization()
+                    {
+                        Scheme = "Test",
+                        Parameters = { { "AccessToken", "token" } }
+                    }
+                }
+            };
+
+            _ec.Setup(x => x.Global).Returns(new GlobalContext()
+            {
+                Variables = serverVariables,
+                Endpoints = endpoints,
+                PrependPath = new List<string>(),
+                EnvironmentVariables = new Dictionary<string, string>()
+            });
+            _ec.Setup(x => x.ExpressionValues).Returns(new DictionaryContextData());
+            _ec.Setup(x => x.GetGitHubContext("workspace")).Returns(actionDirectory);
+            _ec.Setup(x => x.GetMatchers()).Returns(new List<IssueMatcherConfig>());
+            _ec.Setup(x => x.ForceCompleted).Returns(new TaskCompletionSource<int>().Task);
+            _ec.Setup(x => x.CancellationToken).Returns(CancellationToken.None);
+
+            var stepHost = new Mock<IStepHost>();
+            stepHost.Setup(x => x.DetermineNodeRuntimeVersion(It.IsAny<IExecutionContext>(), It.IsAny<string>())).ReturnsAsync("node20");
+            stepHost.Setup(x => x.ResolvePathForStepHost(It.IsAny<IExecutionContext>(), It.IsAny<string>())).Returns((IExecutionContext ec, string path) => path);
+            stepHost.Setup(x => x.ExecuteAsync(
+                It.IsAny<IExecutionContext>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<IDictionary<string, string>>(),
+                It.IsAny<bool>(),
+                It.IsAny<System.Text.Encoding>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(0);
+
+            var handler = new NodeScriptActionHandler();
+            handler.Initialize(hc);
+            handler.ExecutionContext = _ec.Object;
+            handler.StepHost = stepHost.Object;
+            handler.Environment = new Dictionary<string, string>();
+            handler.Inputs = new Dictionary<string, string>();
+            handler.RuntimeVariables = serverVariables;
+            handler.ActionDirectory = actionDirectory;
+            handler.Action = new RepositoryPathReference() { Name = "actions/checkout", Ref = "v2" };
+            handler.Data = new NodeJSActionExecutionData() { Script = scriptFile, NodeVersion = "node20" };
+
+            await handler.RunAsync(ActionRunStage.Main);
+
+            return handler.Environment;
         }
     }
 }

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -238,6 +238,55 @@ namespace GitHub.Runner.Common.Tests.Worker
             }
         }
 
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData("read")]
+        [InlineData("none")]
+        [InlineData("write")]
+        [InlineData("write-only")]
+        public async Task InitializeJob_LogsCacheMode_WhenVariableSet(string mode)
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                _message.Variables["actions_cache_mode"] = mode;
+                _jobEc.InitializeJob(_message, _tokenSource.Token);
+
+                var jobExtension = new JobExtension();
+                jobExtension.Initialize(hc);
+
+                _actionManager.Setup(x => x.PrepareActionsAsync(It.IsAny<IExecutionContext>(), It.IsAny<IEnumerable<Pipelines.JobStep>>(), It.IsAny<Guid>()))
+                              .Returns(Task.FromResult(new PrepareResult(new List<JobExtensionRunner>(), new Dictionary<Guid, IActionRunner>())));
+
+                await jobExtension.InitializeJob(_jobEc, _message);
+
+                _jobServerQueue.Verify(
+                    x => x.QueueWebConsoleLine(It.IsAny<Guid>(), It.Is<string>(m => m.Contains($"Actions cache-mode: {mode}")), It.IsAny<long?>()),
+                    Times.Once);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task InitializeJob_DoesNotLogCacheMode_WhenVariableAbsent()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var jobExtension = new JobExtension();
+                jobExtension.Initialize(hc);
+
+                _actionManager.Setup(x => x.PrepareActionsAsync(It.IsAny<IExecutionContext>(), It.IsAny<IEnumerable<Pipelines.JobStep>>(), It.IsAny<Guid>()))
+                              .Returns(Task.FromResult(new PrepareResult(new List<JobExtensionRunner>(), new Dictionary<Guid, IActionRunner>())));
+
+                await jobExtension.InitializeJob(_jobEc, _message);
+
+                _jobServerQueue.Verify(
+                    x => x.QueueWebConsoleLine(It.IsAny<Guid>(), It.Is<string>(m => m.Contains("Actions cache-mode:")), It.IsAny<long?>()),
+                    Times.Never);
+            }
+        }
+
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -249,8 +249,7 @@ namespace GitHub.Runner.Common.Tests.Worker
         {
             using (TestHostContext hc = CreateTestContext())
             {
-                _message.Variables["actions_cache_mode"] = mode;
-                _jobEc.InitializeJob(_message, _tokenSource.Token);
+                _jobEc.Global.Variables.Set("actions_cache_mode", mode);
 
                 var jobExtension = new JobExtension();
                 jobExtension.Initialize(hc);

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -260,7 +260,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 await jobExtension.InitializeJob(_jobEc, _message);
 
                 _jobServerQueue.Verify(
-                    x => x.QueueWebConsoleLine(It.IsAny<Guid>(), It.Is<string>(m => m.Contains($"Actions cache-mode: {mode}")), It.IsAny<long?>()),
+                    x => x.QueueWebConsoleLine(It.IsAny<Guid>(), It.Is<string>(m => m.Contains($"Cache mode: {mode}")), It.IsAny<long?>()),
                     Times.Once);
             }
         }
@@ -281,7 +281,7 @@ namespace GitHub.Runner.Common.Tests.Worker
                 await jobExtension.InitializeJob(_jobEc, _message);
 
                 _jobServerQueue.Verify(
-                    x => x.QueueWebConsoleLine(It.IsAny<Guid>(), It.Is<string>(m => m.Contains("Actions cache-mode:")), It.IsAny<long?>()),
+                    x => x.QueueWebConsoleLine(It.IsAny<Guid>(), It.Is<string>(m => m.Contains("Cache mode:")), It.IsAny<long?>()),
                     Times.Never);
             }
         }


### PR DESCRIPTION
## Summary

Exposes the effective Actions cache-mode to job steps and surfaces it in the job log. The mode is delivered by the Actions service as the `actions_cache_mode` job variable (one of `none`, `read`, `write`, `write-only`, hyphenated), mirroring the existing `actions_uses_cache_service_v2` variable.

## Changes

- Export env `ACTIONS_CACHE_MODE` to steps from the `actions_cache_mode` job variable in `NodeScriptActionHandler` and `ContainerActionHandler`, mirroring the existing `ACTIONS_CACHE_SERVICE_V2` wiring.
- Log the effective cache-mode at job start in `JobExtension` (single info line near the other job header output).

## Behavior and safety

- The value is provided by the Actions service as the `actions_cache_mode` job variable, one of `none|read|write|write-only` (hyphenated, matching the workflow YAML token). The runner passes it through as-is.
- The runner only reacts when the variable is present and non-empty. With no cache-mode set, behavior is identical to today (no new env var, no new log line).
- Emission of the variable is gated on the service side, so no separate runner feature flag is required.

## Tests

- L0 handler coverage for `read`, `none`, `write`, and `write-only` (env exported with the value), plus absent and empty cases (env not set).

https://github.com/github/actions-persistence/issues/1125