### PR TITLE
Report an infrastructure failure when the debugger Dev Tunnel fails

### DIFF
--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -184,6 +184,13 @@ namespace GitHub.Runner.Common
                 public static readonly string SelfRepository = "actions_self_repository";
             }
 
+            // Categories reported to the service alongside an infrastructure failure so
+            // it can distinguish between the different ways runner infrastructure fails.
+            public static class InfrastructureFailureCategories
+            {
+                public static readonly string DebuggerTunnelFailure = "debugger_tunnel_failure";
+            }
+
             // Node version migration related constants
             public static class NodeMigration
             {

--- a/src/Runner.Worker/Dap/DapDebugger.cs
+++ b/src/Runner.Worker/Dap/DapDebugger.cs
@@ -94,6 +94,10 @@ namespace GitHub.Runner.Worker.Dap
         // listener directly on the configured tunnel port (unit tests only).
         internal bool SkipWebSocketBridge { get; set; }
 
+        // Invoked once the tunnel relay is up, so tests can simulate a relay drop
+        // that lands while startup is still in progress (unit tests only).
+        internal Action TunnelRelayStarted { get; set; }
+
         // Synchronization for step execution
         private TaskCompletionSource<DapCommand> _commandTcs;
         private readonly object _stateLock = new object();
@@ -181,7 +185,27 @@ namespace GitHub.Runner.Worker.Dap
                 await StartTunnelRelayAsync(debuggerConfig);
             }
 
-            _state = DapSessionState.WaitingForConnection;
+            TunnelRelayStarted?.Invoke();
+
+            // The relay can drop while we're still starting up, which terminates the
+            // session and reports the failure. Don't resurrect it or start listening
+            // for a client that has no way to reach us.
+            bool terminatedDuringStartup;
+            lock (_stateLock)
+            {
+                terminatedDuringStartup = _state == DapSessionState.Terminated;
+                if (!terminatedDuringStartup)
+                {
+                    _state = DapSessionState.WaitingForConnection;
+                }
+            }
+
+            if (terminatedDuringStartup)
+            {
+                Trace.Info("Debugger tunnel dropped during startup, skipping connection loop.");
+                return;
+            }
+
             _loopCts = CancellationTokenSource.CreateLinkedTokenSource(jobContext.CancellationToken);
             _connectionLoopTask = ConnectionLoopAsync(_loopCts.Token);
 

--- a/src/Runner.Worker/Dap/DapDebugger.cs
+++ b/src/Runner.Worker/Dap/DapDebugger.cs
@@ -333,7 +333,7 @@ namespace GitHub.Runner.Worker.Dap
                     jobContext.Global.InfrastructureFailureCategory = Constants.Runner.InfrastructureFailureCategories.DebuggerTunnelFailure;
                 }
 
