### PR TITLE
Fix run service job renewal retry

### DIFF
--- a/src/Runner.Listener/JobDispatcher.cs
+++ b/src/Runner.Listener/JobDispatcher.cs
@@ -747,7 +747,7 @@ namespace GitHub.Runner.Listener
 
         private async Task RenewJobRequestAsync(IRunServer runServer, Guid planId, Guid jobId, TaskCompletionSource<int> firstJobRequestRenewed, CancellationToken token)
         {
-            TaskAgentJobRequest request = null;
+            DateTime? lastSuccessfulLockedUntil = null;
             int firstRenewRetryLimit = 5;
             int encounteringError = 0;
 
@@ -759,6 +759,7 @@ namespace GitHub.Runner.Listener
                 {
                     var renewResponse = await runServer.RenewJobAsync(planId, jobId, token);
                     Trace.Info($"Successfully renew job {jobId}, job is valid till {renewResponse.LockedUntil}");
+                    lastSuccessfulLockedUntil = renewResponse.LockedUntil;
 
                     if (!firstJobRequestRenewed.Task.IsCompleted)
                     {
@@ -807,7 +808,7 @@ namespace GitHub.Runner.Listener
                     else
                     {
                         // retry till reach lockeduntil + 5 mins extra buffer.
-                        remainingTime = request.LockedUntil.Value + TimeSpan.FromMinutes(5) - DateTime.UtcNow;
+                        remainingTime = lastSuccessfulLockedUntil.Value + TimeSpan.FromMinutes(5) - DateTime.UtcNow;
                     }
 
                     if (remainingTime > TimeSpan.Zero)
@@ -820,7 +821,7 @@ namespace GitHub.Runner.Listener
                         }
                         else
                         {
-                            Trace.Info($"Retrying lock renewal for job {jobId}. Job is valid until {request.LockedUntil.Value}.");
+                            Trace.Info($"Retrying lock renewal for job {jobId}. Job is valid until {lastSuccessfulLockedUntil.Value}.");
                             if (encounteringError > 5)
                             {
                                 delayTime = BackoffTimerHelper.GetRandomBackoff(TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(30));
@@ -854,6 +855,7 @@ namespace GitHub.Runner.Listener
         private async Task RenewJobRequestAsync(IRunnerServer runnerServer, int poolId, long requestId, Guid lockToken, string orchestrationId, TaskCompletionSource<int> firstJobRequestRenewed, CancellationToken token)
         {
             TaskAgentJobRequest request = null;
+            DateTime? lastSuccessfulLockedUntil = null;
             int firstRenewRetryLimit = 5;
             int encounteringError = 0;
 
@@ -865,6 +867,7 @@ namespace GitHub.Runner.Listener
                 {
                     request = await runnerServer.RenewAgentRequestAsync(poolId, requestId, lockToken, orchestrationId, token);
                     Trace.Info($"Successfully renew job request {requestId}, job is valid till {request.LockedUntil.Value}");
+                    lastSuccessfulLockedUntil = request.LockedUntil;
 
                     if (!firstJobRequestRenewed.Task.IsCompleted)
                     {
@@ -936,7 +939,7 @@ namespace GitHub.Runner.Listener
                         }
                         else
                         {
-                            Trace.Info($"Retrying lock renewal for jobrequest {requestId}. Job is valid until {request.LockedUntil.Value}.");
+                            Trace.Info($"Retrying lock renewal for jobrequest {requestId}. Job is valid until {lastSuccessfulLockedUntil.Value}.");
                             if (encounteringError > 5)
                             {
                                 delayTime = BackoffTimerHelper.GetRandomBackoff(TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(30));

--- a/src/Test/L0/Listener/JobDispatcherL0.cs
+++ b/src/Test/L0/Listener/JobDispatcherL0.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using GitHub.DistributedTask.ObjectTemplating.Tokens;
@@ -341,6 +342,101 @@ namespace GitHub.Runner.Common.Tests.Listener
                 Assert.True(firstJobRequestRenewed.Task.IsCompletedSuccessfully, "First renew should succeed.");
                 Assert.False(cancellationTokenSource.IsCancellationRequested);
                 _runnerServer.Verify(x => x.RenewAgentRequestAsync(It.IsAny<int>(), It.IsAny<long>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(5));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async Task DispatcherRenewJobOnRunServiceRetryAfterGenericException()
+        {
+            // Arrange
+            using (var hc = new TestHostContext(this))
+            {
+                int poolId = 1;
+                Int64 requestId = 1000;
+                int count = 0;
+
+                TaskCompletionSource<int> firstJobRequestRenewed = new();
+                CancellationTokenSource cancellationTokenSource = new();
+
+                hc.SetSingleton<IRunServer>(_runServer.Object);
+                hc.SetSingleton<IConfigurationStore>(_configurationStore.Object);
+                _configurationStore.Setup(x => x.GetSettings())
+                    .Returns(new RunnerSettings() { PoolId = 1 });
+
+                _ = _runServer.Setup(x => x.RenewJobAsync(
+                        It.IsAny<Guid>(),
+                        It.IsAny<Guid>(),
+                        It.IsAny<CancellationToken>()))
+                    .Returns(() =>
+                    {
+                        count++;
+
+                        if (count == 1)
+                        {
+                            // First renewal succeeds.
+                            return Task.FromResult(new RenewJobResponse
+                            {
+                                LockedUntil = DateTime.UtcNow.AddMinutes(5)
+                            });
+                        }
+                        else if (count == 2)
+                        {
+                            // Second renewal fails with a generic exception.
+                            throw new HttpRequestException("Simulated renewal failure.");
+                        }
+                        else if (count == 3)
+                        {
+                            // Retry succeeds.
+                            cancellationTokenSource.Cancel();
+                            return Task.FromResult(new RenewJobResponse
+                            {
+                                LockedUntil = DateTime.UtcNow.AddMinutes(5)
+                            });
+                        }
+
+                        throw new InvalidOperationException("Should not reach here.");
+                    });
+
+                var jobDispatcher = new JobDispatcher();
+                jobDispatcher.Initialize(hc);
+                EnableRunServiceJobForJobDispatcher(jobDispatcher);
+
+                // Set the value of the _isRunServiceJob field to true.
+                var isRunServiceJobField = typeof(JobDispatcher).GetField(
+                    "_isRunServiceJob",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+
+                isRunServiceJobField.SetValue(jobDispatcher, true);
+
+                // Act
+                await jobDispatcher.RenewJobRequestAsync(
+                    GetAgentJobRequestMessage(),
+                    GetServiceEndpoint(),
+                    poolId,
+                    requestId,
+                    Guid.Empty,
+                    Guid.NewGuid().ToString(),
+                    firstJobRequestRenewed,
+                    cancellationTokenSource.Token);
+
+                // Assert
+                Assert.True(
+                    firstJobRequestRenewed.Task.IsCompletedSuccessfully,
+                    "First renew should succeed.");
+
+                Assert.Equal(3, count);
+                Assert.True(
+                    cancellationTokenSource.IsCancellationRequested,
+                    "Cancellation should only happen after the retry succeeds.");
+
+                _runServer.Verify(
+                    x => x.RenewJobAsync(
+                        It.IsAny<Guid>(),
+                        It.IsAny<Guid>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Exactly(3));
             }
         }
 


### PR DESCRIPTION
Fixes #4635.

Run Service job renewal could throw a `NullReferenceException` when a renewal failed after a previous renewal had succeeded.

The retry path was using `request.LockedUntil`, but `request` is never initialized in the `IRunServer` renewal flow. This caused the renewal task to fail and the active job to be abandoned.

This change:
- Tracks the `LockedUntil` value from the last successful renewal.
- Uses the last successful lock expiration when calculating the retry time.
- Updates the retry logging to use the last successful lock expiration.
- Adds a regression test covering a successful renewal followed by a generic failure and a successful retry.

## Testing

- Added a regression test for Run Service job renewal retry.
- Verified the test passes with the fix.
- Verified the test fails with the previous implementation due to `NullReferenceException`.