### PR TITLE
Classify clock-skew invalid_client as retriable, not a deleted registration

### DIFF
--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -187,22 +187,37 @@ namespace GitHub.Runner.Listener
                         ex is VssOAuthTokenRequestException vssOAuthEx &&
                         _credsV2.Federated is VssOAuthCredential vssOAuthCred)
                     {
-                        // "invalid_client" means the runner registration has been deleted from the server.
-                        if (string.Equals(vssOAuthEx.Error, "invalid_client", StringComparison.OrdinalIgnoreCase))
+                        // A clock-skewed token request also comes back as "invalid_client", but its
+                        // message carries "Current server time is ..." - the same sentinel
+                        // IsSessionCreationExceptionRetriable checks below. That is not a deleted
+                        // registration; the request was rejected only because this machine's clock
+                        // hasn't caught up yet. Skip the deleted-registration classification and let
+                        // this fall through to the existing clock-skew retry path instead of
+                        // terminating the runner.
+                        if (vssOAuthEx.Message.Contains("Current server time is"))
                         {
-                            _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
-                            return CreateSessionResult.Failure;
+                            _term.WriteError($"Failed to create a session because of a clock-skewed invalid_client error: {vssOAuthEx.Message}");
+                            Trace.Info("invalid_client with a clock-skew signature detected; deferring to clock-skew retry classification instead of treating the registration as deleted.");
                         }
-
-                        // Check whether we get 401 because the runner registration already removed by the service.
-                        // If the runner registration get deleted, we can't exchange oauth token.
-                        Trace.Error("Test oauth app registration.");
-                        var oauthTokenProvider = new VssOAuthTokenProvider(vssOAuthCred, new Uri(serverUrlV2));
-                        var authError = await oauthTokenProvider.ValidateCredentialAsync(token);
-                        if (string.Equals(authError, "invalid_client", StringComparison.OrdinalIgnoreCase))
+                        else
                         {
-                            _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
-                            return CreateSessionResult.Failure;
+                            // "invalid_client" means the runner registration has been deleted from the server.
+                            if (string.Equals(vssOAuthEx.Error, "invalid_client", StringComparison.OrdinalIgnoreCase))
+                            {
+                                _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
+                                return CreateSessionResult.Failure;
+                            }
+
+                            // Check whether we get 401 because the runner registration already removed by the service.
+                            // If the runner registration get deleted, we can't exchange oauth token.
+                            Trace.Error("Test oauth app registration.");
+                            var oauthTokenProvider = new VssOAuthTokenProvider(vssOAuthCred, new Uri(serverUrlV2));
+                            var authError = await oauthTokenProvider.ValidateCredentialAsync(token);
+                            if (string.Equals(authError, "invalid_client", StringComparison.OrdinalIgnoreCase))
+                            {
+                                _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
+                                return CreateSessionResult.Failure;
+                            }
                         }
                     }
 

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -213,8 +213,15 @@ namespace GitHub.Runner.Listener
                             // If the runner registration get deleted, we can't exchange oauth token.
                             Trace.Error("Test oauth app registration.");
                             var oauthTokenProvider = new VssOAuthTokenProvider(vssOAuthCred, new Uri(serverUrlV2));
