### PR TITLE
Avoid truncating event.json while other steps read it

### DIFF
--- a/src/Runner.Worker/ExecutionContext.cs
+++ b/src/Runner.Worker/ExecutionContext.cs
@@ -1330,8 +1330,33 @@ namespace GitHub.Runner.Worker
             {
                 var workflowFile = Path.Combine(workflowDirectory, "event.json");
                 Trace.Info($"Write event payload to {workflowFile}");
-                File.WriteAllText(workflowFile, gitHubEvent, new UTF8Encoding(false));
+                WriteWebhookPayloadFile(workflowFile, gitHubEvent);
                 SetGitHubContext("event_path", workflowFile);
+            }
+        }
+
+        // Every step writes the very same webhook payload to the very same file before it runs, and
+        // steps can run concurrently (parallel/background steps). This implements an atomic write
+        // that avoids file corruption.
+        private static void WriteWebhookPayloadFile(string workflowFile, string gitHubEvent)
+        {
+            if (File.Exists(workflowFile))
+            {
+                return;
+            }
+
+            var tempFile = $"{workflowFile}.{Guid.NewGuid():N}.tmp";
+            File.WriteAllText(tempFile, gitHubEvent, new UTF8Encoding(false));
+            try
+            {
+                File.Move(tempFile, workflowFile);
+            }
+            catch (IOException) when (File.Exists(workflowFile))
+            {
+            }
+            finally
+            {
+                File.Delete(tempFile);
             }
         }
 


### PR DESCRIPTION
Write the payload to a sibling temporary file and move it into place without allowing an overwrite. That move is atomic and create-only - `link()`+`unlink()` on Unix, `MoveFile` on Windows - so it either publishes the complete payload in one step or fails with `EEXIST`/`ERROR_ALREADY_EXISTS` because another step already published it. Since every step writes identical bytes, that failure means the work is already done and is ignored. `event.json` is therefore created exactly once per job and never replaced, so no action can ever read it mid-write.

Fixes https://github.com/actions/checkout/issues/2484
Fixes https://github.com/actions/cache/issues/1793