### PR TITLE
Block dangerous code execution environment variables in GITHUB_ENV and ::set-env::

### DIFF
--- a/src/Runner.Worker/ActionCommandManager.cs
+++ b/src/Runner.Worker/ActionCommandManager.cs
@@ -301,7 +301,13 @@ namespace GitHub.Runner.Worker
 
         private string[] _setEnvBlockList =
         {
-            "NODE_OPTIONS"
+            "NODE_OPTIONS",
+            "BASH_ENV",
+            "LD_PRELOAD",
+            "LD_LIBRARY_PATH",
+            "NODE_PATH",
+            "PYTHONSTARTUP",
+            "PERL5OPT"
         };
     }
 

--- a/src/Runner.Worker/FileCommandManager.cs
+++ b/src/Runner.Worker/FileCommandManager.cs
@@ -214,7 +214,13 @@ namespace GitHub.Runner.Worker
 
         private string[] _setEnvBlockList =
         {
-            "NODE_OPTIONS"
+            "NODE_OPTIONS",
+            "BASH_ENV",
+            "LD_PRELOAD",
+            "LD_LIBRARY_PATH",
+            "NODE_PATH",
+            "PYTHONSTARTUP",
+            "PERL5OPT"
         };
     }
 

--- a/src/Test/L0/Worker/ActionCommandManagerL0.cs
+++ b/src/Test/L0/Worker/ActionCommandManagerL0.cs
@@ -549,5 +549,44 @@ namespace GitHub.Runner.Common.Tests.Worker
             }
         }
 
+        [Theory]
+        [InlineData("NODE_OPTIONS")]
+        [InlineData("BASH_ENV")]
+        [InlineData("LD_PRELOAD")]
+        [InlineData("LD_LIBRARY_PATH")]
+        [InlineData("NODE_PATH")]
+        [InlineData("PYTHONSTARTUP")]
+        [InlineData("PERL5OPT")]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void SetEnvCommand_BlocksDangerousVars(string envName)
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var issues = new List<Issue>();
+                _ec.Setup(x => x.AddIssue(It.IsAny<Issue>(), It.IsAny<ExecutionContextLogOptions>()))
+                   .Callback((Issue issue, ExecutionContextLogOptions logOptions) =>
+                   {
+                       issues.Add(issue);
+                   });
+
+                _ec.Object.Global.EnvironmentVariables = new Dictionary<string, string>();
+                var expressionValues = new DictionaryContextData
+                {
+                    ["env"] =
+#if OS_WINDOWS
+                        new DictionaryContextData { { Constants.Variables.Actions.AllowUnsupportedCommands, new StringContextData("true") } }
+#else
+                        new CaseSensitiveDictionaryContextData { { Constants.Variables.Actions.AllowUnsupportedCommands, new StringContextData("true") } }
+#endif
+                };
+                _ec.Setup(x => x.ExpressionValues).Returns(expressionValues);
+
+                Assert.True(_commandManager.TryProcessCommand(_ec.Object, $"##[set-env name={envName}]malicious_value", null));
+                Assert.Single(issues);
+                Assert.Equal(IssueType.Error, issues[0].Type);
+                Assert.Empty(_ec.Object.Global.EnvironmentVariables);
+            }
+        }
     }
 }

--- a/src/Test/L0/Worker/SetEnvFileCommandL0.cs
+++ b/src/Test/L0/Worker/SetEnvFileCommandL0.cs
@@ -224,6 +224,59 @@ namespace GitHub.Runner.Common.Tests.Worker
             }
         }
 
+        [Theory]
+        [InlineData("BASH_ENV")]
+        [InlineData("LD_PRELOAD")]
+        [InlineData("LD_LIBRARY_PATH")]
+        [InlineData("NODE_PATH")]
+        [InlineData("PYTHONSTARTUP")]
+        [InlineData("PERL5OPT")]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void SetEnvFileCommand_BlocksAdditionalDangerousVars(string envName)
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "blocked");
+                var content = new List<string>
+                {
+                    $"{envName}=malicious_value",
+                };
+                WriteContent(stateFile, content);
+                _setEnvFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(1, _issues.Count);
+                Assert.Equal(0, _executionContext.Object.Global.EnvironmentVariables.Count);
+            }
+        }
+
+        [Theory]
+        [InlineData("BASH_ENV")]
+        [InlineData("LD_PRELOAD")]
+        [InlineData("LD_LIBRARY_PATH")]
+        [InlineData("NODE_PATH")]
+        [InlineData("PYTHONSTARTUP")]
+        [InlineData("PERL5OPT")]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void SetEnvFileCommand_BlocksAdditionalDangerousVars_Heredoc(string envName)
+        {
+            using (var hostContext = Setup())
+            {
+                var stateFile = Path.Combine(_rootDirectory, "blocked_heredoc");
+                var content = new List<string>
+                {
+                    $"{envName}<<EOF",
+                    "malicious_value",
+                    "EOF",
+                };
+                WriteContent(stateFile, content);
+                _setEnvFileCommand.ProcessCommand(_executionContext.Object, stateFile, null);
+                Assert.Equal(1, _issues.Count);
+                Assert.Equal(0, _executionContext.Object.Global.EnvironmentVariables.Count);
+            }
+        }
+
+
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]


### PR DESCRIPTION
### Description
This PR extends the `_setEnvBlockList` in both `ActionCommandManager.cs` and `FileCommandManager.cs` to block well-known execution-affecting environment variables:
- `BASH_ENV`: Automatically sourced by non-interactive `bash` invocations, leading to arbitrary command execution when subsequent steps run bash scripts.
- `LD_PRELOAD` & `LD_LIBRARY_PATH`: Control dynamic linker library preloading and search order, allowing arbitrary shared object injection when any dynamic executable is spawned in later steps.
- `NODE_PATH`: Injects module resolution lookup paths into Node.js processes, enabling arbitrary JavaScript execution upon loading modules.
- `PYTHONSTARTUP`: Automatically executed on interactive Python startup.
- `PERL5OPT`: Command-line option injection into Perl interpreters.

### Security Impact & Rationale
The runner already implements `_setEnvBlockList` to block dangerous environment variables (currently `NODE_OPTIONS`) from being modified via `GITHUB_ENV` or `::set-env::`.

In multi-step workflows (such as `pull_request_target` workflows running test steps on untrusted PR code followed by privileged deployment or release steps), an untrusted early step could write `LD_PRELOAD` or `BASH_ENV` into `$GITHUB_ENV`. Subsequent privileged steps that run tools, scripts, or deployment binaries would inadvertently execute attacker-controlled code within the privileged execution context.

Adding these standard dangerous environment variables to `_setEnvBlockList` closes these cross-step privilege escalation vectors while maintaining full alignment with the runner's existing security design.

### Changes
1. Added `BASH_ENV`, `LD_PRELOAD`, `LD_LIBRARY_PATH`, `NODE_PATH`, `PYTHONSTARTUP`, `PERL5OPT` to `_setEnvBlockList` in `src/Runner.Worker/ActionCommandManager.cs`.
2. Added the same list to `_setEnvBlockList` in `src/Runner.Worker/FileCommandManager.cs`.
3. Added unit tests for all newly blocked environment variables in `src/Test/L0/Worker/SetEnvFileCommandL0.cs` (covering both standard key=value and heredoc format).
4. Added unit tests for all blocked environment variables in `src/Test/L0/Worker/ActionCommandManagerL0.cs`.

### Verification
- Ran L0 unit tests (`ActionCommandManagerL0` and `SetEnvFileCommandL0`): all 58 tests passed successfully.
- Verified build succeeds with 0 errors and 0 warnings.