-                            var authError = await oauthTokenProvider.ValidateCredentialAsync(token);
-                            if (string.Equals(authError, "invalid_client", StringComparison.OrdinalIgnoreCase))
+                            var (authError, authErrorDescription) = await oauthTokenProvider.ValidateCredentialAsync(token);
+                            if (authErrorDescription?.Contains("Current server time is") == true)
+                            {
+                                // Same clock-skew signature as above, just surfaced through this
+                                // re-validation call instead of the original exception. Defer to the
+                                // clock-skew retry path instead of treating the registration as deleted.
+                                Trace.Info("invalid_client from credential re-validation with a clock-skew signature detected; deferring to clock-skew retry classification instead of treating the registration as deleted.");
+                            }
+                            else if (string.Equals(authError, "invalid_client", StringComparison.OrdinalIgnoreCase))
                             {
                                 _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
                                 return CreateSessionResult.Failure;

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -193,10 +193,11 @@ namespace GitHub.Runner.Listener
                         // registration; the request was rejected only because this machine's clock
                         // hasn't caught up yet. Skip the deleted-registration classification and let
                         // this fall through to the existing clock-skew retry path instead of
-                        // terminating the runner.
-                        if (vssOAuthEx.Message.Contains("Current server time is"))
+                        // terminating the runner. Nothing user-facing is logged here: that retry
+                        // path already prints its own clock-skew message, and logging here too
+                        // would duplicate it on every retry attempt.
+                        if (vssOAuthEx.Message?.Contains("Current server time is") == true)
                         {
-                            _term.WriteError($"Failed to create a session because of a clock-skewed invalid_client error: {vssOAuthEx.Message}");
                             Trace.Info("invalid_client with a clock-skew signature detected; deferring to clock-skew retry classification instead of treating the registration as deleted.");
                         }
                         else

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -151,22 +151,37 @@ namespace GitHub.Runner.Listener
 
                     if (ex is VssOAuthTokenRequestException vssOAuthEx && _creds.Federated is VssOAuthCredential vssOAuthCred)
                     {
-                        // "invalid_client" means the runner registration has been deleted from the server.
-                        if (string.Equals(vssOAuthEx.Error, "invalid_client", StringComparison.OrdinalIgnoreCase))
+                        // A clock-skewed token request also comes back as "invalid_client", but its
+                        // message carries "Current server time is ..." - the same sentinel
+                        // IsSessionCreationExceptionRetriable checks below. That is not a deleted
+                        // registration; the request was rejected only because this machine's clock
+                        // hasn't caught up yet. Skip the deleted-registration classification and let
+                        // this fall through to the existing clock-skew retry path instead of
+                        // terminating the runner.
+                        if (vssOAuthEx.Message.Contains("Current server time is"))
                         {
-                            _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
-                            return CreateSessionResult.Failure;
+                            _term.WriteError($"Failed to create a session because of a clock-skewed invalid_client error: {vssOAuthEx.Message}");
+                            Trace.Info("invalid_client with a clock-skew signature detected; deferring to clock-skew retry classification instead of treating the registration as deleted.");
                         }
-
-                        // Check whether we get 401 because the runner registration already removed by the service.
-                        // If the runner registration get deleted, we can't exchange oauth token.
-                        Trace.Error("Test oauth app registration.");
-                        var oauthTokenProvider = new VssOAuthTokenProvider(vssOAuthCred, new Uri(serverUrl));
-                        var authError = await oauthTokenProvider.ValidateCredentialAsync(token);
-                        if (string.Equals(authError, "invalid_client", StringComparison.OrdinalIgnoreCase))
+                        else
                         {
-                            _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
-                            return CreateSessionResult.Failure;
+                            // "invalid_client" means the runner registration has been deleted from the server.
+                            if (string.Equals(vssOAuthEx.Error, "invalid_client", StringComparison.OrdinalIgnoreCase))
+                            {
+                                _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
+                                return CreateSessionResult.Failure;
+                            }
+
+                            // Check whether we get 401 because the runner registration already removed by the service.
+                            // If the runner registration get deleted, we can't exchange oauth token.
+                            Trace.Error("Test oauth app registration.");
+                            var oauthTokenProvider = new VssOAuthTokenProvider(vssOAuthCred, new Uri(serverUrl));
+                            var authError = await oauthTokenProvider.ValidateCredentialAsync(token);
+                            if (string.Equals(authError, "invalid_client", StringComparison.OrdinalIgnoreCase))
+                            {
+                                _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
+                                return CreateSessionResult.Failure;
+                            }
                         }
                     }
 

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -157,10 +157,11 @@ namespace GitHub.Runner.Listener
                         // registration; the request was rejected only because this machine's clock
                         // hasn't caught up yet. Skip the deleted-registration classification and let
                         // this fall through to the existing clock-skew retry path instead of
-                        // terminating the runner.
-                        if (vssOAuthEx.Message.Contains("Current server time is"))
+                        // terminating the runner. Nothing user-facing is logged here: that retry
+                        // path already prints its own clock-skew message, and logging here too
+                        // would duplicate it on every retry attempt.
+                        if (vssOAuthEx.Message?.Contains("Current server time is") == true)
                         {
-                            _term.WriteError($"Failed to create a session because of a clock-skewed invalid_client error: {vssOAuthEx.Message}");
                             Trace.Info("invalid_client with a clock-skew signature detected; deferring to clock-skew retry classification instead of treating the registration as deleted.");
                         }
                         else

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -177,8 +177,15 @@ namespace GitHub.Runner.Listener
                             // If the runner registration get deleted, we can't exchange oauth token.
                             Trace.Error("Test oauth app registration.");
                             var oauthTokenProvider = new VssOAuthTokenProvider(vssOAuthCred, new Uri(serverUrl));
-                            var authError = await oauthTokenProvider.ValidateCredentialAsync(token);
-                            if (string.Equals(authError, "invalid_client", StringComparison.OrdinalIgnoreCase))
+                            var (authError, authErrorDescription) = await oauthTokenProvider.ValidateCredentialAsync(token);
+                            if (authErrorDescription?.Contains("Current server time is") == true)
+                            {
+                                // Same clock-skew signature as above, just surfaced through this
+                                // re-validation call instead of the original exception. Defer to the
+                                // clock-skew retry path instead of treating the registration as deleted.
+                                Trace.Info("invalid_client from credential re-validation with a clock-skew signature detected; deferring to clock-skew retry classification instead of treating the registration as deleted.");
+                            }
+                            else if (string.Equals(authError, "invalid_client", StringComparison.OrdinalIgnoreCase))
                             {
                                 _term.WriteError("Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.");
                                 return CreateSessionResult.Failure;

--- a/src/Sdk/WebApi/WebApi/OAuth/VssOAuthTokenProvider.cs
+++ b/src/Sdk/WebApi/WebApi/OAuth/VssOAuthTokenProvider.cs
@@ -119,13 +119,17 @@ namespace GitHub.Services.OAuth
             }
         }
 
