### PR TITLE
Add cooperative drain controls for ephemeral runners

### DIFF
--- a/docs/ephemeral-runner-drain.md
+++ b/docs/ephemeral-runner-drain.md
@@ -1,0 +1,30 @@
+# Cooperatively stopping an ephemeral runner
+
+An external supervisor can request drain by creating `.drain` in the runner's
+installation directory. This applies only to runners configured with
+`--ephemeral`; it does not change persistent runners.
+
+The listener finishes its outstanding message poll. If the response contains a
+job, it completes acknowledgement/acquisition and runs that job normally. If
+the response is empty, it exits successfully without starting another poll.
+An already running job finishes through the existing one-job completion path;
+normal job-cancellation messages continue to be processed.
+
+The supervisor must wait for the listener to exit before stopping the host. It
+must not immediately follow creation of `.drain` with a termination signal.
+Idle drain can take the duration of the outstanding long poll, and network
+retries can extend that wait.
+
+The supervisor owns the sentinel: remove it before deliberately starting a new
+registration. The runner does not remove it at startup, because doing so could
+discard a shutdown request made before the listener begins polling. Each runner
+installation has its own sentinel.
+
+An idle drain stops the listener session, but does not deregister the runner or
+delete its local credentials. A supervisor can remove the sentinel and reuse
+that configuration, or separately remove the registration/configuration before
+registering again. Normal automatic deregistration still applies after an
+ephemeral runner completes its job.
+
+This is a cooperative idle-stop primitive, not a guarantee about ambiguous
+server-side delivery after network failures or about forced host termination.

--- a/docs/ephemeral-runner-drain.md
+++ b/docs/ephemeral-runner-drain.md
@@ -1,8 +1,25 @@
 # Cooperatively stopping an ephemeral runner
 
-An external supervisor can request drain by creating `.drain` in the runner's
-installation directory. This applies only to runners configured with
-`--ephemeral`; it does not change persistent runners.
+An external supervisor can request drain through either of two opt-in inputs:
+
+- On Linux and macOS, start `./run.sh --drain-on-sigusr1`, then send `SIGUSR1`
+  to the `Runner.Listener` PID (not the shell/service wrapper).
+- On any supported platform, start `Runner.Listener run --drain-file PATH`, then
+  create that file. There is no default sentinel path; relative paths resolve
+  against the listener's startup working directory. The listener only reads it.
+
+Both inputs latch the same drain state for the lifetime of the listener process.
+They can be enabled together. These options require a runner configured with
+`--ephemeral`; persistent runners and SIGINT/SIGTERM behavior are unchanged.
+
+For a read-only container, the signal input requires no writable control file.
+Alternatively, put the sentinel on a separately mounted runtime directory; the
+installation directory does not need to be writable for the drain mechanism.
+
+For paths containing spaces, invoke the listener directly with a quoted argument,
+for example `./bin/Runner.Listener run --drain-file '/run/runner/drain file'`
+(use `Runner.Listener.exe` on Windows). The shell wrappers do not preserve such
+arguments. A missing or empty path is an error, not an implicit disable switch.
 
 The listener finishes its outstanding message poll. If the response contains a
 job, it completes acknowledgement/acquisition and runs that job normally. If
@@ -11,17 +28,28 @@ An already running job finishes through the existing one-job completion path;
 normal job-cancellation messages continue to be processed.
 
 The supervisor must wait for the listener to exit before stopping the host. It
-must not immediately follow creation of `.drain` with a termination signal.
+must not immediately follow a drain request with a termination signal.
 Idle drain can take the duration of the outstanding long poll, and network
 retries can extend that wait.
 
-The supervisor owns the sentinel: remove it before deliberately starting a new
-registration. The runner does not remove it at startup, because doing so could
-discard a shutdown request made before the listener begins polling. Each runner
-installation has its own sentinel.
+Signal handlers are installed before session startup. Do not send SIGUSR1 until
+the opted-in listener is ready (for example, after `Listening for Jobs`); a
+signal sent before handler installation retains its default OS behavior. A
+signal request does not persist across process exits. The supervisor must stop
+restarting the listener during host shutdown.
+
+The supervisor owns the optional sentinel: use a unique path per listener, and
+remove it before deliberately restarting. The runner does not remove it at
+startup or write to it. Removing it after the runner has observed it does not
+withdraw a drain request. A pre-existing file also supports requesting drain
+before the listener starts.
+
+Do not use the service wrapper's stop operation as the drain request: it sends
+SIGINT and can force-kill the listener after 30 seconds. Send SIGUSR1 directly
+to the opted-in listener, wait for exit, and only then stop the container/host.
 
 An idle drain stops the listener session, but does not deregister the runner or