-                jobContext.Error(message);
+                jobContext.InfrastructureError(message, category: Constants.Runner.InfrastructureFailureCategories.DebuggerTunnelFailure);
                 jobContext.Result = TaskResultUtil.MergeTaskResults(jobContext.Result, TaskResult.Failed);
                 if (jobContext.JobContext != null)
                 {

--- a/src/Runner.Worker/Dap/DapDebugger.cs
+++ b/src/Runner.Worker/Dap/DapDebugger.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Common;
+using GitHub.Runner.Common.Util;
 using GitHub.Runner.Sdk;
 using Microsoft.DevTunnels.Connections;
 using Microsoft.DevTunnels.Contracts;
@@ -73,6 +74,14 @@ namespace GitHub.Runner.Worker.Dap
         // Dev Tunnel relay host for remote debugging
         private TunnelRelayTunnelHost _tunnelRelayHost;
         private IWebSocketDapBridge _webSocketBridge;
+
+        // Set before we intentionally tear the Dev Tunnel down so the relay
+        // disconnect that teardown produces isn't mistaken for a failure.
+        private volatile bool _tunnelShuttingDown;
+
+        // 0 until an unexpected tunnel disconnect has been reported, so the job
+        // is only failed once no matter how many status changes we observe.
+        private int _tunnelFailureReported;
 
         // Cancellation source for the connection loop, cancelled in StopAsync
         // so AcceptTcpClientAsync unblocks cleanly without relying on listener disposal.
@@ -145,6 +154,8 @@ namespace GitHub.Runner.Worker.Dap
             Trace.Info($"Starting DAP debugger on port {debuggerConfig.Tunnel.Port}");
 
             _jobContext = jobContext;
+            _tunnelShuttingDown = false;
+            Interlocked.Exchange(ref _tunnelFailureReported, 0);
             _readyTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var dapPort = SkipWebSocketBridge ? debuggerConfig.Tunnel.Port : 0;
@@ -216,9 +227,141 @@ namespace GitHub.Runner.Worker.Dap
             var tunnelConnectTimeoutSeconds = ResolveTunnelConnectTimeout();
             using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(tunnelConnectTimeoutSeconds));
             Trace.Info($"Connecting to Dev Tunnel relay (timeout: {tunnelConnectTimeoutSeconds}s)");
-            await _tunnelRelayHost.ConnectAsync(tunnel, connectCts.Token);
+
+            try
+            {
+                await _tunnelRelayHost.ConnectAsync(tunnel, connectCts.Token);
+            }
+            catch (OperationCanceledException) when (_jobContext?.CancellationToken.IsCancellationRequested == true)
+            {
+                // The job itself is going away — not a tunnel problem.
+                throw;
+            }
+            catch (OperationCanceledException ex) when (connectCts.IsCancellationRequested)
+            {
+                throw new DebuggerTunnelException(
+                    $"Timed out after {tunnelConnectTimeoutSeconds} seconds while connecting to the debugger tunnel.",
+                    ex);
+            }
+            catch (Exception ex)
+            {
+                throw new DebuggerTunnelException(
+                    $"Failed to connect to the debugger tunnel: {ex.Message}",
+                    ex);
+            }
+
+            // Only watch for drops once we're actually connected. A failure during the
+            // initial connect surfaces as the DebuggerTunnelException above, so watching
+            // earlier would just report the same failure twice.
+            _tunnelRelayHost.ConnectionStatusChanged += OnTunnelConnectionStatusChanged;
+
+            // Close the (tiny) window between ConnectAsync returning and the handler
+            // being attached, during which a drop would go unnoticed.
+            HandleTunnelConnectionStatusChanged(_tunnelRelayHost.ConnectionStatus, _tunnelRelayHost.DisconnectException);
 
             Trace.Info("Dev Tunnel relay started");