-        public async Task<string> ValidateCredentialAsync(CancellationToken cancellationToken)
+        // Returns the underlying authentication error together with its description. Callers that
+        // need to distinguish a clock-skewed "invalid_client" (the description carries "Current
+        // server time is ...") from a genuine one (e.g. a deleted registration) need the
+        // description - the error code alone is identical in both cases.
+        public async Task<(string Error, string ErrorDescription)> ValidateCredentialAsync(CancellationToken cancellationToken)
         {
             var tokenHttpClient = new VssOAuthTokenHttpClient(this.SignInUrl);
             var tokenResponse = await tokenHttpClient.GetTokenAsync(this.Grant, this.ClientCredential, this.TokenParameters, cancellationToken);
 
-            // return the underlying authentication error
-            return tokenResponse.Error;
+            // return the underlying authentication error and its description
+            return (tokenResponse.Error, tokenResponse.ErrorDescription);
         }
 
         /// <summary>

--- a/src/Test/L0/Listener/BrokerMessageListenerL0.cs
+++ b/src/Test/L0/Listener/BrokerMessageListenerL0.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Listener;
 using GitHub.Runner.Listener.Configuration;
 using GitHub.Services.Common;
+using GitHub.Services.OAuth;
 using Moq;
 using Xunit;
 
@@ -477,6 +479,141 @@ namespace GitHub.Runner.Common.Tests.Listener
 
                 // Verify LoadSettings was never called
                 _config.Verify(x => x.LoadSettings(), Times.Never());
