### PR TITLE
Recreate session on RunnerSessionInvalid from broker

### DIFF
--- a/src/Runner.Common/BrokerServer.cs
+++ b/src/Runner.Common/BrokerServer.cs
@@ -108,7 +108,7 @@ namespace GitHub.Runner.Common
 
         public bool ShouldRetryException(Exception ex)
         {
-            if (ex is AccessDeniedException || ex is VssUnauthorizedException || ex is RunnerNotFoundException || ex is HostedRunnerDeprovisionedException)
+            if (ex is AccessDeniedException || ex is VssUnauthorizedException || ex is RunnerNotFoundException || ex is HostedRunnerDeprovisionedException || ex is TaskAgentSessionExpiredException)
             {
                 return false;
             }

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -341,7 +341,7 @@ namespace GitHub.Runner.Listener
                     Trace.Error("Catch exception during get next message.");
                     Trace.Error(ex);
 
-                    // don't retry if SkipSessionRecover = true, DT service will delete agent session to stop agent from taking more jobs.
+// Don't retry if SkipSessionRecover is true; the service will delete the runner session to stop the runner from taking more jobs.
                     if (!HostContext.AllowAuthMigration &&
                         ex is TaskAgentSessionExpiredException &&
                         !_settings.SkipSessionRecover && (await CreateSessionAsync(token) == CreateSessionResult.Success))

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -338,7 +338,14 @@ namespace GitHub.Runner.Listener
                     Trace.Error("Catch exception during get next message.");
                     Trace.Error(ex);
 
+                    // don't retry if SkipSessionRecover = true, DT service will delete agent session to stop agent from taking more jobs.
                     if (!HostContext.AllowAuthMigration &&
+                        ex is TaskAgentSessionExpiredException &&
+                        !_settings.SkipSessionRecover && (await CreateSessionAsync(token) == CreateSessionResult.Success))
+                    {
+                        Trace.Info($"{nameof(TaskAgentSessionExpiredException)} received, recovered by recreate session.");
+                    }
+                    else if (!HostContext.AllowAuthMigration &&
                         !IsGetNextMessageExceptionRetriable(ex))
                     {
                         throw new NonRetryableException("Get next message failed with non-retryable error.", ex);

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -341,7 +341,7 @@ namespace GitHub.Runner.Listener
                     Trace.Error("Catch exception during get next message.");
                     Trace.Error(ex);
 
-// Don't retry if SkipSessionRecover is true; the service will delete the runner session to stop the runner from taking more jobs.
+                    // don't retry if SkipSessionRecover = true, the service will delete the runner session to stop the runner from taking more jobs.
                     if (!HostContext.AllowAuthMigration &&
                         ex is TaskAgentSessionExpiredException &&
                         !_settings.SkipSessionRecover && (await CreateSessionAsync(token) == CreateSessionResult.Success))

--- a/src/Sdk/RSWebApi/Contracts/BrokerErrorKind.cs
+++ b/src/Sdk/RSWebApi/Contracts/BrokerErrorKind.cs
@@ -8,5 +8,6 @@ namespace GitHub.Actions.RunService.WebApi
         public const string RunnerNotFound = "RunnerNotFound";
         public const string RunnerVersionTooOld = "RunnerVersionTooOld";
         public const string HostedRunnerDeprovisioned = "HostedRunnerDeprovisioned";
+        public const string RunnerSessionInvalid = "RunnerSessionInvalid";
     }
 }

--- a/src/Sdk/WebApi/WebApi/BrokerHttpClient.cs
+++ b/src/Sdk/WebApi/WebApi/BrokerHttpClient.cs
@@ -125,6 +125,8 @@ namespace GitHub.Actions.RunService.WebApi
                         };
                     case BrokerErrorKind.HostedRunnerDeprovisioned:
                         throw new HostedRunnerDeprovisionedException(brokerError.Message);
+                    case BrokerErrorKind.RunnerSessionInvalid:
+                        throw new TaskAgentSessionExpiredException(brokerError.Message);
                     default:
                         break;
                 }