+        }
+
+        private void OnTunnelConnectionStatusChanged(object sender, ConnectionStatusChangedEventArgs e)
+        {
+            HandleTunnelConnectionStatusChanged(e.Status, e.DisconnectException);
+        }
+
+        /// <summary>
+        /// Reacts to Dev Tunnel relay connection status changes. The Dev Tunnel SDK
+        /// reconnects on its own, so transient drops show up as <c>Connecting</c> and
+        /// only a settled <c>Disconnected</c> means the relay is really gone.
+        /// </summary>
+        internal void HandleTunnelConnectionStatusChanged(ConnectionStatus status, Exception disconnectException)
+        {
+            try
+            {
+                Trace.Info($"Dev Tunnel relay connection status: {status}");
+
+                if (status != ConnectionStatus.Disconnected)
+                {
+                    return;
+                }
+
+                if (_tunnelShuttingDown)
+                {
+                    Trace.Info("Dev Tunnel relay disconnected while shutting down — expected, ignoring.");
+                    return;
+                }
+
+                ReportTunnelDisconnected(disconnectException);
+            }
+            catch (Exception ex)
+            {
+                // This runs on a Dev Tunnel SDK callback thread — never let it throw.
+                Trace.Error($"Error handling Dev Tunnel connection status change: {ex.Message}");
+                Trace.Error(ex);
+            }
+        }
+
+        /// <summary>
+        /// Fails the job when the debugger's tunnel drops unexpectedly. Without the
+        /// tunnel the debug client can never resume the job, so anything waiting on a
+        /// DAP pause would hang until the job timeout — fail fast instead.
+        /// </summary>
+        private void ReportTunnelDisconnected(Exception disconnectException)
+        {
+            if (Interlocked.Exchange(ref _tunnelFailureReported, 1) != 0)
+            {
+                return;
+            }
+
+            IExecutionContext jobContext;
+            lock (_stateLock)
+            {
+                jobContext = _jobContext;
+            }
+
+            var detail = string.IsNullOrEmpty(disconnectException?.Message)
+                ? string.Empty
+                : $" {disconnectException.Message}";
+            var message = $"The debugger lost its connection to the tunnel and the job cannot continue.{detail}";
+            Trace.Error(message);
+
+            if (jobContext != null)
+            {
+                // A disconnect can land at any point in the job, including outside a step
+                // record, so set the category directly rather than relying on an issue
+                // being flushed by a step completing.
+                if (string.IsNullOrEmpty(jobContext.Global.InfrastructureFailureCategory))
+                {
+                    jobContext.Global.InfrastructureFailureCategory = Constants.Runner.InfrastructureFailureCategories.DebuggerTunnelFailure;
+                }
+
+                jobContext.Error(message);
+                jobContext.Result = TaskResultUtil.MergeTaskResults(jobContext.Result, TaskResult.Failed);
+                if (jobContext.JobContext != null)
+                {
+                    jobContext.JobContext.Status = jobContext.Result?.ToActionResult();
+                }
+
+                jobContext.Global.JobTelemetry?.Add(new JobTelemetry
+                {
+                    Type = JobTelemetryType.General,
+                    Message = "DebuggerConnectionResult: TunnelDisconnected"
+                });
+            }
+
+            // Unblock anything waiting on the debug client so the job stops waiting.
+            var readyTcs = _readyTcs;
+            if (readyTcs?.TrySetException(new DebuggerTunnelException(message)) == true)
+            {
+                // Make sure the fault is observed even when nothing is awaiting it.
+                _ = readyTcs.Task.ContinueWith(static t => _ = t.Exception, TaskContinuationOptions.OnlyOnFaulted);
+            }
+
+            lock (_stateLock)
+            {
+                _state = DapSessionState.Terminated;
+                _commandTcs?.TrySetResult(DapCommand.Disconnect);
+            }
+
+            HandleClientDisconnected();
         }
 
         public async Task WaitUntilReadyAsync()