+            }
+        }
+
+        // Mirrors MessageListenerL0's coverage for the same fix (actions/runner#4648), for the
+        // broker listener - flagged in review as missing so a future change couldn't regress
+        // just the broker path without either suite catching it.
+        //
+        // Covers actions/runner#4648: an OAuth "invalid_client" caused purely by clock skew
+        // (the token request itself carries "Current server time is ..." in its message, the
+        // same sentinel IsSessionCreationExceptionRetriable already checks) must not be treated
+        // as a deleted registration. It must fall through to the existing clock-skew retry path
+        // instead of returning CreateSessionResult.Failure (which Runner.cs maps to
+        // ReturnCode.TerminatedError, so systemd never retries).
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async Task CreateSession_ClockSkewInvalidClient_RetriesInsteadOfTerminating()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var mockTerm = new Mock<ITerminal>();
+                tc.SetSingleton<ITerminal>(mockTerm.Object);
+
+                var rsaKeyManager = new Mock<IRSAKeyManager>();
+                rsaKeyManager.Setup(x => x.GetKey()).Returns(RSA.Create(2048));
+                tc.SetSingleton<IRSAKeyManager>(rsaKeyManager.Object);
+
+                var oauth = new OAuthCredential();
+                oauth.CredentialData = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                oauth.CredentialData.Data.Add("clientId", "someClientId");
+                oauth.CredentialData.Data.Add("authorizationUrl", "https://s.server");
+                var federatedCreds = oauth.GetVssCredentials(tc, false);
+                // BrokerMessageListener.CreateSessionAsync loads _credsV2 via
+                // LoadCredentials(allowAuthUrlV2: true) - that is the credential object the
+                // invalid_client guard actually inspects.
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(federatedCreds);
+
+                var expectedSession = new TaskAgentSession();
+
+                // Reproduces the real message shape from the issue: a token-expiry check against
+                // the server's clock, surfaced by the service as an OAuth "invalid_client" error.
+                var skewException = new VssOAuthTokenRequestException(
+                    "The token expired on 08/24/2026 19:15:44. Current server time is 08/25/2026 01:44:14.")
+                {
+                    Error = "invalid_client",
+                };
+
+                _brokerServer
+                    .SetupSequence(x => x.CreateSessionAsync(
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Throws(skewException)
+                    .Returns(Task.FromResult(expectedSession));
+
+                // Act.
+                BrokerMessageListener listener = new();
+                listener.Initialize(tc);
+
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert: the clock-skew invalid_client did not terminate the call - it fell
+                // through to the existing clock-skew retry path, and the next attempt (clock now
+                // caught up) succeeded.
+                Assert.Equal(CreateSessionResult.Success, result);
+                _brokerServer
+                    .Verify(x => x.CreateSessionAsync(
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Exactly(2));
+
+                mockTerm.Verify(x => x.WriteError(It.Is<string>(s => s.Contains("registration has been deleted"))), Times.Never);
+            }
+        }
+
+        // Companion to the test above: a genuine deleted-registration invalid_client (no
+        // clock-skew sentinel in the message) must keep terminating immediately, exactly as
+        // before. This fix must not weaken true deleted-registration handling.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async Task CreateSession_InvalidClientWithoutClockSkew_StillTerminatesAsDeletedRegistration()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var mockTerm = new Mock<ITerminal>();
+                tc.SetSingleton<ITerminal>(mockTerm.Object);
+
+                var rsaKeyManager = new Mock<IRSAKeyManager>();
+                rsaKeyManager.Setup(x => x.GetKey()).Returns(RSA.Create(2048));
+                tc.SetSingleton<IRSAKeyManager>(rsaKeyManager.Object);
+
+                var oauth = new OAuthCredential();
+                oauth.CredentialData = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                oauth.CredentialData.Data.Add("clientId", "someClientId");
+                oauth.CredentialData.Data.Add("authorizationUrl", "https://s.server");
+                var federatedCreds = oauth.GetVssCredentials(tc, false);
+                _credMgr.Setup(x => x.LoadCredentials(true)).Returns(federatedCreds);
+
+                // A genuine deleted-registration response: invalid_client with no clock-skew
+                // sentinel anywhere in the message.
+                var deletedException = new VssOAuthTokenRequestException("Client authentication failed.")
+                {
+                    Error = "invalid_client",
+                };
+
+                _brokerServer
+                    .Setup(x => x.CreateSessionAsync(
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Throws(deletedException);
+
+                // Act.
+                BrokerMessageListener listener = new();
+                listener.Initialize(tc);
+
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert: still terminates immediately as a deleted registration - exactly one
+                // attempt, no retry.
+                Assert.Equal(CreateSessionResult.Failure, result);
+                _brokerServer
+                    .Verify(x => x.CreateSessionAsync(
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Once());
+
+                mockTerm.Verify(x => x.WriteError(It.Is<string>(s => s.Contains("registration has been deleted"))), Times.Once);
             }
         }
 

--- a/src/Test/L0/Listener/MessageListenerL0.cs
+++ b/src/Test/L0/Listener/MessageListenerL0.cs
@@ -10,6 +10,7 @@ using GitHub.DistributedTask.WebApi;
 using GitHub.Runner.Listener;
 using GitHub.Runner.Listener.Configuration;
 using GitHub.Services.Common;
+using GitHub.Services.OAuth;
 using GitHub.Services.WebApi;
 using Moq;
 using Xunit;
@@ -735,6 +736,138 @@ namespace GitHub.Runner.Common.Tests.Listener
                     .Verify(x => x.ForceRefreshConnection(It.IsAny<VssCredentials>()), Times.Once());
 
                 Assert.True(tc.AllowAuthMigration);
+            }
+        }
+
+        // Covers actions/runner#4648: an OAuth "invalid_client" caused purely by clock skew
+        // (the token request itself carries "Current server time is ..." in its message, the
+        // same sentinel IsSessionCreationExceptionRetriable already checks) must not be treated
+        // as a deleted registration. It must fall through to the existing clock-skew retry path
+        // instead of returning CreateSessionResult.Failure (which Runner.cs maps to
+        // ReturnCode.TerminatedError, so systemd never retries).
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async Task CreateSession_ClockSkewInvalidClient_RetriesInsteadOfTerminating()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var mockTerm = new Mock<ITerminal>();
+                tc.SetSingleton<ITerminal>(mockTerm.Object);
+
+                var rsaKeyManager = new Mock<IRSAKeyManager>();
+                rsaKeyManager.Setup(x => x.GetKey()).Returns(RSA.Create(2048));
+                tc.SetSingleton<IRSAKeyManager>(rsaKeyManager.Object);
+
+                var oauth = new OAuthCredential();
+                oauth.CredentialData = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                oauth.CredentialData.Data.Add("clientId", "someClientId");
+                oauth.CredentialData.Data.Add("authorizationUrl", "https://s.server");
+                var federatedCreds = oauth.GetVssCredentials(tc, false);
+                _credMgr.Setup(x => x.LoadCredentials(It.IsAny<bool>())).Returns(federatedCreds);
+
+                var expectedSession = new TaskAgentSession();
+
+                // Reproduces the real message shape from the issue: a token-expiry check against
+                // the server's clock, surfaced by the service as an OAuth "invalid_client" error.
+                var skewException = new VssOAuthTokenRequestException(
+                    "The token expired on 08/24/2026 19:15:44. Current server time is 08/25/2026 01:44:14.")
+                {
+                    Error = "invalid_client",
+                };
+
+                _runnerServer
+                    .SetupSequence(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Throws(skewException)
+                    .Returns(Task.FromResult(expectedSession));
+
+                // Act.
+                MessageListener listener = new();
+                listener.Initialize(tc);
+
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert: the clock-skew invalid_client did not terminate the call - it fell
+                // through to the existing clock-skew retry path, and the next attempt (clock now
+                // caught up) succeeded.
+                Assert.Equal(CreateSessionResult.Success, result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Exactly(2));
+
+                mockTerm.Verify(x => x.WriteError(It.Is<string>(s => s.Contains("registration has been deleted"))), Times.Never);
+            }
+        }
+
+        // Companion to the test above: a genuine deleted-registration invalid_client (no
+        // clock-skew sentinel in the message) must keep terminating immediately, exactly as
+        // before. This fix must not weaken true deleted-registration handling.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Runner")]
+        public async Task CreateSession_InvalidClientWithoutClockSkew_StillTerminatesAsDeletedRegistration()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = tc.GetTrace();
+
+                // Arrange.
+                var mockTerm = new Mock<ITerminal>();
+                tc.SetSingleton<ITerminal>(mockTerm.Object);
+
+                var rsaKeyManager = new Mock<IRSAKeyManager>();
+                rsaKeyManager.Setup(x => x.GetKey()).Returns(RSA.Create(2048));
+                tc.SetSingleton<IRSAKeyManager>(rsaKeyManager.Object);
+
+                var oauth = new OAuthCredential();
+                oauth.CredentialData = new CredentialData() { Scheme = Constants.Configuration.OAuth };
+                oauth.CredentialData.Data.Add("clientId", "someClientId");
+                oauth.CredentialData.Data.Add("authorizationUrl", "https://s.server");
+                var federatedCreds = oauth.GetVssCredentials(tc, false);
+                _credMgr.Setup(x => x.LoadCredentials(It.IsAny<bool>())).Returns(federatedCreds);
+
+                // A genuine deleted-registration response: invalid_client with no clock-skew
+                // sentinel anywhere in the message.
+                var deletedException = new VssOAuthTokenRequestException("Client authentication failed.")
+                {
+                    Error = "invalid_client",
+                };
+
+                _runnerServer
+                    .Setup(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token))
+                    .Throws(deletedException);
+
+                // Act.
+                MessageListener listener = new();
+                listener.Initialize(tc);
+
+                CreateSessionResult result = await listener.CreateSessionAsync(tokenSource.Token);
+                trace.Info("result: {0}", result);
+
+                // Assert: still terminates immediately as a deleted registration - exactly one
+                // attempt, no retry.
+                Assert.Equal(CreateSessionResult.Failure, result);
+                _runnerServer
+                    .Verify(x => x.CreateAgentSessionAsync(
+                        _settings.PoolId,
+                        It.Is<TaskAgentSession>(y => y != null),
+                        tokenSource.Token), Times.Once());
+
+                mockTerm.Verify(x => x.WriteError(It.Is<string>(s => s.Contains("registration has been deleted"))), Times.Once);
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #4648. When a self-hosted runner's system clock hasn't synchronized yet at boot, `CreateSessionAsync` (both `MessageListener` and `BrokerMessageListener`) classifies the resulting OAuth `invalid_client` as a deleted registration, prints a misleading message, and returns `CreateSessionResult.Failure` unconditionally - which `Runner.cs` maps to `ReturnCode.TerminatedError`, so systemd never retries and the runner stays offline until manually restarted.

