### PR TITLE
feat: report token permissions via env var

### DIFF
--- a/src/Runner.Worker/JobExtension.cs
+++ b/src/Runner.Worker/JobExtension.cs
@@ -20,6 +20,7 @@ using GitHub.Runner.Sdk;
 using GitHub.Runner.Worker.Dap;
 using GitHub.Services.Common;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using Pipelines = GitHub.DistributedTask.Pipelines;
 
 namespace GitHub.Runner.Worker
@@ -159,6 +160,19 @@ namespace GitHub.Runner.Worker
                                 context.Output($"{entry.Key}: {entry.Value}");
                             }
                             context.Output("##[endgroup]");
+
+                            try {
+                                // serialize permissions into an env var
+                                var contractResolver = new DefaultContractResolver() { NamingStrategy = new SnakeCaseNamingStrategy(true, false) };
+                                var permissionsJson = JsonConvert.SerializeObject(permissions, new JsonSerializerSettings() { ContractResolver = contractResolver, Formatting = Formatting.None });
+                                context.Global.EnvironmentVariables["GITHUB_TOKEN_PERMISSIONS"] = permissionsJson;
+                                context.SetEnvContext("GITHUB_TOKEN_PERMISSIONS", permissionsJson);
+                            }
+                            catch (Exception ex)
+                            {
+                                context.Output($"Fail to serialize GITHUB_TOKEN_PERMISSIONS: {ex.Message}");
+                                Trace.Error(ex);
+                            }
                         }
                     }
                     catch (Exception ex)

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -1090,6 +1090,26 @@ namespace GitHub.Runner.Common.Tests.Worker
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task GITHUB_TOKEN_PERMISSIONS_IsSetInEnvContext()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var jobExtension = new JobExtension();
+                jobExtension.Initialize(hc);
+
+                _actionManager.Setup(x => x.PrepareActionsAsync(It.IsAny<IExecutionContext>(), It.IsAny<IEnumerable<Pipelines.JobStep>>(), It.IsAny<Guid>()))
+                              .Returns(Task.FromResult(new PrepareResult(new List<JobExtensionRunner>(), new Dictionary<Guid, IActionRunner>())));
+
+                _jobEc.Global.Variables.Set("system.github.token.permissions", "{\"Actions\": \"write\", \"Contents\": \"write\", \"PullRequests\": \"read\"}");
+                await jobExtension.InitializeJob(_jobEc, _message);
+
+                Assert.Equal("{\"actions\":\"write\",\"contents\":\"write\",\"pull_requests\":\"read\"}", _jobEc.Global.EnvironmentVariables["GITHUB_TOKEN_PERMISSIONS"]);
+            }
+        }
+
         private void EnableDebuggerOnMessage(TestHostContext hc)
         {
             _message.EnableDebugger = true;


### PR DESCRIPTION
## What

Set a `GITHUB_TOKEN_PERMISSIONS` environment variable that reports the default github token's permissions, e.g.

```
{"contents": "write", "pull_requests": "read", ...}
```

## Why

Background: https://github.com/orgs/community/discussions/73397

For authors of reusable actions, there's not a good way to know which permissions are available to the github token. Although the permissions do appear in the output (under `Set up job`), you can't get at them programmatically unless you do silly things like parse the `Worker_*.log` file to extract it from the job message 🙈 

By making those permissions readable from the environment, actions can do things like:

- inform the end-user that some required permissions need to be set on the job in order for the action to work
- fall back to other strategies of accessing data, depending on which permission are available ([for example](https://github.com/orgs/community/discussions/73397#discussioncomment-8885874))
- etc