### PR TITLE
Stream action archive downloads to disk instead of buffering in memory

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1666,7 +1666,11 @@ namespace GitHub.Runner.Worker
                                 httpClient.DefaultRequestHeaders.Authorization = CreateAuthHeader(executionContext, downloadUrl, downloadAuthToken);
 
                                 httpClient.DefaultRequestHeaders.UserAgent.AddRange(HostContext.UserAgents);
-                                using (var response = await httpClient.GetAsync(downloadUrl))
+                                // ResponseHeadersRead keeps the archive from being buffered entirely
+                                // in memory before it is copied to disk; the default (ResponseContentRead)
+                                // holds the whole tarball in the managed heap, which can OOM
+                                // memory-constrained runners on large action repositories.
+                                using (var response = await httpClient.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead, actionDownloadCancellation.Token))
                                 {
                                     requestId = UrlUtil.GetGitHubRequestId(response.Headers);
                                     if (!string.IsNullOrEmpty(requestId))

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1667,7 +1667,11 @@ namespace GitHub.Runner.Worker
                                 httpClient.DefaultRequestHeaders.Authorization = CreateAuthHeader(executionContext, downloadUrl, downloadAuthToken);
 
                                 httpClient.DefaultRequestHeaders.UserAgent.AddRange(HostContext.UserAgents);
-                                using (var response = await httpClient.GetAsync(downloadUrl))
+                                // ResponseHeadersRead keeps the archive from being buffered entirely
+                                // in memory before it is copied to disk; the default (ResponseContentRead)
+                                // holds the whole tarball in the managed heap, which can OOM
+                                // memory-constrained runners on large action repositories.
+                                using (var response = await httpClient.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead, actionDownloadCancellation.Token))
                                 {
                                     requestId = UrlUtil.GetGitHubRequestId(response.Headers);
                                     if (!string.IsNullOrEmpty(requestId))


### PR DESCRIPTION
Fixes #4587

`DownloadRepositoryArchive` calls `HttpClient.GetAsync(downloadUrl)` with the default `HttpCompletionOption.ResponseContentRead`, which buffers the entire archive in the managed heap before `ReadAsStreamAsync()` returns — so the `CopyToAsync` into the `FileStream` copies from memory, not from the network. Peak worker memory grows by the full archive size per download (~73 MB in our case for an action hosted in a monorepo, since the codeload tarball is a snapshot of the whole source tree), and the retry loop re-buffers the entire body on each attempt. On memory-constrained self-hosted runners this throws `System.OutOfMemoryException` during the "Download action repository" phase (full details and job logs in #4587).

This change passes `HttpCompletionOption.ResponseHeadersRead` so the body is streamed to disk with a fixed-size buffer, making peak memory independent of archive size. It also passes the existing download cancellation token to `GetAsync`, so the download timeout covers the connect/headers phase as well.

We've been running this change built from source on our Kubernetes-hosted runners and it resolves the OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)