### PR TITLE
fix(parser): handle self-repository references in comparison parser

### DIFF
--- a/src/Runner.Worker/ActionManifestManagerWrapper.cs
+++ b/src/Runner.Worker/ActionManifestManagerWrapper.cs
@@ -274,6 +274,15 @@ namespace GitHub.Runner.Worker
                 };
             }
 
+            if (GitHub.DistributedTask.Pipelines.PipelineConstants.TryParseSelfRepository(uses, out var selfPath))
+            {
+                return new GitHub.DistributedTask.Pipelines.RepositoryPathReference
+                {
+                    RepositoryType = GitHub.DistributedTask.Pipelines.PipelineConstants.SelfRepositoryAlias,
+                    Path = selfPath
+                };
+            }
+
             // Repository reference: owner/repo@ref or owner/repo/path@ref
             var atIndex = uses.LastIndexOf('@');
             string refPart = null;

--- a/src/Sdk/WorkflowParser/Conversion/WorkflowTemplateConverter.cs
+++ b/src/Sdk/WorkflowParser/Conversion/WorkflowTemplateConverter.cs
@@ -1759,7 +1759,8 @@ namespace GitHub.Actions.WorkflowParser.Conversion
 
                 if (!uses.Value.StartsWith(WorkflowTemplateConstants.DockerUriPrefix, StringComparison.Ordinal) &&
                     !uses.Value.StartsWith("./") &&
-                    !uses.Value.StartsWith(".\\"))
+                    !uses.Value.StartsWith(".\\") &&
+                    !GitHub.DistributedTask.Pipelines.PipelineConstants.TryParseSelfRepository(uses.Value, out _))
                 {
                     var usesSegments = uses.Value.Split('@');
                     var pathSegments = usesSegments[0].Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Test/L0/Worker/ActionManifestParserComparisonL0.cs
+++ b/src/Test/L0/Worker/ActionManifestParserComparisonL0.cs
@@ -94,6 +94,46 @@ namespace GitHub.Runner.Common.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        public void Load_SelfRepositoryReference_BothParsersAgree()
+        {
+            try
+            {
+                Setup();
+                _ec.Object.Global.Variables.Set(Constants.Runner.Features.CompareWorkflowParser, "true");
+
+                var legacyManager = new ActionManifestManagerLegacy();
+                legacyManager.Initialize(_hc);
+                _hc.SetSingleton<IActionManifestManagerLegacy>(legacyManager);
+
+                var newManager = new ActionManifestManager();
+                newManager.Initialize(_hc);
+                _hc.SetSingleton<IActionManifestManager>(newManager);
+
+                var wrapper = new ActionManifestManagerWrapper();
+                wrapper.Initialize(_hc);
+
+                var manifestPath = Path.Combine(TestUtil.GetTestDataPath(), "self_repository_composite_action.yml");
+
+                var result = wrapper.Load(_ec.Object, manifestPath);
+
+                Assert.NotNull(result);
+                var composite = Assert.IsType<CompositeActionExecutionData>(result.Execution);
+                var nestedAction = Assert.Single(composite.Steps);
+                var reference = Assert.IsType<GitHub.DistributedTask.Pipelines.RepositoryPathReference>(nestedAction.Reference);
+                Assert.Equal(GitHub.DistributedTask.Pipelines.PipelineConstants.SelfRepositoryAlias, reference.RepositoryType);
+                Assert.Equal("actions/nested", reference.Path);
+                Assert.False(_ec.Object.Global.HasActionManifestMismatch);
+                _ec.Verify(x => x.AddIssue(It.IsAny<Issue>(), It.IsAny<ExecutionContextLogOptions>()), Times.Never);
+            }
+            finally
+            {
+                Teardown();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
         public void EvaluateJobContainer_EmptyImage_BothParsersReturnNull()
         {
             try

--- a/src/Test/TestData/self_repository_composite_action.yml
+++ b/src/Test/TestData/self_repository_composite_action.yml
@@ -1,0 +1,8 @@
+name: Self-repository composite
+description: Tests a self-repository action reference
+
+runs:
+  using: composite
+  steps:
+    - name: Nested action
+      uses: $/actions/nested


### PR DESCRIPTION
Accept `$/` self-repository references consistently when action-manifest parser comparison is enabled.

The newer parser previously emitted a false validation annotation and converted this reference differently from the legacy parser. This aligns validation and conversion with the legacy behavior, with a regression test covering comparison mode.

Fixes #4706