@@ -462,6 +605,10 @@ namespace GitHub.Runner.Worker.Dap
 
         public async Task StopAsync()
         {
+            // Everything from here on is deliberate teardown, so any relay disconnect
+            // it produces is expected and must not be reported as an infra failure.
+            _tunnelShuttingDown = true;
+
             if (_cancellationRegistration.HasValue)
             {
                 _cancellationRegistration.Value.Dispose();
@@ -481,6 +628,7 @@ namespace GitHub.Runner.Worker.Dap
                 if (_tunnelRelayHost != null)
                 {
                     Trace.Info("Stopping Dev Tunnel relay");
+                    _tunnelRelayHost.ConnectionStatusChanged -= OnTunnelConnectionStatusChanged;
                     var disposeTask = _tunnelRelayHost.DisposeAsync().AsTask();
                     if (await Task.WhenAny(disposeTask, Task.Delay(10_000)) != disposeTask)
                     {

--- a/src/Runner.Worker/Dap/DebuggerTunnelException.cs
+++ b/src/Runner.Worker/Dap/DebuggerTunnelException.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace GitHub.Runner.Worker.Dap
+{
+    /// <summary>
+    /// Raised when the debugger's Dev Tunnel relay connection cannot be established
+    /// or is lost while the job is running.
+    /// </summary>
+    /// <remarks>
+    /// This is a dedicated type so callers can tell a broken tunnel (an infrastructure
+    /// failure the user cannot do anything about) apart from a user simply never
+    /// attaching a debug client, which surfaces as a <see cref="TimeoutException"/>.
+    /// </remarks>
+    public sealed class DebuggerTunnelException : Exception
+    {
+        public DebuggerTunnelException(string message)
+            : base(message)
+        {
+        }
+
+        public DebuggerTunnelException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -664,8 +664,23 @@ namespace GitHub.Runner.Worker
                             context.Error("Job was cancelled before debugger client connected.");
                             throw;
                         }
+                        catch (DebuggerTunnelException ex)
+                        {
+                            // The Dev Tunnel relay could not be established, or dropped while we
+                            // were waiting. The user can't do anything about that, so report it
+                            // as an infrastructure failure rather than a job error.
+                            Trace.Error($"DAP debugger tunnel failed: {ex.Message}");
+                            AddDebuggerConnectionTelemetry(jobContext, "TunnelFailed");
+                            context.InfrastructureError(
+                                ex.Message,
+                                category: Constants.Runner.InfrastructureFailureCategories.DebuggerTunnelFailure);
+                            throw;
+                        }
                         catch (Exception ex)
                         {
+                            // Deliberately NOT an infrastructure failure. The common case here is
+                            // the TimeoutException from WaitUntilReadyAsync, which only means the
+                            // user never attached a debug client — the tunnel itself was fine.
                             Trace.Error($"DAP debugger failed: {ex.Message}");
                             AddDebuggerConnectionTelemetry(jobContext, $"Failed: {ex.GetType().Name}");
                             context.Error("The debugger failed to start or no debugger client connected in time.");

--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -678,9 +678,6 @@ namespace GitHub.Runner.Worker
                         }
                         catch (Exception ex)
                         {
-                            // Deliberately NOT an infrastructure failure. The common case here is
-                            // the TimeoutException from WaitUntilReadyAsync, which only means the
-                            // user never attached a debug client — the tunnel itself was fine.
                             Trace.Error($"DAP debugger failed: {ex.Message}");
                             AddDebuggerConnectionTelemetry(jobContext, $"Failed: {ex.GetType().Name}");
                             context.Error("The debugger failed to start or no debugger client connected in time.");

--- a/src/Test/L0/Worker/DapDebuggerL0.cs
+++ b/src/Test/L0/Worker/DapDebuggerL0.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -8,8 +9,10 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
+using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Worker;
 using GitHub.Runner.Worker.Dap;
+using Microsoft.DevTunnels.Connections;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -249,8 +252,13 @@ namespace GitHub.Runner.Common.Tests.Worker
             };
             var debuggerConfig = new DebuggerConfig(true, tunnel, overrideWelcomeMessage, welcomeMessage);
             var jobContext = new Mock<IExecutionContext>();
+            jobContext.SetupProperty(x => x.Result);
             jobContext.Setup(x => x.CancellationToken).Returns(cancellationToken);
-            jobContext.Setup(x => x.Global).Returns(new GlobalContext { Debugger = debuggerConfig });
+            jobContext.Setup(x => x.Global).Returns(new GlobalContext
+            {
+                Debugger = debuggerConfig,
+                JobTelemetry = new List<JobTelemetry>()
+            });
             jobContext
                 .Setup(x => x.GetGitHubContext(It.IsAny<string>()))
                 .Returns((string contextName) => string.Equals(contextName, "job", StringComparison.Ordinal) ? jobName : null);
@@ -788,6 +796,165 @@ namespace GitHub.Runner.Common.Tests.Worker
                 await _debugger.StopAsync();
 
                 // StopAsync after already stopped
+                await _debugger.StopAsync();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task UnexpectedTunnelDisconnectFailsJobAsInfrastructureFailure()
+        {
+            using (CreateTestContext())
+            {
+                var port = GetFreePort();
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                var jobContext = CreateJobContextWithTunnel(cts.Token, port);
+                await _debugger.StartAsync(jobContext.Object);
+
+                _debugger.HandleTunnelConnectionStatusChanged(
+                    ConnectionStatus.Disconnected,
+                    new IOException("relay went away"));
+
+                Assert.Equal("debugger_tunnel_failure", jobContext.Object.Global.InfrastructureFailureCategory);
+                Assert.Equal(TaskResult.Failed, jobContext.Object.Result);
+                Assert.Equal(DapSessionState.Terminated, _debugger.State);
+                Assert.Contains(
+                    jobContext.Object.Global.JobTelemetry,
+                    t => t.Message == "DebuggerConnectionResult: TunnelDisconnected");
+
+                await _debugger.StopAsync();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task UnexpectedTunnelDisconnectIsOnlyReportedOnce()
+        {
+            using (CreateTestContext())
+            {
+                var port = GetFreePort();
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                var jobContext = CreateJobContextWithTunnel(cts.Token, port);
+                await _debugger.StartAsync(jobContext.Object);
+
+                _debugger.HandleTunnelConnectionStatusChanged(ConnectionStatus.Disconnected, null);
+                _debugger.HandleTunnelConnectionStatusChanged(ConnectionStatus.Disconnected, null);
+
+                Assert.Single(jobContext.Object.Global.JobTelemetry);
+                await _debugger.StopAsync();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task ExpectedTunnelDisconnectDuringTeardownIsNotAnInfrastructureFailure()
+        {
+            using (CreateTestContext())
+            {
+                var port = GetFreePort();
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                var jobContext = CreateJobContextWithTunnel(cts.Token, port);
+                await _debugger.StartAsync(jobContext.Object);
+
+                // StopAsync marks the debugger as shutting down; the relay disconnect it
+                // triggers is expected and must not be reported.
+                await _debugger.StopAsync();
+                _debugger.HandleTunnelConnectionStatusChanged(ConnectionStatus.Disconnected, null);
+
+                Assert.True(string.IsNullOrEmpty(jobContext.Object.Global.InfrastructureFailureCategory));
+                Assert.Null(jobContext.Object.Result);
+                Assert.Empty(jobContext.Object.Global.JobTelemetry);
+            }
+        }
+
+        [Theory]
+        [InlineData(ConnectionStatus.Connecting)]
+        [InlineData(ConnectionStatus.Connected)]
+        [InlineData(ConnectionStatus.RefreshingTunnelAccessToken)]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task TransientTunnelStatusChangesDoNotFailJob(ConnectionStatus status)
+        {
+            using (CreateTestContext())
+            {
+                var port = GetFreePort();
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                var jobContext = CreateJobContextWithTunnel(cts.Token, port);
+                await _debugger.StartAsync(jobContext.Object);
+
+                _debugger.HandleTunnelConnectionStatusChanged(status, null);
+
+                Assert.True(string.IsNullOrEmpty(jobContext.Object.Global.InfrastructureFailureCategory));
+                Assert.Null(jobContext.Object.Result);
+                Assert.NotEqual(DapSessionState.Terminated, _debugger.State);
+
+                await _debugger.StopAsync();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task TunnelDisconnectWhileWaitingForClientSurfacesAsTunnelException()
+        {
+            using (CreateTestContext())
+            {
+                var port = GetFreePort();
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                var jobContext = CreateJobContextWithTunnel(cts.Token, port);
+                await _debugger.StartAsync(jobContext.Object);
+
+                var waitTask = _debugger.WaitUntilReadyAsync();
+                await Task.Delay(50);
+
+                _debugger.HandleTunnelConnectionStatusChanged(ConnectionStatus.Disconnected, null);
+
+                await Assert.ThrowsAsync<DebuggerTunnelException>(() => waitTask);
+                Assert.Equal("debugger_tunnel_failure", jobContext.Object.Global.InfrastructureFailureCategory);
+
+                await _debugger.StopAsync();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task TunnelDisconnectDuringStepPauseReleasesWait()
+        {
+            using (CreateTestContext())
+            {
+                var port = GetFreePort();
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                var jobContext = CreateJobContextWithTunnel(cts.Token, port);
+                await _debugger.StartAsync(jobContext.Object);
+
+                // Complete handshake so the session is ready
+                var waitTask = _debugger.WaitUntilReadyAsync();
+                using var client = await ConnectClientAsync(port);
+                await SendRequestAsync(client.GetStream(), new Request
+                {
+                    Seq = 1,
+                    Type = "request",
+                    Command = "configurationDone"
+                });
+                await waitTask;
+
+                // The step pauses waiting for a debugger command it will never get.
+                var step = CreateStep("Test Step");
+                var stepTask = _debugger.OnStepStartingAsync(step.Object);
+                await Task.Delay(50);
+                Assert.False(stepTask.IsCompleted);
+
+                _debugger.HandleTunnelConnectionStatusChanged(ConnectionStatus.Disconnected, null);
+
+                await stepTask;
+                Assert.Equal(TaskResult.Failed, jobContext.Object.Result);
+                Assert.Equal("debugger_tunnel_failure", jobContext.Object.Global.InfrastructureFailureCategory);
+                Assert.Equal(DapSessionState.Terminated, _debugger.State);
+
                 await _debugger.StopAsync();
             }
         }

--- a/src/Test/L0/Worker/DapDebuggerL0.cs
+++ b/src/Test/L0/Worker/DapDebuggerL0.cs
@@ -830,6 +830,35 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        public async Task TunnelDisconnectDuringStartupDoesNotResurrectTheSession()
+        {
+            using (CreateTestContext())
+            {
+                var port = GetFreePort();
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                var jobContext = CreateJobContextWithTunnel(cts.Token, port);
+
+                // Simulate the relay dropping between connecting and the rest of startup.
+                _debugger.TunnelRelayStarted = () => _debugger.HandleTunnelConnectionStatusChanged(
+                    ConnectionStatus.Disconnected,
+                    new IOException("relay went away during startup"));
+
+                await _debugger.StartAsync(jobContext.Object);
+
+                Assert.Equal(DapSessionState.Terminated, _debugger.State);
+                Assert.False(_debugger.IsActive);
+                Assert.Equal("debugger_tunnel_failure", jobContext.Object.Global.InfrastructureFailureCategory);
+                Assert.Equal(TaskResult.Failed, jobContext.Object.Result);
+
+                await Assert.ThrowsAsync<DebuggerTunnelException>(() => _debugger.WaitUntilReadyAsync());
+
+                await _debugger.StopAsync();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
         public async Task UnexpectedTunnelDisconnectIsOnlyReportedOnce()
         {
             using (CreateTestContext())

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -1033,5 +1033,78 @@ namespace GitHub.Runner.Common.Tests.Worker
                 mockDebugger.Verify(x => x.StopAsync(), Times.Once);
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task DebuggerTunnelFailureIsReportedAsInfrastructureFailure()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var jobExtension = new JobExtension();
+                jobExtension.Initialize(hc);
+
+                EnableDebuggerOnMessage(hc);
+
+                var mockDebugger = new Mock<IDapDebugger>();
+                mockDebugger.Setup(x => x.StartAsync(It.IsAny<IExecutionContext>()))
+                            .ThrowsAsync(new DebuggerTunnelException("Failed to connect to the debugger tunnel: relay unreachable."));
+                mockDebugger.Setup(x => x.StopAsync()).Returns(Task.CompletedTask);
+                hc.SetSingleton(mockDebugger.Object);
+
+                _actionManager.Setup(x => x.PrepareActionsAsync(It.IsAny<IExecutionContext>(), It.IsAny<IEnumerable<Pipelines.JobStep>>(), It.IsAny<Guid>()))
+                              .Returns(Task.FromResult(new PrepareResult(new List<JobExtensionRunner>(), new Dictionary<Guid, IActionRunner>())));
+
+                await Assert.ThrowsAsync<DebuggerTunnelException>(() => jobExtension.InitializeJob(_jobEc, _message));
+
+                Assert.Equal("debugger_tunnel_failure", _jobEc.Global.InfrastructureFailureCategory);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task DebuggerClientConnectionTimeoutIsNotAnInfrastructureFailure()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var jobExtension = new JobExtension();
+                jobExtension.Initialize(hc);
+
+                EnableDebuggerOnMessage(hc);
+
+                // The tunnel came up fine — the user just never attached a debug client.
+                var mockDebugger = new Mock<IDapDebugger>();
+                mockDebugger.Setup(x => x.StartAsync(It.IsAny<IExecutionContext>())).Returns(Task.CompletedTask);
+                mockDebugger.Setup(x => x.WaitUntilReadyAsync())
+                            .ThrowsAsync(new TimeoutException("No debugger client connected within 15 minutes."));
+                mockDebugger.Setup(x => x.StopAsync()).Returns(Task.CompletedTask);
+                hc.SetSingleton(mockDebugger.Object);
+
+                _actionManager.Setup(x => x.PrepareActionsAsync(It.IsAny<IExecutionContext>(), It.IsAny<IEnumerable<Pipelines.JobStep>>(), It.IsAny<Guid>()))
+                              .Returns(Task.FromResult(new PrepareResult(new List<JobExtensionRunner>(), new Dictionary<Guid, IActionRunner>())));
+
+                await Assert.ThrowsAsync<TimeoutException>(() => jobExtension.InitializeJob(_jobEc, _message));
+
+                Assert.True(string.IsNullOrEmpty(_jobEc.Global.InfrastructureFailureCategory));
+            }
+        }
+
+        private void EnableDebuggerOnMessage(TestHostContext hc)
+        {
+            _message.EnableDebugger = true;
+            _message.DebuggerTunnel = new Pipelines.DebuggerTunnelInfo
+            {
+                TunnelId = "test-tunnel",
+                ClusterId = "test-cluster",
+                HostToken = "test-token",
+                Port = 9229
+            };
+
+            // Re-initialize the execution context so it picks up debugger config
+            _jobEc = new Runner.Worker.ExecutionContext();
+            _jobEc.Initialize(hc);
+            _jobEc.InitializeJob(_message, _tokenSource.Token);
+        }
     }
 }


### PR DESCRIPTION
Reports a runner infrastructure failure when a debugger job's Dev Tunnel connection cannot be established, or drops mid-job. Previously both cases surfaced as a plain step error (or, for a mid-job drop, were invisible entirely — the job would sit on a DAP pause until the job timeout).

Infrastructure failure category: `debugger_tunnel_failure` (`Constants.Runner.InfrastructureFailureCategories.DebuggerTunnelFailure`). The matching case in run-service is being added separately.

Behaviour:

- Tunnel relay fails to connect (including the 30s connect timeout) — wrapped in a new `DebuggerTunnelException` and reported via `InfrastructureError` from "Set up job".
- Tunnel disconnects mid-job — sets the infra failure category, fails the job, and releases the DAP wait so the job doesn't hang. Disconnects we initiate during `StopAsync` teardown are ignored via an explicit shutdown flag, and transient reconnect transitions are not treated as failures.
- **A debugger client never attaching within the timeout is deliberately NOT an infrastructure failure.** That is a user-side outcome, not broken infrastructure, and keeps its existing plain `context.Error(...)` behaviour. There is a regression test for this.

github/actions-runtime#5587