--- a/src/Test/L0/Listener/BrokerMessageListenerL0.cs
+++ b/src/Test/L0/Listener/BrokerMessageListenerL0.cs
@@ -366,6 +366,80 @@ namespace GitHub.Runner.Common.Tests.Listener
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Runner")]
+        public async Task GetNextMessage_RecreatesSessionOnSessionExpired()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(new VssCredentials());
+
+                var expectedSession = new TaskAgentSession();
+                _brokerServer
+                    .Setup(x => x.CreateSessionAsync(
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Returns(Task.FromResult(expectedSession));
+
+                var expectedMessage = new TaskAgentMessage();
+                var throwSessionExpired = true;
+                _brokerServer
+                    .Setup(x => x.GetRunnerMessageAsync(
+                        It.IsAny<Guid?>(),
+                        It.IsAny<TaskAgentStatus>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<CancellationToken>()))
+                    .Returns(async (Guid? sessionId, TaskAgentStatus status, string version, string os, string architecture, bool disableUpdate, CancellationToken token) =>
+                    {
+                        await Task.Yield();
+                        if (throwSessionExpired)
+                        {
+                            throwSessionExpired = false;
+                            throw new TaskAgentSessionExpiredException("Runner session is invalid");
+                        }
+
+                        return expectedMessage;
+                    });
+
+                // Act.
+                BrokerMessageListener listener = new();
+                listener.Initialize(tc);
+
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+                Assert.Equal(CreateSessionResult.Success, result);
+
+                TaskAgentMessage message = await listener.GetNextMessageAsync(tokenSource.Token);
+                trace.Info("message: {0}", message);
+
+                // Assert.
+                Assert.Equal(expectedMessage, message);
+                _brokerServer
+                   .Verify(x => x.GetRunnerMessageAsync(
+                       It.IsAny<Guid?>(),
+                       It.IsAny<TaskAgentStatus>(),
+                       It.IsAny<string>(),
+                       It.IsAny<string>(),
+                       It.IsAny<string>(),
+                       It.IsAny<bool>(),
+                       It.IsAny<CancellationToken>()), Times.Exactly(2));
+
+                // Session recreated once on the expired exception (plus the initial create above).
+                _brokerServer
+                   .Verify(x => x.CreateSessionAsync(
+                       It.Is<TaskAgentSession>(y => y != null),
+                       tokenSource.Token), Times.Exactly(2));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
         public async Task CreatesSessionWithProvidedSettings()
         {
             using (TestHostContext tc = CreateTestContext())
@@ -400,7 +474,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                    .Verify(x => x.CreateSessionAsync(
                        It.Is<TaskAgentSession>(y => y != null),
                        tokenSource.Token), Times.Once());
-                
+
                 // Verify LoadSettings was never called
                 _config.Verify(x => x.LoadSettings(), Times.Never());
             }


### PR DESCRIPTION
## What

The service is changing so that when a runner polls (`GET /message`) or acknowledges with an invalid session, it returns **HTTP 400** with a structured broker error body:

```json
{"source":"actions-broker-listener","errorKind":"RunnerSessionInvalid","statusCode":400,"errorMessage":"Runner session is invalid"}
```

instead of a bare `403`. Today a bare `403` makes the runner throw a fatal, misleading `AccessDeniedException{ErrorCode=1}` ("runner deprecated") and stop.

This PR makes the broker path behave like legacy Azure Pipelines did: on an expired/invalid session the runner recreates its session and keeps polling.

This brings it into parity with the MessageListener.cs

## Changes

1. `BrokerErrorKind.cs` — add the `RunnerSessionInvalid` constant.
2. `BrokerHttpClient.GetRunnerMessageAsync` — map `RunnerSessionInvalid` to `TaskAgentSessionExpiredException`.
3. `BrokerMessageListener.GetNextMessageAsync` — mirror legacy `MessageListener`: on `TaskAgentSessionExpiredException` (and when `!SkipSessionRecover`), recreate the session and continue polling instead of throwing a non-retryable error.

Added an L0 test asserting that when `GetRunnerMessageAsync` throws `TaskAgentSessionExpiredException`, the listener recreates the session and continues polling.

## Rollout

Companion service PR: github/actions-broker-listener#2490. **The runner change must roll out BEFORE the service enables its `RejectInvalidSessions` flag.**

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>