-delete its local credentials. A supervisor can remove the sentinel and reuse
+delete its local credentials. A supervisor can clear any sentinel and reuse
 that configuration, or separately remove the registration/configuration before
 registering again. Normal automatic deregistration still applies after an
 ephemeral runner completes its job.

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -95,6 +95,7 @@ namespace GitHub.Runner.Common
                 public static class Args
                 {
                     public static readonly string Auth = "auth";
+                    public static readonly string DrainFile = "drain-file";
                     public static readonly string Labels = "labels";
                     public static readonly string MonitorSocketAddress = "monitorsocketaddress";
                     public static readonly string Name = "name";
@@ -131,6 +132,7 @@ namespace GitHub.Runner.Common
                 //validOptions dictionary as well present in the CommandSettings.cs
                 public static class Flags
                 {
+                    public static readonly string DrainOnSigusr1 = "drain-on-sigusr1";
                     public static readonly string Check = "check";
                     public static readonly string Commit = "commit";
                     public static readonly string Ephemeral = "ephemeral";

--- a/src/Runner.Listener/BrokerMessageListener.cs
+++ b/src/Runner.Listener/BrokerMessageListener.cs
@@ -272,6 +272,13 @@ namespace GitHub.Runner.Listener
             }
         }
 
+        private Func<bool> _idleDrainRequested = () => false;
+
+        public void SetIdleDrainCheck(Func<bool> drainRequested)
+        {
+            _idleDrainRequested = drainRequested;
+        }
+
         public async Task<TaskAgentMessage> GetNextMessageAsync(CancellationToken token)
         {
             bool encounteringError = false;
@@ -282,6 +289,11 @@ namespace GitHub.Runner.Listener
 
             while (true)
             {
+                // Finish an outstanding response before checking for idle drain.
+                if (_idleDrainRequested())
+                {
+                    return null;
+                }
                 TaskAgentMessage message = null;
                 _getMessagesTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
                 try

--- a/src/Runner.Listener/CommandSettings.cs
+++ b/src/Runner.Listener/CommandSettings.cs
@@ -65,6 +65,8 @@ namespace GitHub.Runner.Listener
                 new string[]
                 {
                     Constants.Runner.CommandLine.Flags.Once,
+                    Constants.Runner.CommandLine.Flags.DrainOnSigusr1,
+                    Constants.Runner.CommandLine.Args.DrainFile,
                     Constants.Runner.CommandLine.Args.JitConfig,
                     Constants.Runner.CommandLine.Args.StartupType
                 },
@@ -93,6 +95,17 @@ namespace GitHub.Runner.Listener
 
         // Keep this around since customers still relies on it
         public bool RunOnce => TestFlag(Constants.Runner.CommandLine.Flags.Once);
+        public bool DrainOnSigusr1 => TestFlag(Constants.Runner.CommandLine.Flags.DrainOnSigusr1);
+        public string GetDrainFile()
+        {
+            string name = Constants.Runner.CommandLine.Args.DrainFile;
+            string path = GetArg(name);
+            if (string.IsNullOrEmpty(path) && (_parser.Args.ContainsKey(name) || _parser.Flags.Contains(name, StringComparer.OrdinalIgnoreCase)))
+            {
+                throw new ArgumentException("--drain-file requires a nonempty path.");
+            }
+            return path;
+        }
 
         // Constructor.
         public CommandSettings(IHostContext context, string[] args)

--- a/src/Runner.Listener/DrainRequest.cs
+++ b/src/Runner.Listener/DrainRequest.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace GitHub.Runner.Listener
+{
+    // Requesting drain must never cancel the listener's HTTP or worker tokens.
+    internal sealed class DrainRequest : IDisposable
+    {
+        private readonly string _file;
+        private readonly PosixSignalRegistration _signal;
+        private int _requested;
+
+        public DrainRequest(string file, bool useSigusr1)
+        {
+            _file = file;
+            if (useSigusr1)
+            {
+                // SIGUSR1 is 10 on supported Linux architectures and 30 on macOS.
+                // .NET accepts native signal numbers for signals outside its enum.
+                int signal = OperatingSystem.IsLinux() ? 10 : OperatingSystem.IsMacOS() ? 30 :
+                    throw new PlatformNotSupportedException("--drain-on-sigusr1 requires Linux or macOS; use --drain-file on other platforms.");
+                _signal = PosixSignalRegistration.Create((PosixSignal)signal, context =>
+                {
+                    context.Cancel = true;
+                    Request();
+                });
+            }
+        }
+
+        public void Request() => Interlocked.Exchange(ref _requested, 1);
+
+        public bool IsRequested
+        {
+            get
+            {
+                if (Volatile.Read(ref _requested) == 0 && _file != null && File.Exists(_file))
+                {
+                    Request();
+                }
+                return Volatile.Read(ref _requested) != 0;
+            }
+        }
+
+        public void Dispose() => _signal?.Dispose();
+    }
+}

--- a/src/Runner.Listener/MessageListener.cs
+++ b/src/Runner.Listener/MessageListener.cs
@@ -31,6 +31,7 @@ namespace GitHub.Runner.Listener
         Task<CreateSessionResult> CreateSessionAsync(CancellationToken token);
         Task DeleteSessionAsync();
         Task<TaskAgentMessage> GetNextMessageAsync(CancellationToken token);
+        void SetIdleDrainCheck(Func<bool> drainRequested);
         Task DeleteMessageAsync(TaskAgentMessage message);
         Task AcknowledgeMessageAsync(string runnerRequestId, CancellationToken cancellationToken);
 
@@ -59,6 +60,12 @@ namespace GitHub.Runner.Listener
         private VssCredentials _credsV2;
         private bool _needRefreshCredsV2 = false;
         private bool _handlerInitialized = false;
+        private Func<bool> _idleDrainRequested = () => false;
+
+        public void SetIdleDrainCheck(Func<bool> drainRequested)
+        {
+            _idleDrainRequested = drainRequested;
+        }
 
         public override void Initialize(IHostContext hostContext)
         {
@@ -244,6 +251,11 @@ namespace GitHub.Runner.Listener
             while (true)
             {
                 token.ThrowIfCancellationRequested();
+                // Do not cancel a poll that may already carry a job assignment.
+                if (_idleDrainRequested())
+                {
+                    return null;
+                }
                 TaskAgentMessage message = null;
                 _getMessagesTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
                 try

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -512,6 +512,12 @@ namespace GitHub.Runner.Listener
 
                     jobDispatcher.JobStatus += _listener.OnJobStatus;
 
+                    // The supervisor owns the sentinel lifecycle. Restrict this
+                    // check to one-job runners: after acquisition, keep job
+                    // cancellation polling alive until RunOnceJobCompleted fires.
+                    string drainPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Root), ".drain");
+                    _listener.SetIdleDrainCheck(() => settings.Ephemeral && !runOnceJobReceived && File.Exists(drainPath));
+
                     while (!HostContext.RunnerShutdownToken.IsCancellationRequested)
                     {
                         // Check if we need to restart the session and can do so (job dispatcher not busy)
@@ -604,6 +610,11 @@ namespace GitHub.Runner.Listener
                             }
 
                             message = await getNextMessage; //get next message
+                            if (message == null && settings.Ephemeral && !runOnceJobReceived && File.Exists(drainPath))
+                            {
+                                Trace.Info("Idle drain completed without interrupting a job acquisition.");
+                                return Constants.Runner.ReturnCode.Success;
+                            }
                             HostContext.WritePerfCounter($"MessageReceived_{message.MessageType}");
                             if (string.Equals(message.MessageType, AgentRefreshMessage.MessageType, StringComparison.OrdinalIgnoreCase))
                             {
@@ -688,7 +699,7 @@ namespace GitHub.Runner.Listener
                                 else
                                 {
                                     var messageRef = StringUtil.ConvertFromJson<RunnerJobRequestRef>(message.Body);
-                                    
+
                                     // Acknowledge (best-effort)
                                     if (messageRef.ShouldAcknowledge) // Temporary feature flag
                                     {

--- a/src/Runner.Listener/Runner.cs
+++ b/src/Runner.Listener/Runner.cs
@@ -32,6 +32,7 @@ namespace GitHub.Runner.Listener
     public sealed class Runner : RunnerService, IRunner
     {
         private IMessageListener _listener;
+        private DrainRequest _drainRequest;
         private ITerminal _term;
         private bool _inConfigStage;
         private ManualResetEvent _completedCommand = new(false);
@@ -328,6 +329,14 @@ namespace GitHub.Runner.Listener
                     var returnJobResultForHosted = StringUtil.ConvertToBoolean(Environment.GetEnvironmentVariable("ACTIONS_RUNNER_RETURN_JOB_RESULT_FOR_HOSTED"));
 
                     // Run the runner interactively or as service
+                    string drainFile = command.GetDrainFile();
+                    if (!settings.Ephemeral && (command.DrainOnSigusr1 || !string.IsNullOrEmpty(drainFile)))
+                    {
+                        _term.WriteError("Drain options require a runner configured with --ephemeral.");
+                        return Constants.Runner.ReturnCode.TerminatedError;
+                    }
+                    _drainRequest = new DrainRequest(
+                        string.IsNullOrEmpty(drainFile) ? null : Path.GetFullPath(drainFile), command.DrainOnSigusr1);
                     return await ExecuteRunnerAsync(settings, command.RunOnce || settings.Ephemeral || returnJobResultForHosted, returnJobResultForHosted);
                 }
                 else
@@ -338,6 +347,7 @@ namespace GitHub.Runner.Listener
             }
             finally
             {
+                _drainRequest?.Dispose();
                 _authMigrationClaimsCheckTokenSource?.Cancel();
                 _authMigrationTelemetryTokenSource?.Cancel();
                 HostContext.AuthMigrationChanged -= HandleAuthMigrationChanged;
@@ -512,11 +522,9 @@ namespace GitHub.Runner.Listener
 
                     jobDispatcher.JobStatus += _listener.OnJobStatus;
 
-                    // The supervisor owns the sentinel lifecycle. Restrict this
-                    // check to one-job runners: after acquisition, keep job
+                    // Drain state survives session restarts. After acquisition, keep job
                     // cancellation polling alive until RunOnceJobCompleted fires.
-                    string drainPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Root), ".drain");
-                    _listener.SetIdleDrainCheck(() => settings.Ephemeral && !runOnceJobReceived && File.Exists(drainPath));
+                    _listener.SetIdleDrainCheck(() => settings.Ephemeral && !runOnceJobReceived && _drainRequest.IsRequested);
 
                     while (!HostContext.RunnerShutdownToken.IsCancellationRequested)
                     {
@@ -610,7 +618,7 @@ namespace GitHub.Runner.Listener
                             }
 
                             message = await getNextMessage; //get next message
-                            if (message == null && settings.Ephemeral && !runOnceJobReceived && File.Exists(drainPath))
+                            if (message == null && settings.Ephemeral && !runOnceJobReceived && _drainRequest.IsRequested)
                             {
                                 Trace.Info("Idle drain completed without interrupting a job acquisition.");
                                 return Constants.Runner.ReturnCode.Success;
@@ -1146,6 +1154,10 @@ Options:
  --version  Prints the runner version
  --commit   Prints the runner commit
  --check    Check the runner's network connectivity with GitHub server
+
+Run Options (ephemeral runners only):
+ --drain-on-sigusr1     Treat SIGUSR1 as a cooperative drain request (Linux/macOS)
+ --drain-file path      Watch an optional supervisor-owned drain file (no default)
 
 Config Options:
  --unattended           Disable interactive prompts for missing arguments. Defaults will be used for missing options

--- a/src/Test/L0/Listener/DrainRequestL0.cs
+++ b/src/Test/L0/Listener/DrainRequestL0.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using GitHub.Runner.Listener;
+using Xunit;
+
+namespace GitHub.Runner.Common.Tests.Listener
+{
+    // Signal handlers are process-wide; do not overlap other drain tests.
+    [Collection("Ephemeral drain")]
+    public sealed class DrainRequestL0
+    {
+        [Fact]
+        public void RequestIsLatchedAndIdempotent()
+        {
+            using var drain = new DrainRequest(null, false);
+            Assert.False(drain.IsRequested);
+            drain.Request();
+            drain.Request();
+            Assert.True(drain.IsRequested);
+        }
+
+        [Fact]
+        public void FileIsOptionalAndRequestSurvivesRemoval()
+        {
+            using var hc = new TestHostContext(this);
+            string path = Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), "custom-drain");
+            Assert.False(File.Exists(path));
+            using var disabled = new DrainRequest(null, false);
+            using var drain = new DrainRequest(path, false);
+            try
+            {
+                Assert.False(drain.IsRequested);
+                File.WriteAllText(path, "");
+                Assert.False(disabled.IsRequested);
+                Assert.True(drain.IsRequested);
+                File.Delete(path);
+                Assert.True(drain.IsRequested);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Sigusr1RequestsDrainWithoutAFile()
+        {
+            if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => new DrainRequest(null, true));
+                return;
+            }
+
+            using var drain = new DrainRequest(null, true);
+            Assert.False(drain.IsRequested);
+            // Use the OS's named signal so the test independently checks our mapping.
+            using var sender = Process.Start(new ProcessStartInfo("/bin/kill")
+            {
+                UseShellExecute = false,
+                ArgumentList = { "-USR1", Environment.ProcessId.ToString() }
+            });
+            Assert.True(sender.WaitForExit(5000));
+            Assert.Equal(0, sender.ExitCode);
+            Assert.True(SpinWait.SpinUntil(() => drain.IsRequested, TimeSpan.FromSeconds(5)));
+        }
+
+        [Fact]
+        public void RunAcceptsBothDrainOptions()
+        {
+            using var hc = new TestHostContext(this);
+            hc.SetSingleton<IPromptManager>(new Moq.Mock<IPromptManager>().Object);
+            var command = new CommandSettings(hc, new[] { "run", "--drain-on-sigusr1", "--drain-file", "/run/runner/drain" });
+            Assert.Empty(command.Validate());
+            Assert.True(command.DrainOnSigusr1);
+            Assert.Equal("/run/runner/drain", command.GetDrainFile());
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MissingDrainFileValueIsRejected(bool emptyArgument)
+        {
+            using var hc = new TestHostContext(this);
+            hc.SetSingleton<IPromptManager>(new Moq.Mock<IPromptManager>().Object);
+            var args = emptyArgument ? new[] { "run", "--drain-file", "" } : new[] { "run", "--drain-file" };
+            var command = new CommandSettings(hc, args);
+            Assert.Throws<ArgumentException>(() => command.GetDrainFile());
+        }
+    }
+}

--- a/src/Test/L0/Listener/EphemeralDrainL0.cs
+++ b/src/Test/L0/Listener/EphemeralDrainL0.cs
@@ -1,0 +1,238 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GitHub.DistributedTask.WebApi;
+using GitHub.Runner.Listener;
+using GitHub.Runner.Listener.Configuration;
+using GitHub.Services.Common;
+using GitHub.Services.WebApi;
+using Moq;
+using Xunit;
+using Pipelines = GitHub.DistributedTask.Pipelines;
+
+namespace GitHub.Runner.Common.Tests.Listener
+{
+    [CollectionDefinition("Ephemeral drain", DisableParallelization = true)]
+    public sealed class EphemeralDrainCollection { }
+
+    [Collection("Ephemeral drain")]
+    public sealed class EphemeralDrainL0 : IDisposable
+    {
+        private readonly string _hostedReturnCode = Environment.GetEnvironmentVariable("ACTIONS_RUNNER_RETURN_JOB_RESULT_FOR_HOSTED");
+
+        public EphemeralDrainL0()
+        {
+            Environment.SetEnvironmentVariable("ACTIONS_RUNNER_RETURN_JOB_RESULT_FOR_HOSTED", null);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("ACTIONS_RUNNER_RETURN_JOB_RESULT_FOR_HOSTED", _hostedReturnCode);
+        }
+
+        // Real Runner + real message listener. Only remote services and worker
+        // execution are mocked, with explicit barriers at dispatch boundaries.
+        [Theory]
+        [InlineData("idle", true)]
+        [InlineData("idle", false)]
+        [InlineData("before-listening", true)]
+        [InlineData("before-listening", false)]
+        [InlineData("poll", true)]
+        [InlineData("ack", true)]
+        [InlineData("acquire", true)]
+        [InlineData("worker", true)]
+        [InlineData("cancel", true)]
+        public async Task DrainAtBoundary(string boundary, bool brokerFlow)
+        {
+            using var hc = new TestHostContext(this, $"{boundary}-{brokerFlow}");
+            var settings = new RunnerSettings
+            {
+                AgentId = 123,
+                AgentName = "drain-test",
+                PoolId = 456,
+                ServerUrl = "https://github.example",
+                ServerUrlV2 = "https://broker.example",
+                UseV2Flow = brokerFlow,
+                Ephemeral = true,
+                WorkFolder = "_work"
+            };
+            var config = new Mock<IConfigurationManager>();
+            config.Setup(x => x.LoadSettings()).Returns(settings);
+            config.Setup(x => x.IsConfigured()).Returns(true);
+            var store = new Mock<IConfigurationStore>();
+            store.Setup(x => x.GetCredentials()).Returns(new CredentialData { Scheme = Constants.Configuration.OAuthAccessToken });
+            var creds = new Mock<ICredentialManager>();
+            creds.Setup(x => x.LoadCredentials(It.IsAny<bool>())).Returns(new VssCredentials());
+            var broker = new Mock<IBrokerServer>();
+            var runnerServer = new Mock<IRunnerServer>();
+            var runServer = new Mock<IRunServer>();
+            var dispatcher = new Mock<IJobDispatcher>();
+            hc.SetSingleton<IConfigurationManager>(config.Object);
+            hc.SetSingleton<IConfigurationStore>(store.Object);
+            hc.SetSingleton<ICredentialManager>(creds.Object);
+            hc.SetSingleton<IBrokerServer>(broker.Object);
+            hc.SetSingleton<IRunnerServer>(runnerServer.Object);
+            hc.SetSingleton<IJobNotification>(new Mock<IJobNotification>().Object);
+            hc.SetSingleton<IPromptManager>(new Mock<IPromptManager>().Object);
+            hc.EnqueueInstance<IRunServer>(runServer.Object);
+            hc.EnqueueInstance<IJobDispatcher>(dispatcher.Object);
+            hc.EnqueueInstance<IErrorThrottler>(new Mock<IErrorThrottler>().Object);
+
+            IMessageListener listener = brokerFlow ? new BrokerMessageListener() : new MessageListener();
+            listener.Initialize(hc);
+            hc.SetSingleton<IMessageListener>(listener);
+            broker.Setup(x => x.CreateSessionAsync(It.IsAny<TaskAgentSession>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TaskAgentSession());
+            runnerServer.Setup(x => x.CreateAgentSessionAsync(It.IsAny<int>(), It.IsAny<TaskAgentSession>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TaskAgentSession());
+
+            var pollEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releasePoll = new TaskCompletionSource<TaskAgentMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var ackEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseAck = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var acquireEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseAcquire = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var workerEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var cancelReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var drainWritten = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var workerCompleted = new TaskCompletionSource<TaskResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var polls = 0;
+            var ran = false;
+            var shutdownBeforeCompletion = false;
+            var request = new Pipelines.AgentJobRequestMessage(
+                new TaskOrchestrationPlanReference(), null, Guid.NewGuid(), "test", "test", null,
+                null, null, new Dictionary<string, VariableValue>(), new List<MaskHint>(),
+                new Pipelines.JobResources(), new Pipelines.ContextData.DictionaryContextData(),
+                new Pipelines.WorkspaceOptions(), new List<Pipelines.ActionStep>(), null, null, null, null, null);
+
+            async Task<TaskAgentMessage> Poll(CancellationToken token)
+            {
+                if (Interlocked.Increment(ref polls) == 1)
+                {
+                    pollEntered.TrySetResult(true);
+                    return await releasePoll.Task.WaitAsync(token);
+                }
+                if (boundary == "cancel" && polls == 2)
+                {
+                    await drainWritten.Task.WaitAsync(token);
+                    return null;
+                }
+                if (boundary == "cancel" && polls == 3)
+                {
+                    return new TaskAgentMessage
+                    {
+                        MessageId = 2,
+                        MessageType = JobCancelMessage.MessageType,
+                        Body = JsonUtility.ToString(new JobCancelMessage(request.JobId, TimeSpan.FromSeconds(30)))
+                    };
+                }
+                await Task.Delay(Timeout.Infinite, token);
+                return null;
+            }
+            broker.Setup(x => x.GetRunnerMessageAsync(It.IsAny<Guid?>(), It.IsAny<TaskAgentStatus>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns((Guid? session, TaskAgentStatus status, string version, string os, string arch, bool disable, CancellationToken token) => Poll(token));
+            runnerServer.Setup(x => x.GetAgentMessageAsync(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<long?>(),
+                It.IsAny<TaskAgentStatus>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns((int pool, Guid session, long? last, TaskAgentStatus status, string version, string os, string arch, bool disable, CancellationToken token) => Poll(token));
+            broker.Setup(x => x.AcknowledgeRunnerRequestAsync(It.IsAny<string>(), It.IsAny<Guid?>(),
+                It.IsAny<TaskAgentStatus>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(async (string id, Guid? session, TaskAgentStatus status, string version, string os, string arch, CancellationToken token) =>
+                {
+                    ackEntered.TrySetResult(true);
+                    await releaseAck.Task.WaitAsync(token);
+                });
+            runServer.Setup(x => x.GetJobMessageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(async (string id, string owner, CancellationToken token) =>
+                {
+                    acquireEntered.TrySetResult(true);
+                    await releaseAcquire.Task.WaitAsync(token);
+                    return request;
+                });
+            dispatcher.Setup(x => x.RunOnceJobCompleted).Returns(workerCompleted);
+            dispatcher.Setup(x => x.Run(It.IsAny<Pipelines.AgentJobRequestMessage>(), true)).Callback(() =>
+            {
+                ran = true;
+                workerEntered.TrySetResult(true);
+            });
+            dispatcher.Setup(x => x.Cancel(It.IsAny<JobCancelMessage>())).Returns(() =>
+            {
+                cancelReceived.TrySetResult(true);
+                return true;
+            });
+            dispatcher.Setup(x => x.ShutdownAsync()).Returns(() =>
+            {
+                shutdownBeforeCompletion = ran && !workerCompleted.Task.IsCompleted;
+                return Task.CompletedTask;
+            });
+
+            string sentinel = Path.Combine(hc.GetDirectory(WellKnownDirectory.Root), ".drain");
+            Assert.False(File.Exists(sentinel), "Test must not overwrite an existing sentinel");
+            Task<int> execution = null;
+            try
+            {
+                if (boundary == "before-listening") File.WriteAllText(sentinel, "drain");
+                var runner = new Runner.Listener.Runner();
+                runner.Initialize(hc);
+                execution = runner.ExecuteCommand(new CommandSettings(hc, new[] { "run" }));
+                if (boundary == "before-listening")
+                {
+                    Assert.Equal(0, await execution.WaitAsync(TimeSpan.FromSeconds(8)));
+                    Assert.Equal(0, polls);
+                    Assert.False(ran);
+                    return;
+                }
+                await pollEntered.Task.WaitAsync(TimeSpan.FromSeconds(8));
+                if (boundary == "idle" || boundary == "poll") File.WriteAllText(sentinel, "drain");
+                if (boundary == "idle")
+                {
+                    releasePoll.SetResult(null);
+                    Assert.Equal(0, await execution.WaitAsync(TimeSpan.FromSeconds(8)));
+                    Assert.Equal(1, polls);
+                    Assert.False(ran);
+                    return;
+                }
+                releasePoll.SetResult(new TaskAgentMessage
+                {
+                    MessageId = 1,
+                    MessageType = JobRequestMessageTypes.RunnerJobRequest,
+                    Body = JsonUtility.ToString(new RunnerJobRequestRef
+                    {
+                        RunnerRequestId = "job",
+                        BillingOwnerId = "owner",
+                        RunServiceUrl = "https://run.example",
+                        ShouldAcknowledge = true
+                    })
+                });
+                await ackEntered.Task.WaitAsync(TimeSpan.FromSeconds(8));
+                if (boundary == "ack") File.WriteAllText(sentinel, "drain");
+                releaseAck.SetResult(true);
+                await acquireEntered.Task.WaitAsync(TimeSpan.FromSeconds(8));
+                if (boundary == "acquire") File.WriteAllText(sentinel, "drain");
+                releaseAcquire.SetResult(true);
+                await workerEntered.Task.WaitAsync(TimeSpan.FromSeconds(8));
+                if (boundary == "worker" || boundary == "cancel") File.WriteAllText(sentinel, "drain");
+                drainWritten.TrySetResult(true);
+                if (boundary == "cancel") await cancelReceived.Task.WaitAsync(TimeSpan.FromSeconds(8));
+                Assert.False(execution.IsCompleted);
+                Assert.False(hc.RunnerShutdownToken.IsCancellationRequested);
+                dispatcher.Verify(x => x.ShutdownAsync(), Times.Never());
+                workerCompleted.SetResult(boundary == "cancel" ? TaskResult.Canceled : TaskResult.Succeeded);
+                Assert.Equal(0, await execution.WaitAsync(TimeSpan.FromSeconds(8)));
+                Assert.False(shutdownBeforeCompletion);
+                dispatcher.Verify(x => x.Run(It.IsAny<Pipelines.AgentJobRequestMessage>(), true), Times.Once());
+            }
+            finally
+            {
+                if (execution != null && !execution.IsCompleted)
+                {
+                    hc.ShutdownRunner(ShutdownReason.UserCancelled);
+                    try { await execution.WaitAsync(TimeSpan.FromSeconds(3)); } catch { }
+                }
+                File.Delete(sentinel);
+            }
+        }
+    }
+}

--- a/src/Test/L0/Listener/EphemeralDrainL0.cs
+++ b/src/Test/L0/Listener/EphemeralDrainL0.cs
@@ -44,6 +44,8 @@ namespace GitHub.Runner.Common.Tests.Listener
         [InlineData("acquire", true)]
         [InlineData("worker", true)]
         [InlineData("cancel", true)]
+        [InlineData("persistent-options", true)]
+        [InlineData("persistent-options", false)]
         public async Task DrainAtBoundary(string boundary, bool brokerFlow)
         {
             using var hc = new TestHostContext(this, $"{boundary}-{brokerFlow}");
@@ -55,7 +57,7 @@ namespace GitHub.Runner.Common.Tests.Listener
                 ServerUrl = "https://github.example",
                 ServerUrlV2 = "https://broker.example",
                 UseV2Flow = brokerFlow,
-                Ephemeral = true,
+                Ephemeral = boundary != "persistent-options",
                 WorkFolder = "_work"
             };
             var config = new Mock<IConfigurationManager>();
@@ -176,7 +178,14 @@ namespace GitHub.Runner.Common.Tests.Listener
                 if (boundary == "before-listening") File.WriteAllText(sentinel, "drain");
                 var runner = new Runner.Listener.Runner();
                 runner.Initialize(hc);
-                execution = runner.ExecuteCommand(new CommandSettings(hc, new[] { "run" }));
+                execution = runner.ExecuteCommand(new CommandSettings(hc, new[] { "run", "--drain-file", sentinel }));
+                if (boundary == "persistent-options")
+                {
+                    Assert.Equal(Constants.Runner.ReturnCode.TerminatedError, await execution.WaitAsync(TimeSpan.FromSeconds(8)));
+                    Assert.Equal(0, polls);
+                    Assert.False(ran);
+                    return;
+                }
                 if (boundary == "before-listening")
                 {
                     Assert.Equal(0, await execution.WaitAsync(TimeSpan.FromSeconds(8)));


### PR DESCRIPTION
_Drafted with Codex assistance; open as a draft for author review._

## Summary

Adds cooperative drain for `--ephemeral` runners with two explicit, independent inputs:

- `run --drain-on-sigusr1`: SIGUSR1 latches a drain request on Linux/macOS, without a control file.
- `run --drain-file PATH`: watches a supervisor-owned file at a configurable location. No default path and no writes to the installation directory. The two inputs can be enabled together.

Refs #2190 (original graceful-shutdown request) and #2582 (SIGINT follow-up). Credits #4461 for the sentinel approach. Persistent-runner support and existing SIGINT/SIGTERM semantics are unchanged.

## Implementation

- `DrainRequest` owns a shared, thread-safe latch and optional signal registration. Observed requests survive file removal and listener-session restarts, but not process restarts.
- Both message listeners check the latch between long polls, including internal retries after empty responses. The signal handler only latches state; it does not cancel HTTP requests or worker tokens.
- An outstanding response carrying a job is acknowledged/acquired and processed normally. Once a job is received, cancellation-message polling and the existing one-job completion path continue; drain does not enter `ShutdownAsync` early and cancel the worker.
- Idle exit retains registration/local credentials. Normal ephemeral job completion retains automatic deregistration. The supervisor owns the optional file, listener restart policy, and host shutdown.
- Add CLI help, usage documentation, and tests for the shared latch, native SIGUSR1, explicit file selection, missing option values, ephemeral-only validation, and dispatch boundaries.

For read-only containers, use the signal input or a separately mounted runtime directory for the optional file. Send SIGUSR1 directly to the opted-in listener after it is ready, not to the shell/service wrapper. The existing wrapper stop path can force-kill after 30 seconds and is not the drain interface.

## Verification

- The original file-only implementation passed nine regression cases against upstream `759385a3510197a58b5c08dc1f373b74b9f4643b`; the unmodified baseline passed five and timed out in four idle/pre-listen cases.
- That implementation also passed live temporary-runner smoke tests on Linux: idle exit 0 after 52.1 seconds, and a real job completed after a drain request before normal listener exit.
- For this updated implementation, a small macOS probe compiled the production `DrainRequest` source and verified actual SIGUSR1 delivery without a file, optional file selection, and latching after file removal.
- `./dev.sh format` passed. The updated full regression suite still needs CI; upstream workflow runs currently require maintainer approval. The earlier file-only results are not claimed as coverage of the new signal integration.

Idle latency includes outstanding long polls. Ambiguous delivery after transport failures, forced termination, and actual runner upgrades are outside the verification claims.
