### PR TITLE
Setup Job: reword locked-dependencies log line to use lockfile language

### DIFF
--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -195,7 +195,7 @@ namespace GitHub.Runner.Worker
                     // versions from the workflow's lockfile.
                     if (message.ActionsDependencies != null && message.ActionsDependencies.Count > 0)
                     {
-                        context.Output("Using locked actions versions from the workflow's lockfile");
+                        context.Output("Using locked action versions from the workflow's lockfile");
                     }
 
                     // Prepare the workflow directory

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -191,11 +191,11 @@ namespace GitHub.Runner.Worker
                         context.Output($"Runner is running behind proxy server '{HostContext.WebProxy.HttpsProxyAddress}' for all HTTPS requests.");
                     }
 
-                    // Signal to the user that the job is running with locked/pinned
-                    // action dependencies (a lockfile is in effect).
+                    // Signal to the user that the job is using locked action
+                    // versions from the workflow's lockfile.
                     if (message.ActionsDependencies != null && message.ActionsDependencies.Count > 0)
                     {
-                        context.Output("Running with locked dependencies");
+                        context.Output("Using locked actions versions from the workflow's lockfile");
                     }
 
                     // Prepare the workflow directory

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -220,7 +220,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 await jobExtension.InitializeJob(_jobEc, _message);
 
-                Assert.Contains(consoleLines, line => line.Contains("Using locked actions versions from the workflow's lockfile"));
+                Assert.Contains(consoleLines, line => line.Contains("Using locked action versions from the workflow's lockfile"));
             }
         }
 
@@ -243,7 +243,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 await jobExtension.InitializeJob(_jobEc, _message);
 
-                Assert.DoesNotContain(consoleLines, line => line.Contains("Using locked actions versions from the workflow's lockfile"));
+                Assert.DoesNotContain(consoleLines, line => line.Contains("Using locked action versions from the workflow's lockfile"));
             }
         }
 

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -220,7 +220,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 await jobExtension.InitializeJob(_jobEc, _message);
 
-                Assert.Contains(consoleLines, line => line.Contains("Running with locked dependencies"));
+                Assert.Contains(consoleLines, line => line.Contains("Using locked actions versions from the workflow's lockfile"));
             }
         }
 
@@ -243,7 +243,7 @@ namespace GitHub.Runner.Common.Tests.Worker
 
                 await jobExtension.InitializeJob(_jobEc, _message);
 
-                Assert.DoesNotContain(consoleLines, line => line.Contains("Running with locked dependencies"));
+                Assert.DoesNotContain(consoleLines, line => line.Contains("Using locked actions versions from the workflow's lockfile"));
             }
         }
 


### PR DESCRIPTION
Copy-only follow-up to #4546.

That PR shipped a **Set up job** log line announcing when a job runs with locked action dependencies. Based on follow-up feedback we're adjusting the wording only:

- A reviewer asked us to avoid an uppercase "Action" in user-facing copy.
- The product owner prefers **lockfile** wording over "pinning"/"pinned" language.

### Change
The line in `src/Runner.Worker/JobExtension.cs` now reads:

> Using locked actions versions from the workflow's lockfile

(previously "Running with locked dependencies")

This updates:
- the log string,
- the two matching assertions in `src/Test/L0/Worker/JobExtensionL0.cs` (positive + negative), and
- the preceding code comment (drops "pinned" in favor of lockfile language).

No behavior change — copy only.

Refs: github/actions-dispatch#567