### PR TITLE
Setup Job: announce when running with locked dependencies

### DIFF
--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -191,6 +191,13 @@ namespace GitHub.Runner.Worker
                         context.Output($"Runner is running behind proxy server '{HostContext.WebProxy.HttpsProxyAddress}' for all HTTPS requests.");
                     }
 
+                    // Signal to the user that the job is running with locked/pinned
+                    // action dependencies (a lockfile is in effect).
+                    if (message.ActionsDependencies != null && message.ActionsDependencies.Count > 0)
+                    {
+                        context.Output("Running with locked dependencies");
+                    }
+
                     // Prepare the workflow directory
                     context.Output("Prepare workflow directory");
                     var directoryManager = HostContext.GetService<IPipelineDirectoryManager>();

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -202,6 +202,54 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        public async Task JobExtensionOutputsLockedDependenciesWhenPresent()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var consoleLines = new List<string>();
+                _jobServerQueue.Setup(x => x.QueueWebConsoleLine(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<long?>()))
+                               .Callback((Guid _, string line, long? __) => consoleLines.Add(line));
+
+                _message.ActionsDependencies.Add("actions/checkout@v4:sha256-abc123");
+
+                var jobExtension = new JobExtension();
+                jobExtension.Initialize(hc);
+
+                _actionManager.Setup(x => x.PrepareActionsAsync(It.IsAny<IExecutionContext>(), It.IsAny<IEnumerable<Pipelines.JobStep>>(), It.IsAny<Guid>()))
+                              .Returns(Task.FromResult(new PrepareResult(new List<JobExtensionRunner>(), new Dictionary<Guid, IActionRunner>())));
+
+                await jobExtension.InitializeJob(_jobEc, _message);
+
+                Assert.Contains(consoleLines, line => line.Contains("Running with locked dependencies"));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task JobExtensionDoesNotOutputLockedDependenciesWhenAbsent()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var consoleLines = new List<string>();
+                _jobServerQueue.Setup(x => x.QueueWebConsoleLine(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<long?>()))
+                               .Callback((Guid _, string line, long? __) => consoleLines.Add(line));
+
+                var jobExtension = new JobExtension();
+                jobExtension.Initialize(hc);
+
+                _actionManager.Setup(x => x.PrepareActionsAsync(It.IsAny<IExecutionContext>(), It.IsAny<IEnumerable<Pipelines.JobStep>>(), It.IsAny<Guid>()))
+                              .Returns(Task.FromResult(new PrepareResult(new List<JobExtensionRunner>(), new Dictionary<Guid, IActionRunner>())));
+
+                await jobExtension.InitializeJob(_jobEc, _message);
+
+                Assert.DoesNotContain(consoleLines, line => line.Contains("Running with locked dependencies"));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
         public async Task JobExtensionBuildPreStepsList()
         {
             using (TestHostContext hc = CreateTestContext())
@@ -292,15 +340,22 @@ namespace GitHub.Runner.Common.Tests.Worker
         public async Task JobExtensionBuildFailsWithoutContainerIfRequired()
         {
             Environment.SetEnvironmentVariable(Constants.Variables.Actions.RequireJobContainer, "true");
-            using (TestHostContext hc = CreateTestContext())
+            try
             {
-                var jobExtension = new JobExtension();
-                jobExtension.Initialize(hc);
+                using (TestHostContext hc = CreateTestContext())
+                {
+                    var jobExtension = new JobExtension();
+                    jobExtension.Initialize(hc);
 
-                _actionManager.Setup(x => x.PrepareActionsAsync(It.IsAny<IExecutionContext>(), It.IsAny<IEnumerable<Pipelines.JobStep>>(), It.IsAny<Guid>()))
-                              .Returns(Task.FromResult(new PrepareResult(new List<JobExtensionRunner>() { new JobExtensionRunner(null, "", "prepare1", null), new JobExtensionRunner(null, "", "prepare2", null) }, new Dictionary<Guid, IActionRunner>())));
+                    _actionManager.Setup(x => x.PrepareActionsAsync(It.IsAny<IExecutionContext>(), It.IsAny<IEnumerable<Pipelines.JobStep>>(), It.IsAny<Guid>()))
+                                  .Returns(Task.FromResult(new PrepareResult(new List<JobExtensionRunner>() { new JobExtensionRunner(null, "", "prepare1", null), new JobExtensionRunner(null, "", "prepare2", null) }, new Dictionary<Guid, IActionRunner>())));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => jobExtension.InitializeJob(_jobEc, _message));
+                    await Assert.ThrowsAsync<ArgumentException>(() => jobExtension.InitializeJob(_jobEc, _message));
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.Variables.Actions.RequireJobContainer, null);
             }
         }
 


### PR DESCRIPTION
## Why

When a job runs with lockfile-pinned action dependencies, the runner already receives the resolved pins (via `#4372 propagate actions dependencies`) but gives the user no signal that pinning is in effect. This closes that feedback gap in the most visible place: the **Set up job** log.

## What

In `JobExtension.InitializeJob`, the "Set up job" block now prints a single line whenever the job message carries a non-empty `ActionsDependencies` list:

```
Running with locked dependencies
```

No lockfile means an empty list means no line, so the behavior is gated purely on the presence of dependency data. No feature flag is needed. This is intentionally a single announcement line, not an enumerated list, per the product decision for this iteration.

## Note on the tracking issue title

The tracking issue's title says "show pinned dependencies" (i.e. enumerate them). The shipped behavior here is the minimal boolean-style line, not an enumeration, per the product owner's direction. The issue may be retitled separately. Flagging so reviewers aren't confused by the title vs. behavior mismatch.

## Bundled unrelated fix (please note)

This PR also fixes a pre-existing env-var leak in the test `JobExtensionBuildFailsWithoutContainerIfRequired`: it set `RequireJobContainer=true` via `Environment.SetEnvironmentVariable` and never reset it. Because L0 tests share a process, that leak caused the two new lockfile tests to fail depending on ordering (they hit `ValidateJobContainer` and threw). I wrapped that test's body in try/finally to reset the variable.

It is unrelated to the feature but was necessary to make the new tests reliable, which is why an otherwise-untouched test changed. It is a small, self-contained change; happy to split it into its own PR if reviewers prefer.

## Testing

- `JobExtensionL0` suite: 27/27 passing via the repo's local SDK (`./dev.sh`).
- Note: `./dev.sh format` crashes in my local environment (a Mono build-host crash inside `dotnet format`, reproducible on a clean tree too), so I matched the surrounding code style manually. Please rely on the CI format check for formatting validation rather than assuming local format was run.

## Changes

- `src/Runner.Worker/JobExtension.cs` - emit `Running with locked dependencies` when `message.ActionsDependencies` is non-empty.
- `src/Test/L0/Worker/JobExtensionL0.cs` - two L0 tests (line present when deps present, absent when empty) plus the env-var leak fix described above.

Towards: github/actions-dispatch#567