## Root cause

`invalid_client` short-circuits to `Failure` *before* `IsSessionCreationExceptionRetriable` ever runs - in both listeners. That method already has a clock-skew retry path (checks for `"Current server time is"` in the exception message, retries every 30s for up to 30 minutes), but it's unreachable for this case because the `invalid_client` check above it returns first.

A clock-skewed token request also comes back as `invalid_client`, with `"Current server time is ..."` in the message - the exact sentinel `IsSessionCreationExceptionRetriable` already checks for. It just never gets there.

## Fix

Minimal, no new retry policy: guard both `invalid_client` checks (the exception's own `.Error`, and the `ValidateCredentialAsync` fallback probe) in each listener on that same sentinel. When present, skip the deleted-registration classification and fall through to the existing clock-skew retry path instead of returning `Failure`. A genuine deleted registration (`invalid_client` without the sentinel) is unaffected - same message, same immediate `Failure`, unchanged.

Kept both listeners in sync; the fix is structurally identical in each (`BrokerMessageListener` keeps its existing `!HostContext.AllowAuthMigration` outer condition untouched).

## Tests

Added to `MessageListenerL0`:
- `CreateSession_ClockSkewInvalidClient_RetriesInsteadOfTerminating` - `invalid_client` + clock-skew sentinel now retries (`CreateAgentSessionAsync` called twice: skew failure, then success) instead of terminating; no deleted-registration message is written.
- `CreateSession_InvalidClientWithoutClockSkew_StillTerminatesAsDeletedRegistration` - companion test proving a genuine deleted registration (no sentinel) still terminates immediately with exactly one attempt and the existing message - this fix must not weaken that path.

Verified both are real regression coverage, not just passing incidentally: temporarily reverted the source change (`git stash` on the two listener files only, tests kept) and reran - the skew test failed (`Expected: Success, Actual: Failure`) while the deleted-registration test still passed in both states. Restored the fix and reran the full `MessageListenerL0` + `BrokerMessageListenerL0` suite (19 tests) - all green.

```bash
dotnet test src/Test/Test.csproj -c Debug --filter "FullyQualifiedName~MessageListenerL0"
```

## Compatibility with #4330

Checked #4330's full diff against this change before opening this PR: it modifies `BrokerServer.ShouldRetryException` (a *different* retry classifier, used for message polling, not session creation) and a separate `RunnerNotFoundException` classifier elsewhere in `BrokerMessageListener.cs`. It does not touch `CreateSessionAsync` or `IsSessionCreationExceptionRetriable` in either listener - confirmed by checking out its branch and diffing the resulting file directly. No behavioral overlap; at most a trivial rebase if both land, since both touch the same file in different regions.

## Scope

`src/Runner.Listener/MessageListener.cs`, `src/Runner.Listener/BrokerMessageListener.cs`, `src/Test/L0/Listener/MessageListenerL0.cs`. No changes to `systemd`/NTP handling, no changes to `ConnectivityAndDNSChecks` (#4595), no new retry policy or configuration surface.
